### PR TITLE
Shapely Py3k support

### DIFF
--- a/geoalchemy2/compat.py
+++ b/geoalchemy2/compat.py
@@ -1,0 +1,22 @@
+"""
+Python 2 and 3 compatibility:
+
+    - Py3k `memoryview()` made an alias for Py2k `buffer()`
+    - Py3k `bytes()` made an alias for Py2k `str()`
+"""
+
+import sys
+py3k = sys.version_info[0] == 3
+
+
+if py3k:
+    # Python 2.6 flake8 workaround
+    buffer = __builtins__['memoryview']
+    _bytes = bytes
+
+    def bytes(val):
+        return _bytes(val.encode("latin-1") if isinstance(val, str) else val)
+
+else:
+    buffer = buffer
+    bytes = str

--- a/geoalchemy2/shape.py
+++ b/geoalchemy2/shape.py
@@ -6,6 +6,7 @@ import shapely.wkb
 import shapely.wkt
 
 from .elements import WKBElement, WKTElement
+from .compat import buffer, bytes
 
 
 def to_shape(element):
@@ -20,7 +21,7 @@ def to_shape(element):
     """
     assert isinstance(element, (WKBElement, WKTElement))
     if isinstance(element, WKBElement):
-        return shapely.wkb.loads(str(element.data))
+        return shapely.wkb.loads(bytes(element.data))
     elif isinstance(element, WKTElement):
         return shapely.wkt.loads(element.data)
 
@@ -42,4 +43,4 @@ def from_shape(shape, srid=-1):
         from shapely.geometry import Point
         wkb_element = from_shape(Point(5, 45), srid=4326)
     """
-    return WKBElement(buffer(shape.wkb), srid=srid)  # flake8: noqa
+    return WKBElement(buffer(shape.wkb), srid=srid)

--- a/geoalchemy2/tests/test_functional.py
+++ b/geoalchemy2/tests/test_functional.py
@@ -158,11 +158,8 @@ class InsertionORMTest(unittest.TestCase):
 
     def test_WKBElement(self):
         from geoalchemy2 import WKBElement
-        try:
-            from geoalchemy2.shape import from_shape
-            from shapely.geometry import LineString
-        except ImportError:
-            raise SkipTest
+        from geoalchemy2.shape import from_shape
+        from shapely.geometry import LineString
         shape = LineString([[0, 0], [1, 1]])
         l = Lake(from_shape(shape, srid=4326))
         session.add(l)

--- a/geoalchemy2/tests/test_shape.py
+++ b/geoalchemy2/tests/test_shape.py
@@ -1,14 +1,11 @@
 from nose.tools import ok_, eq_
-from nose.plugins.skip import SkipTest
+from geoalchemy2.compat import buffer, bytes
 
 
 def test_to_shape_WKBElement():
     from geoalchemy2.elements import WKBElement
-    try:
-        from geoalchemy2.shape import to_shape
-        from shapely.geometry import Point
-    except ImportError:
-        raise SkipTest
+    from geoalchemy2.shape import to_shape
+    from shapely.geometry import Point
 
     e = WKBElement('\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00'
                    '\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@')
@@ -20,11 +17,8 @@ def test_to_shape_WKBElement():
 
 def test_to_shape_WKTElement():
     from geoalchemy2.elements import WKTElement
-    try:
-        from geoalchemy2.shape import to_shape
-        from shapely.geometry import Point
-    except ImportError:
-        raise SkipTest
+    from geoalchemy2.shape import to_shape
+    from shapely.geometry import Point
 
     e = WKTElement('POINT(1 2)')
     s = to_shape(e)
@@ -35,17 +29,14 @@ def test_to_shape_WKTElement():
 
 def test_from_shape():
     from geoalchemy2.elements import WKBElement
-    try:
-        from geoalchemy2.shape import from_shape
-        import shapely.wkb
-        from shapely.geometry import Point
-    except ImportError:
-        raise SkipTest
+    from geoalchemy2.shape import from_shape
+    import shapely.wkb
+    from shapely.geometry import Point
 
     p = Point(1, 2)
     e = from_shape(p)
     ok_(isinstance(e, WKBElement))
-    ok_(isinstance(e.data, buffer))  # flake8: noqa
-    s = shapely.wkb.loads(str(e.data))
+    ok_(isinstance(e.data, buffer))
+    s = shapely.wkb.loads(bytes(e.data))
     ok_(isinstance(s, Point))
     ok_(p.equals(p))

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ from setuptools import setup, find_packages
 version = '0.2.2'
 
 install_requires = [
-    'SQLAlchemy>=0.8'
+    'SQLAlchemy>=0.8',
+    'Shapely>=1.3.0'
     ]
-
 
 setup_requires = [
     'nose'
@@ -16,12 +16,6 @@ setup_requires = [
 tests_require = install_requires + [
     'psycopg2'
     ]
-
-
-if sys.version_info[0] == 2:
-    # Shapely is only compatible with Python 2.x
-    tests_require.append('shapely')
-
 
 setup(name='GeoAlchemy2',
       version=version,


### PR DESCRIPTION
Shapely 1.3.0 was released, and it supports Py3k. Here's P2k/Py3k compatibility.
