### PR TITLE
Add missing underscore in ST_Distance_Sphere function name

### DIFF
--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -219,8 +219,8 @@ class ST_Distance(GenericFunction):
     name = 'ST_Distance'
 
 
-class ST_DistanceSphere(GenericFunction):
-    name = 'ST_DistanceSphere'
+class ST_Distance_Sphere(GenericFunction):
+    name = 'ST_Distance_Sphere'
 
 
 class ST_DFullyWithin(GenericFunction):

--- a/geoalchemy2/tests/test_functions.py
+++ b/geoalchemy2/tests/test_functions.py
@@ -117,8 +117,8 @@ def test_ST_Distance():
     _test_simple_func('ST_Distance')
 
 
-def test_ST_DistanceSphere():
-    _test_simple_func('ST_DistanceSphere')
+def test_ST_Distance_Sphere():
+    _test_simple_func('ST_Distance_Sphere')
 
 
 def test_ST_DFullyWithin():


### PR DESCRIPTION
Correct function name is [`ST_Distance_Sphere`](http://www.postgis.org/docs/ST_Distance_Sphere.html).
