### PR TITLE
Add note in documentation about Shapely

### DIFF
--- a/geoalchemy2/shape.py
+++ b/geoalchemy2/shape.py
@@ -1,5 +1,10 @@
 """
 This module provides utility functions for integrating with Shapely.
+
+.. note::
+
+    As GeoAlchemy 2 itself has no dependency on `Shapely`, applications using
+    functions of this module have to ensure that `Shapely` is available.
 """
 
 import shapely.wkb


### PR DESCRIPTION
This PR adds a note in the documentation, that GeoAlchemy 2 has no dependency on Shapely.
