### PR TITLE
Create indices on GIS types as a constraint on the parent object

### DIFF
--- a/TEST.rst
+++ b/TEST.rst
@@ -28,10 +28,10 @@ Create the ``gis`` database::
 
     $ sudo -u postgres createdb -E UTF-8 gis
     $ sudo -u postgres psql -d gis -c 'CREATE SCHEMA gis;'
-    $ sudo -u postgres psql -c 'GRANT CREATE ON DATABASE gis TO "gis";'
+    $ sudo -u postgres psql -d gis -c 'GRANT CREATE ON DATABASE gis TO "gis";'
     $ sudo -u postgres psql -d gis -c 'GRANT USAGE,CREATE ON SCHEMA gis TO "gis";'
 
-Enable PostGIS for the ``gid`` database.
+Enable PostGIS for the ``gis`` database.
 
 For PostGIS 1.5::
 

--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -84,24 +84,6 @@ def _setup_ddl_event_listeners():
                     stmt = stmt.execution_options(autocommit=True)
                     bind.execute(stmt)
 
-                # Add spatial indices for the Geometry and Geography columns
-                if isinstance(c.type, (Geometry, Geography)) and \
-                        c.type.spatial_index is True:
-                    bind.execute('CREATE INDEX "idx_%s_%s" ON "%s"."%s" '
-                                 'USING GIST (%s)' %
-                                 (table.name, c.name, table_schema,
-                                  table.name, c.name))
-
-                # Add spatial indices for the Raster columns
-                #
-                # Note the use of ST_ConvexHull since most raster operators are
-                # based on the convex hull of the rasters.
-                if isinstance(c.type, Raster) and c.type.spatial_index is True:
-                    bind.execute('CREATE INDEX "idx_%s_%s" ON "%s"."%s" '
-                                 'USING GIST (ST_ConvexHull(%s))' %
-                                 (table.name, c.name, table_schema,
-                                  table.name, c.name))
-
         elif event == 'after-drop':
             # Restore original column list including managed Geometry columns
             table.columns = table.info.pop('_saved_columns')

--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -306,6 +306,9 @@ _FUNCTIONS = [
      'Returns a "simplified" version of the given geometry using the '
      'Douglas-Peucker algorithm'),
 
+    ('ST_ConvexHull', types.Geometry,
+     'Returns the convex hull of the given geometry'),
+
     #
     # Raster Constructors
     #


### PR DESCRIPTION
Right now, using Geoalchemy2 together with alembic is problematic, since ga2 creates indices by directly emitting SQL during the DDL generation stage. alembic does not pick this up obviously, and constantly tries to delete the spatial indices when generating migrations.

This pull request moves index creation into the GIS types themselves, making sure that the proper indices appear in the table / model metadata, which is what alembic uses to create migration scripts.

Let me know if I haven't followed your code guidelines fully. I ran all tests and they checked out.