### PR TITLE
Tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 GeoAlchemy2.egg-info
 .coverage
 doc/_build/
+.tox
+*.venv*

--- a/geoalchemy2/tests/test_functional.py
+++ b/geoalchemy2/tests/test_functional.py
@@ -2,6 +2,9 @@ import unittest
 from nose.tools import eq_, ok_, raises
 from nose.plugins.skip import SkipTest
 
+import sys
+py3k = sys.version_info[0] == 3
+
 from sqlalchemy import create_engine, MetaData, Column, Integer, func
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
@@ -156,13 +159,11 @@ class InsertionORMTest(unittest.TestCase):
         srid = session.execute(l.geom.ST_SRID()).scalar()
         eq_(srid, 4326)
 
+    @unittest.skipIf(py3k, "Shapely is not Py3k compatible")
     def test_WKBElement(self):
         from geoalchemy2 import WKBElement
-        try:
-            from geoalchemy2.shape import from_shape
-            from shapely.geometry import LineString
-        except ImportError:
-            raise SkipTest
+        from geoalchemy2.shape import from_shape
+        from shapely.geometry import LineString
         shape = LineString([[0, 0], [1, 1]])
         l = Lake(from_shape(shape, srid=4326))
         session.add(l)

--- a/geoalchemy2/tests/test_shape.py
+++ b/geoalchemy2/tests/test_shape.py
@@ -1,14 +1,15 @@
+import unittest
 from nose.tools import ok_, eq_
 from nose.plugins.skip import SkipTest
 
+import sys
+py3k = sys.version_info[0] == 3
 
+@unittest.skipIf(py3k, "Shapely is not Py3k compatible")
 def test_to_shape_WKBElement():
     from geoalchemy2.elements import WKBElement
-    try:
-        from geoalchemy2.shape import to_shape
-        from shapely.geometry import Point
-    except ImportError:
-        raise SkipTest
+    from geoalchemy2.shape import to_shape
+    from shapely.geometry import Point
 
     e = WKBElement('\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00'
                    '\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@')
@@ -18,13 +19,11 @@ def test_to_shape_WKBElement():
     eq_(s.y, 2)
 
 
+@unittest.skipIf(py3k, "Shapely is not Py3k compatible")
 def test_to_shape_WKTElement():
     from geoalchemy2.elements import WKTElement
-    try:
-        from geoalchemy2.shape import to_shape
-        from shapely.geometry import Point
-    except ImportError:
-        raise SkipTest
+    from geoalchemy2.shape import to_shape
+    from shapely.geometry import Point
 
     e = WKTElement('POINT(1 2)')
     s = to_shape(e)
@@ -33,14 +32,12 @@ def test_to_shape_WKTElement():
     eq_(s.y, 2)
 
 
+@unittest.skipIf(py3k, "Shapely is not Py3k compatible")
 def test_from_shape():
     from geoalchemy2.elements import WKBElement
-    try:
-        from geoalchemy2.shape import from_shape
-        import shapely.wkb
-        from shapely.geometry import Point
-    except ImportError:
-        raise SkipTest
+    from geoalchemy2.shape import from_shape
+    import shapely.wkb
+    from shapely.geometry import Point
 
     p = Point(1, 2)
     e = from_shape(p)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup_requires = [
     ]
 
 tests_require = install_requires + [
+    'tox',
     'psycopg2'
     ]
 
@@ -32,6 +33,8 @@ setup(name='GeoAlchemy2',
           "Environment :: Plugins",
           "Operating System :: OS Independent",
           "Programming Language :: Python",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 3",
           "Intended Audience :: Information Technology",
           "License :: OSI Approved :: MIT License",
           "Topic :: Scientific/Engineering :: GIS"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,35 @@
+[tox]
+envlist=py27sqla08,py27sqla09,py33sqla08,py33sqla09
+
+[testenv]
+commands=nosetests --verbose --processes=1
+
+[testenv:py27sqla08]
+basepython=python2.7
+deps=
+    nose
+    psycopg2
+    Shapely
+    SQLAlchemy==0.8.4
+
+[testenv:py27sqla09]
+basepython=python2.7
+deps=
+    nose
+    psycopg2
+    Shapely
+    SQLAlchemy==0.9.0
+
+[testenv:py33sqla08]
+basepython=python3.3
+deps=
+    nose
+    psycopg2
+    SQLAlchemy==0.8.4
+
+[testenv:py33sqla09]
+basepython=python3.3
+deps=
+    nose
+    psycopg2
+    SQLAlchemy==0.9.0


### PR DESCRIPTION
Implement Tox (http://tox.readthedocs.org/) testing. This tests Python 2.7 and Python 3.3, each with SQLAlchemy 0.8.4 and SQLAlchemy 0.9.0, for four test runs total. If you cherry-pick SQLA 0.9 fixes from another PR, you'll have all tests pass. Run the tests by calling `tox`.
