### PR TITLE
Add Loïc Gasser to the contributors list

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -102,6 +102,7 @@ Contributors:
 * Dolf Andringa (https://github.com/dolfandringa)
 * Frédéric Junod, Camptocamp SA (https://github.com/fredj)
 * ijl (https://github.com/ijl)
+* Loïc Gasser (https://github.com/loicgasser)
 * Marcel Radischat (https://github.com/quiqua)
 * rapto (https://github.com/rapto)
 * Tobias Bieniek (https://github.com/Turbo87)


### PR DESCRIPTION
This adds @loicgasser to the list of contributors.