### PR TITLE
Add a GeoJSON type to handle REST APIs stored in PostGIS

### DIFF
--- a/TEST.rst
+++ b/TEST.rst
@@ -1,6 +1,15 @@
-=====
-Tests
-=====
+=============================
+Tests using the pytest runner
+=============================
+
+QUICK TEST
+==========
+
+Are your Python, Postgres and PostGIS dependencies are all installed?
+Run the tests in a created ``gis`` database::
+
+    $ sudo -u postgres psql ./tests/create_database.sql
+    $ py.test
 
 Install system dependencies
 ===========================
@@ -17,9 +26,17 @@ Install the Python dependencies::
 
     $ pip install -r requirements.txt
     $ pip install psycopg2
+    $ pip install pytest
 
-Set up the database
-===================
+Set up the database using psql
+==============================
+
+Create all ``gis`` database objects at once::
+
+    $ sudo -u postgres psql ./tests/create_database.sql
+
+Or set up the database using SHELL commands
+===========================================
 
 Create the ``gis`` role::
 

--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -176,6 +176,112 @@ class Geography(_GISType):
         ``column_expression`` method. """
 
 
+# ==============================================================================
+# GeoJSON Columns and Elements for SQLAlchemy
+# ==============================================================================
+
+import json
+from geoalchemy2.elements import _SpatialElement
+from sqlalchemy.sql import functions
+from sqlalchemy.sql import func
+
+
+class GeoJSONElement(_SpatialElement, functions.Function):
+    """
+    Instances of this class wrap a GeoJSON value.
+
+    Usage examples::
+
+        geojson_element = GeoJSONElement('''{
+                "coordinates": [
+                    -73.974413,
+                    40.646598
+                ],
+                "type": "Point"
+            }''')
+
+        geojson_element_SRID_4326 = GeoJSONElement('''{
+                "coordinates": [
+                    -73.974413,
+                    40.646598
+                ],
+                "crs": {
+                    "properties": {
+                        "name": "EPSG:4326"
+                    },
+                    "type": "name"
+                },
+                "type": "Point"
+            }''')
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        _SpatialElement.__init__(self, *args, **kwargs)
+        functions.Function.__init__(
+            self,
+            "ST_GeomFromGeoJSON",
+            self.data
+        )
+
+    @property
+    def desc(self):
+        """
+        This element's description string.
+        """
+        return self.data
+    
+    @property
+    def as_dict(self):
+        """
+        This element as a dict object.
+        """
+        return json.loads(self.data)
+
+
+class GeometryJSON(Geometry):
+    ''' Geometry JSON or GeoJSON Field
+    
+    This field returns a Geometry object in GeoJSON format.
+
+    Creating a geometry JSON column is done like this::
+
+        Column(GeometryJSON(geometry_type='POINT', srid=4326))
+
+    See :class:`geoalchemy2.types._GISType` for the list of arguments that can
+    be passed to the constructor.
+
+    '''
+
+    from_text = 'ST_GeomFromGeoJSON'
+    """ The ``FromText`` geometry constructor. Used by the parent class'
+        ``bind_expression`` method. """
+
+    def column_expression(self, col):
+        # ST_AsGeoJSON(geometry col, integer maxdecimaldigits=15, integer options=0)
+        return func.ST_AsGeoJSON(col, 15, 2, type_=self)
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            if value is not None:
+                return GeoJSONElement(value, srid=self.srid)
+        return process
+
+    def bind_expression(self, bindvalue):
+        return getattr(func, self.from_text)(bindvalue, type_=self)
+
+    def bind_processor(self, dialect):
+        def process(bindvalue):
+            if isinstance(bindvalue, GeoJSONElement):
+                return '%s' % (bindvalue.data,)
+            else:
+                return bindvalue
+        return process
+
+
+# ==============================================================================
+
+
 class Raster(UserDefinedType):
     """
     The Raster column type.
@@ -252,4 +358,6 @@ class GeometryDump(CompositeType):
 # subsystem.
 ischema_names['geometry'] = Geometry
 ischema_names['geography'] = Geography
+ischema_names['geojson'] = GeometryJSON
 ischema_names['raster'] = Raster
+

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+# -----------------------------------------------------------------------------
+# GeoAlchemy2: Run Unit Tests
+# -----------------------------------------------------------------------------
+# This SHELL script creates a database named "gis" and adds PostGIS support.
+# -----------------------------------------------------------------------------
+
+#  Set current PostGIS version when not provided.
+# -----------------------------------------------------------------------------
+if [ "$POSTGIS_VERSION" == "" ]; then
+    export POSTGIS_VERSION=2.1
+fi
+
+# Set up the test environment in PosgreSQL.
+# -----------------------------------------------------------------------------
+echo "Setting up GIS test database ..."
+source ./tests/setup_tests.sh
+
+# Use pytest to run unit tests. 
+# -----------------------------------------------------------------------------
+py.test
+

--- a/tests/create_database.sql
+++ b/tests/create_database.sql
@@ -1,6 +1,6 @@
 -- GeoAlchemy2 PostGIS Tests: Set up the database
 -- -----------------------------------------------------------------------------
--- This PSQL script creates a database named "gis" and adds PostGIS support.
+-- This PSQL script creates a database named "gis" which needs PostGIS support.
 -- Use this to run the GeoAlchemy2 unit tests for Python.
 -- -----------------------------------------------------------------------------
 -- NOTE: Log-in as a DB Superuser, e.g. "postgres".
@@ -23,6 +23,7 @@ GRANT USAGE, CREATE ON SCHEMA gis TO "gis";
 
 -- Enable PostGIS for the "gis" database.
 -- -----------------------------------------------------------------------------
+-- NOTE: See ./tests/setup_tests.sh where an IF-statment installs PostGIS.
 
 -- -----------------------------------------------------------------------------
 -- For PostGIS 1.5: Use the PSQL scripts.
@@ -34,6 +35,6 @@ GRANT USAGE, CREATE ON SCHEMA gis TO "gis";
 -- -----------------------------------------------------------------------------
 -- For PostGIS 2: Create the extension here.
 -- -----------------------------------------------------------------------------
-CREATE EXTENSION postgis;
-CREATE EXTENSION postgis_topology;
+-- CREATE EXTENSION postgis;
+-- CREATE EXTENSION postgis_topology;
 

--- a/tests/create_database.sql
+++ b/tests/create_database.sql
@@ -1,0 +1,39 @@
+-- GeoAlchemy2 PostGIS Tests: Set up the database
+-- -----------------------------------------------------------------------------
+-- This PSQL script creates a database named "gis" and adds PostGIS support.
+-- Use this to run the GeoAlchemy2 unit tests for Python.
+-- -----------------------------------------------------------------------------
+-- NOTE: Log-in as a DB Superuser, e.g. "postgres".
+-- -----------------------------------------------------------------------------
+
+-- Create the "gis" role:
+CREATE ROLE gis PASSWORD 'gis' SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN;
+
+-- Create the "gis" database:
+CREATE DATABASE gis ENCODING 'UTF8';
+
+-- Connect to "gis" database for all other objects.
+\connect gis
+
+CREATE SCHEMA gis;
+
+-- Grant permissions:
+GRANT CREATE ON DATABASE gis TO "gis";
+GRANT USAGE, CREATE ON SCHEMA gis TO "gis";
+
+-- Enable PostGIS for the "gis" database.
+-- -----------------------------------------------------------------------------
+
+-- -----------------------------------------------------------------------------
+-- For PostGIS 1.5: Use the PSQL scripts.
+--
+-- OFF \i /usr/share/postgresql/9.x/contrib/postgis-1.5/postgis.sql
+-- OFF \i /usr/share/postgresql/9.x/contrib/postgis-1.5/spatial_ref_sys.sql
+-- -----------------------------------------------------------------------------
+
+-- -----------------------------------------------------------------------------
+-- For PostGIS 2: Create the extension here.
+-- -----------------------------------------------------------------------------
+CREATE EXTENSION postgis;
+CREATE EXTENSION postgis_topology;
+

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+# -----------------------------------------------------------------------------
+# GeoAlchemy2 Setup Tests: Set up the test environment 
+# -----------------------------------------------------------------------------
+# This SHELL script creates a database named "gis" and adds PostGIS support.
+# The env variable POSTGIS_VERSION selects PostGIS 1.5 or 2.x+ versions.
+# Use this to prepare for the GeoAlchemy2 unit tests for Python.
+# -----------------------------------------------------------------------------
+# NOTE: Log-in as a DB Superuser, e.g. "postgres".
+# -----------------------------------------------------------------------------
+
+echo "Creating GIS test database ..."
+psql -U postgres -f ./tests/create_database.sql
+
+# -----------------------------------------------------------------------------
+# Enable PostGIS for the "gis" database.
+# -----------------------------------------------------------------------------
+echo "Installing PostGIS version $POSTGIS_VERSION ..."
+
+if [ "$POSTGIS_VERSION" == "1.5" ]; then
+    # -------------------------------------------------------------------------
+    # For PostGIS 1.5: Use the PSQL scripts.
+    # -------------------------------------------------------------------------
+    psql -U postgres -f /usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql;
+    psql -U postgres -f /usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql;
+    echo "OK PostGIS version $POSTGIS_VERSION"
+else
+    # -------------------------------------------------------------------------
+    # For PostGIS 2: Create the extension in PSQL.
+    # -------------------------------------------------------------------------
+    psql -U postgres -c "CREATE EXTENSION postgis;";
+    echo "OK PostGIS version $POSTGIS_VERSION"
+fi
+

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -6,6 +6,7 @@ from geoalchemy2.types import Geometry
 from geoalchemy2.elements import (
     WKTElement, WKBElement, RasterElement, CompositeElement
 )
+from geoalchemy2.types import GeoJSONElement
 
 
 @pytest.fixture
@@ -152,6 +153,34 @@ class TestExtendedWKBElement():
         e = WKBElement(b'\x01\x02')
         assert isinstance(str(e), str)
 
+# ==============================================================================
+
+class TestGeoJSONElement():
+    point_str = '''{
+                "coordinates": [
+                    -75.00,
+                    40.00
+                ],
+                "type": "Point"
+            }'''
+
+    def test_desc(self):
+        e = GeoJSONElement(self.point_str)
+        assert e.desc ==  self.point_str
+
+    def test_function_call(self):
+        e = GeoJSONElement(self.point_str)
+        f = e.ST_Buffer(2)
+        eq_sql(f, 'ST_Buffer(ST_GeomFromGeoJSON(:ST_GeomFromGeoJSON_1), :param_1)')
+        assert f.compile().params == {
+            u'param_1': 2, u'ST_GeomFromGeoJSON_1': self.point_str
+        }
+
+    def test_function_str(self):
+        e = GeoJSONElement(self.point_str)
+        assert isinstance(str(e), str)
+
+# ==============================================================================
 
 class TestRasterElement():
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -23,7 +23,7 @@ from geoalchemy2.shape import from_shape
 from shapely.geometry import LineString
 
 
-engine = create_engine('postgresql://gis:gis@localhost/gis', echo=True)
+engine = create_engine('postgresql://gis:gis@localhost:5432/gis', echo=True)
 metadata = MetaData(engine)
 Base = declarative_base(metadata=metadata)
 


### PR DESCRIPTION
PostGIS supports http://geojson.org/ strings as way to read GEOMETRY columns, like WKT. GeoJSON  features are a good way to pass GIS data via a REST API.

This new GeoAlchemy2 type, GeometryJSON(), lets us marshall GEOMETRY columns to a REST API (nearly) automatically. The GeoJSONElement() wrapper can show it as either a GeoJSON string or a dict object. 
