### PR TITLE
Fixed suspected typo in doc comment, srid 426 -> 4326

### DIFF
--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -56,7 +56,7 @@ class _GISType(UserDefinedType):
 
     ``srid``
 
-        The SRID for this column. E.g. 426. Default is ``-1``.
+        The SRID for this column. E.g. 4326. Default is ``-1``.
 
     ``dimension``
 


### PR DESCRIPTION
_GISType Constructor arguments comments give an example SRID of 426.  This was probably intended to be 4326.
