### PR TITLE
Fix TypeError for PyPy

### DIFF
--- a/geoalchemy2/compat.py
+++ b/geoalchemy2/compat.py
@@ -4,14 +4,18 @@ Python 2 and 3 compatibility:
     - Py3k `memoryview()` made an alias for Py2k `buffer()`
     - Py3k `bytes()` made an alias for Py2k `str()`
 """
-import __builtin__
+try:
+    import __builtin__ as builtins
+except ImportError:
+    import builtins
+
 import sys
 
 if sys.version_info[0] == 2:
-    buffer = getattr(__builtin__, 'buffer')
+    buffer = getattr(builtins, 'buffer')
     bytes = str
 
 else:
     # Python 2.6 flake8 workaround
-    buffer = getattr(__builtin__, 'memoryview')
+    buffer = getattr(builtins, 'memoryview')
     bytes = bytes


### PR DESCRIPTION
A module object is not subscriptable in PyPy. A subscriptable module is an implementation detail for CPython. The help doc only says you can use dotted notation to get attributes out of a module, it doesn't implement `__getitem__`.
