### PR TITLE
Read geometries with ST_AsEWKB instead of ST_AsBinary

### DIFF
--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -23,7 +23,7 @@ class _GISType(UserDefinedType):
 
     This class defines ``bind_expression`` and ``column_expression`` methods
     that wrap column expressions in ``ST_GeomFromEWKT``, ``ST_GeogFromText``,
-    or ``ST_AsBinary`` calls.
+    or ``ST_AsEWKB`` calls.
 
     This class also defines ``result_processor`` and ``bind_processor``
     methods. The function returned by ``result_processor`` converts WKB values
@@ -100,7 +100,7 @@ class _GISType(UserDefinedType):
         return '%s(%s,%d)' % (self.name, self.geometry_type, self.srid)
 
     def column_expression(self, col):
-        return func.ST_AsBinary(col, type_=self)
+        return func.ST_AsEWKB(col, type_=self)
 
     def result_processor(self, dialect, coltype):
         def process(value):
@@ -160,6 +160,11 @@ class Geography(_GISType):
     from_text = 'ST_GeogFromText'
     """ The ``FromText`` geography constructor. Used by the parent class'
         ``bind_expression`` method. """
+
+    def column_expression(self, col):
+        # load column as WKB because ST_AsEWKB is not defined for geography
+        # see http://postgis.net/docs/ST_AsEWKB.html
+        return func.ST_AsBinary(col, type_=self)
 
 
 class Raster(UserDefinedType):

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -95,7 +95,7 @@ class TestOperator():
         eq_sql(expr, '"table".geom <-> ST_GeomFromEWKT(:geom_1)')
         s = geometry_table.select().order_by(
             geometry_table.c.geom.distance_centroid('POINT(1 2)')).limit(10)
-        eq_sql(s, 'SELECT ST_AsBinary("table".geom) AS geom '
+        eq_sql(s, 'SELECT ST_AsEWKB("table".geom) AS geom '
                   'FROM "table" '
                   'ORDER BY "table".geom <-> ST_GeomFromEWKT(:geom_1) '
                   'LIMIT :param_1')
@@ -106,7 +106,7 @@ class TestOperator():
         eq_sql(expr, '"table".geom <#> ST_GeomFromEWKT(:geom_1)')
         s = geometry_table.select().order_by(
             geometry_table.c.geom.distance_box('POINT(1 2)')).limit(10)
-        eq_sql(s, 'SELECT ST_AsBinary("table".geom) AS geom '
+        eq_sql(s, 'SELECT ST_AsEWKB("table".geom) AS geom '
                   'FROM "table" '
                   'ORDER BY "table".geom <#> ST_GeomFromEWKT(:geom_1) '
                   'LIMIT :param_1')

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -23,7 +23,7 @@ def _test_simple_func(name):
 
 def _test_geometry_returning_func(name):
     eq_sql(getattr(func, name)(1).select(),
-           'SELECT ST_AsBinary(%(name)s(:param_1)) AS "%(name)s_1"' %
+           'SELECT ST_AsEWKB(%(name)s(:param_1)) AS "%(name)s_1"' %
            dict(name=name))
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,7 +37,7 @@ class TestGeometry():
 
     def test_column_expression(self, geometry_table):
         s = select([geometry_table.c.geom])
-        eq_sql(s, 'SELECT ST_AsBinary("table".geom) AS geom FROM "table"')
+        eq_sql(s, 'SELECT ST_AsEWKB("table".geom) AS geom FROM "table"')
 
     def test_select_bind_expression(self, geometry_table):
         s = select(['foo']).where(geometry_table.c.geom == 'POINT(1 2)')
@@ -53,7 +53,7 @@ class TestGeometry():
     def test_function_call(self, geometry_table):
         s = select([geometry_table.c.geom.ST_Buffer(2)])
         eq_sql(s,
-               'SELECT ST_AsBinary(ST_Buffer("table".geom, :param_1)) '
+               'SELECT ST_AsEWKB(ST_Buffer("table".geom, :param_1)) '
                'AS "ST_Buffer_1" FROM "table"')
 
     def test_non_ST_function_call(self, geometry_table):
@@ -67,7 +67,7 @@ class TestGeometry():
         from sqlalchemy.sql import select
         s = select([geometry_table]).alias('name').select()
         eq_sql(s,
-               'SELECT ST_AsBinary(name.geom) AS geom FROM '
+               'SELECT ST_AsEWKB(name.geom) AS geom FROM '
                '(SELECT "table".geom AS geom FROM "table") AS name')
 
 
@@ -95,7 +95,7 @@ class TestGeography():
     def test_function_call(self, geography_table):
         s = select([geography_table.c.geom.ST_Buffer(2)])
         eq_sql(s,
-               'SELECT ST_AsBinary(ST_Buffer("table".geom, :param_1)) '
+               'SELECT ST_AsEWKB(ST_Buffer("table".geom, :param_1)) '
                'AS "ST_Buffer_1" FROM "table"')
 
     def test_non_ST_function_call(self, geography_table):
@@ -199,5 +199,5 @@ class TestCompositeType():
     def test_ST_Dump(self, geography_table):
         s = select([func.ST_Dump(geography_table.c.geom).geom])
         eq_sql(s,
-               'SELECT ST_AsBinary((ST_Dump("table".geom)).geom) AS geom '
+               'SELECT ST_AsEWKB((ST_Dump("table".geom)).geom) AS geom '
                'FROM "table"')


### PR DESCRIPTION
Otherwise geos can't correctly read 3d geometries: geos supports EWKB, not WKB [1]


[1] http://lists.osgeo.org/pipermail/geos-devel/2013-December/006755.html