### PR TITLE
Elements and comparator SQLAlchemy 0.9 compatibility

### DIFF
--- a/geoalchemy2/comparator.py
+++ b/geoalchemy2/comparator.py
@@ -43,7 +43,10 @@ Reference
 """
 
 from sqlalchemy.types import UserDefinedType
-from sqlalchemy.sql import expression
+try:
+    from sqlalchemy.sql.functions import _FunctionGenerator
+except ImportError:  # SQLA < 0.9
+    from sqlalchemy.sql.expression import _FunctionGenerator
 
 
 class BaseComparator(UserDefinedType.Comparator):
@@ -71,7 +74,7 @@ class BaseComparator(UserDefinedType.Comparator):
         # SQLAlchemy's "func" object. This is to be able to "bind" the
         # function to the SQL expression. See also GenericFunction above.
 
-        func_ = expression._FunctionGenerator(expr=self.expr)
+        func_ = _FunctionGenerator(expr=self.expr)
         return getattr(func_, name)
 
     def intersects(self, other):


### PR DESCRIPTION
SQLAlchemy's [changelog for version 0.9](http://docs.sqlalchemy.org/en/latest/changelog/changelog_09.html) notes that the `sqlalchemy.sql.expression` module has been refactored: some objects that geoalchemy2 uses have been moved, or not been exposed in a new module `__all__`. I've therefore updated geoalchemy2's imports to be compatible with both SQLA < 0.9 and >= 0.9. Tests pass on both 0.8.2 and 0.9dev.
