### PR TITLE
Adds basic equals comparator to basic spatial type

### DIFF
--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -53,6 +53,14 @@ class _SpatialElement(object):
         func_ = functions._FunctionGenerator(expr=self)
         return getattr(func_, name)
 
+    def __eq__(self, other):
+        '''
+        Basic equals comparator so that values can be set to NULL
+        '''
+        if isinstance(other, _SpatialElement):
+            return self.srid == other.srid and self.data == other.data
+        return False
+
 
 class WKTElement(_SpatialElement, functions.Function):
     """

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -37,6 +37,27 @@ class TestWKTElement():
             u'ST_GeomFromText_2': -1
         }
 
+    def test_compare(self):
+        # Two identical points
+        e0 = WKTElement('POINT(1 2)')
+        e1 = WKTElement('POINT(1 2)')
+        assert e0 == e1
+
+        # A diffenent point
+        e2 = WKTElement('POINT(2 1)')
+        assert e0 != e2
+        
+        # Same point but wiht different projections, should not be equivalent
+        e3 = WKTElement('POINT(1 2)', srid=4326)
+        assert e0 != e3
+
+        # Same points of the same SRID
+        e4 = WKTElement('POINT(1 2)', srid=4326)
+        assert e3 == e4
+
+        # Can make safe comparisons to None (aka NULL value)
+        assert (e0 == None) == False
+
 
 class TestWKTElementFunction():
 
@@ -80,6 +101,28 @@ class TestWKBElement():
             u'param_1': 2, u'ST_GeomFromWKB_1': b'\x01\x02',
             u'ST_GeomFromWKB_2': -1
         }
+
+    def test_compare(self):
+        # Two identical points
+        e0 = WKBElement(b'\x01\x02')
+        e1 = WKBElement(b'\x01\x02')
+        assert e0 == e1
+
+        # A diffenent point
+        e2 = WKBElement(b'\x02\x01')
+        assert e0 != e2
+        
+        # Same point but wiht different projections, should not be equivalent
+        e3 = WKBElement(b'\x01\x02', srid=4326)
+        assert e0 != e3
+
+        # Same points of the same SRID
+        e4 = WKBElement(b'\x01\x02', srid=4326)
+        assert e3 == e4
+
+        # Can make safe comparisons to None (aka NULL value)
+        assert (e0 == None) == False
+
 
 
 class TestRasterElement():


### PR DESCRIPTION
- This addresses an error raised when SQLAlchemy 1.0+ attempts to invoke
  a comparator on the WKB Elements with a "None", which one might desire
  in order to update a column to NULL.
