### PR TITLE
Add EWKB support

### DIFF
--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -113,6 +113,35 @@ class WKBElement(_SpatialElement, functions.Function):
         return binascii.hexlify(self.data)
 
 
+class EWKBElement(_SpatialElement, functions.Function):
+    """
+    Instances of this class wrap a EWKB value. Geometry values read
+    from the database are converted to instances of this type. You may
+    need to create instances of ``EWKBElement`` yourself.
+
+    Note: you cannot create ``EWKBElement`` objects directly from Shapely
+    geometries using the :func:`geoalchemy2.shape.from_shape` function as there
+    is currently no support in Shapely for SRIDs. Instead, you must have a
+    valid EWKB (e.g. beggining with SRID=4326;) and use directly
+    a ``EWKBElement`` (e.g. ``EWKBElement(buffer(ewkb))``).
+    """
+
+    def __init__(self, *args, **kwargs):
+        _SpatialElement.__init__(self, *args, **kwargs)
+        functions.Function.__init__(
+            self,
+            "ST_GeomFromEWKB",
+            self.data
+        )
+
+    @property
+    def desc(self):
+        """
+        This element's description string.
+        """
+        return binascii.hexlify(self.data)
+
+
 class RasterElement(FunctionElement):
     """
     Instances of this class wrap a ``raster`` value. Raster values read

--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -86,6 +86,9 @@ class GenericFunction(functions.GenericFunction):
     def __init__(self, *args, **kwargs):
         expr = kwargs.pop('expr', None)
         if expr is not None:
+            # Use instance based type for Geometry (see: use_ewkb option)
+            if isinstance(expr.type, types.Geometry) and len(args) > 0:
+                self.type = expr.type
             args = (expr,) + args
         functions.GenericFunction.__init__(self, *args, **kwargs)
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import Table, MetaData, Column, String, func
 from geoalchemy2.types import Geometry
 from geoalchemy2.elements import (
-    WKTElement, WKBElement, RasterElement, CompositeElement
+    WKTElement, WKBElement, EWKBElement, RasterElement, CompositeElement
 )
 
 
@@ -83,6 +83,27 @@ class TestWKBElement():
 
     def test_function_str(self):
         e = WKBElement(b'\x01\x02')
+        assert isinstance(str(e), str)
+
+
+class TestEWKBElement():
+
+    def test_dec(self):
+        e = EWKBElement(b'\x01\x02')
+        assert e.desc == b'0102'
+
+    def test_function_call(self):
+        e = EWKBElement(b'\x01\x02')
+        f = e.ST_Buffer(2)
+        eq_sql(f, 'ST_Buffer('
+               'ST_GeomFromEWKB(:ST_GeomFromEWKB_1), '
+               ':param_1)')
+        assert f.compile().params == {
+            u'param_1': 2, u'ST_GeomFromEWKB_1': b'\x01\x02'
+        }
+
+    def test_function_str(self):
+        e = EWKBElement(b'\x01\x02')
         assert isinstance(str(e), str)
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -54,14 +54,18 @@ def test_ST_X():
 def test_ST_Y():
     _test_simple_func('ST_Y')
 
+
 def test_ST_Z():
     _test_simple_func('ST_Z')
+
 
 def test_ST_AsBinary():
     _test_simple_func('ST_AsBinary')
 
+
 def test_ST_AsEWKB():
     _test_simple_func('ST_AsEWKB')
+
 
 def test_ST_AsGeoJSON():
     _test_simple_func('ST_AsGeoJSON')
@@ -82,8 +86,10 @@ def test_ST_AsSVG():
 def test_ST_AsText():
     _test_simple_func('ST_AsText')
 
+
 def test_ST_AsEWKT():
     _test_simple_func('ST_AsEWKT')
+
 
 def test_ST_Area():
     _test_simple_func('ST_Area')

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -1,8 +1,10 @@
 from geoalchemy2.compat import buffer, bytes
-from geoalchemy2.elements import WKBElement, WKTElement
+from geoalchemy2.elements import WKBElement, EWKBElement, WKTElement
 from geoalchemy2.shape import from_shape, to_shape
 
+from copy import copy
 import shapely.wkb
+import shapely.geos
 from shapely.geometry import Point
 
 
@@ -15,6 +17,17 @@ def test_to_shape_WKBElement():
     assert s.y == 2
 
 
+def test_to_shape_EWKBElement():
+    e = EWKBElement(b'\001\001\000\000\200\000\000\000\000\000\000\000'
+                    b'\000\000\000\000\000\000\000\360?\000\000\000\000'
+                    b'\000\000\000@')
+    s = to_shape(e)
+    assert isinstance(s, Point)
+    assert s.x == 0
+    assert s.y == 1
+    assert s.z == 2
+
+
 def test_to_shape_WKTElement():
     e = WKTElement('POINT(1 2)')
     s = to_shape(e)
@@ -23,11 +36,27 @@ def test_to_shape_WKTElement():
     assert s.y == 2
 
 
-def test_from_shape():
+def test_from_shape_WKBElement():
     p = Point(1, 2)
     e = from_shape(p)
     assert isinstance(e, WKBElement)
     assert isinstance(e.data, buffer)
+
+    s = shapely.wkb.loads(bytes(e.data))
+    assert isinstance(s, Point)
+    assert p.equals(p)
+
+
+def test_from_shape_EWKBElement():
+    p = Point(1, 2, 3)
+    wkbwriter_defaults = copy(shapely.geos.WKBWriter.defaults)
+    e = from_shape(p, use_ewkb=True)
+    assert isinstance(e, EWKBElement)
+    assert isinstance(e.data, buffer)
+    wkbwriter_new_defaults = shapely.geos.WKBWriter.defaults
+    # Make sur the WKBWriter defaults have not changed
+    for k in wkbwriter_new_defaults.keys():
+        assert wkbwriter_defaults[k] == wkbwriter_new_defaults[k]
 
     s = shapely.wkb.loads(bytes(e.data))
     assert isinstance(s, Point)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -16,15 +16,18 @@ def geometry_table():
     table = Table('table', MetaData(), Column('geom', Geometry))
     return table
 
+
 @pytest.fixture
 def geometry_table_ewkb():
     table = Table('table', MetaData(), Column('geom', Geometry(use_ewkb=True)))
     return table
 
+
 @pytest.fixture
 def geography_table():
     table = Table('table', MetaData(), Column('geom', Geography))
     return table
+
 
 @pytest.fixture
 def raster_table():
@@ -68,7 +71,6 @@ class TestGeometry():
         eq_sql(s,
                'SELECT ST_AsEWKB(ST_Buffer("table".geom, :param_1)) '
                'AS "ST_Buffer_1" FROM "table"')
-
 
     def test_non_ST_function_call(self, geometry_table):
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -16,12 +16,15 @@ def geometry_table():
     table = Table('table', MetaData(), Column('geom', Geometry))
     return table
 
+@pytest.fixture
+def geometry_table_ewkb():
+    table = Table('table', MetaData(), Column('geom', Geometry(use_ewkb=True)))
+    return table
 
 @pytest.fixture
 def geography_table():
     table = Table('table', MetaData(), Column('geom', Geography))
     return table
-
 
 @pytest.fixture
 def raster_table():
@@ -39,6 +42,10 @@ class TestGeometry():
         s = select([geometry_table.c.geom])
         eq_sql(s, 'SELECT ST_AsBinary("table".geom) AS geom FROM "table"')
 
+    def test_column_expression_ewkb(self, geometry_table_ewkb):
+        s = select([geometry_table_ewkb.c.geom])
+        eq_sql(s, 'SELECT ST_AsEWKB("table".geom) AS geom FROM "table"')
+
     def test_select_bind_expression(self, geometry_table):
         s = select(['foo']).where(geometry_table.c.geom == 'POINT(1 2)')
         eq_sql(s, 'SELECT foo FROM "table" WHERE '
@@ -55,6 +62,13 @@ class TestGeometry():
         eq_sql(s,
                'SELECT ST_AsBinary(ST_Buffer("table".geom, :param_1)) '
                'AS "ST_Buffer_1" FROM "table"')
+
+    def test_function_call_ewkb(self, geometry_table_ewkb):
+        s = select([geometry_table_ewkb.c.geom.ST_Buffer(2)])
+        eq_sql(s,
+               'SELECT ST_AsEWKB(ST_Buffer("table".geom, :param_1)) '
+               'AS "ST_Buffer_1" FROM "table"')
+
 
     def test_non_ST_function_call(self, geometry_table):
 


### PR DESCRIPTION
This is an attempt to integrate what has been discussed in https://github.com/geoalchemy/geoalchemy2/pull/92

The reason: http://osgeo-org.1560.x6.nabble.com/WKB-representation-is-EWKB-not-OGC-td5092794.html
(e.g. Shapely relies on EWKB, which is fine in 2D, every WKB == every EWKB, but when it comes to 3D geoms it is not the case, so we can't decode 3D geoms coming from postgis with Shapely using the current geoalchemy setup...)

It adds one new option to `Geometry`, namely `use_ewkb` and one new element `EWKBElement`.

I had to change the `GenericFunction` to make sure the instance of the `type` was used to take into account the `use_ewkb` option.
Relevant code in SQLAlchemy can be found here:
https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/sql/functions.py#L529

For EWKB postgis formats:
http://postgis.net/docs/ST_AsEWKB.html
http://postgis.net/docs/manual-2.2/ST_GeomFromEWKB.html

Now, I am not 100% sure that's a the design you want, so let me know and I'll adapt gladly.