### PR TITLE
doc: Enabled html_static_path variable again

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ html_theme_path = ['_themes']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
This reverts commit ed770da9c0fc81e483848c60d88c4ab5732599ba.

Somehow the smaller logo wasn't copied properly anymore after the patch.
