### PR TITLE
Update TravisCI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,8 @@ env:
   - POSTGIS_VERSION=2
 
 install:
-  # Add PPA for geos 3.3.x
-  - if [[ "$POSTGIS_VERSION" != "1.5" ]]; then sudo apt-add-repository -y ppa:sharpie/for-science; fi
-
-  # Add PPA for PostGIS 2.x
-  - if [[ "$POSTGIS_VERSION" != "1.5" ]]; then sudo apt-add-repository -y ppa:sharpie/postgis-nightly; fi
-  - if [[ "$POSTGIS_VERSION" != "1.5" ]]; then sudo apt-get update; fi
-
-  # Install PostGIS
-  - sudo apt-get install postgresql-9.1-postgis -q
+  # Install PostGIS 1.5
+  - if [[ "$POSTGIS_VERSION" == "1.5" ]]; then sudo apt-get install -y --force-yes postgresql-9.1-postgis=1.5.3-2 postgis=1.5.3-2; fi
 
   # Install flake8 style checker and the coverage module
   - pip install flake8 coverage


### PR DESCRIPTION
The new TravisCI build environment now ships with PostGIS 2.1 by default. I don't know if it is possible to install PostGIS 1.5 instead for testing, but in any case the config file needs to be adjusted to make it work with at least PostGIS 2.1.

(see http://about.travis-ci.org/blog/2013-11-18-upcoming-build-environment-updates/)
