### PR TITLE
WKTElement: fix __str__ under python 3

### DIFF
--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -41,6 +41,8 @@ class _SpatialElement(object):
     def __str__(self):
         if not PY3:
             return self.desc
+        if isinstance(self.desc, str):
+            return self.desc
         return self.desc.decode('utf-8')
 
     def __repr__(self):
@@ -133,7 +135,9 @@ class RasterElement(FunctionElement):
         FunctionElement.__init__(self, self.data)
 
     def __str__(self):
-        return self.desc  # pragma: no cover
+        if not PY3:
+            return self.desc
+        return self.desc.decode('utf-8')
 
     def __repr__(self):
         return "<%s at 0x%x; %r>" % \

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -24,6 +24,7 @@ class TestWKTElement():
     def test_desc(self):
         e = WKTElement('POINT(1 2)')
         assert e.desc == 'POINT(1 2)'
+        assert str(e) == 'POINT(1 2)'
 
     def test_function_call(self):
         e = WKTElement('POINT(1 2)')
@@ -43,6 +44,7 @@ class TestExtendedWKTElement():
     def test_desc(self):
         e = WKTElement('SRID=3857;POINT(1 2 3)', extended=True)
         assert e.desc == 'SRID=3857;POINT(1 2 3)'
+        assert str(e) == 'SRID=3857;POINT(1 2 3)'
 
     def test_function_call(self):
         e = WKTElement('SRID=3857;POINT(1 2 3)', extended=True)
@@ -114,6 +116,7 @@ class TestWKBElement():
     def test_desc(self):
         e = WKBElement(b'\x01\x02', extended=True)
         assert e.desc == b'0102'
+        assert str(e) == '0102'
 
     def test_function_call(self):
         e = WKBElement(b'\x01\x02', extended=True)
@@ -136,6 +139,7 @@ class TestExtendedWKBElement():
     def test_desc(self):
         e = WKBElement(b'\x01\x02')
         assert e.desc == b'0102'
+        assert str(e) == '0102'
 
     def test_function_call(self):
         e = WKBElement(b'\x01\x02')
@@ -158,6 +162,7 @@ class TestRasterElement():
     def test_desc(self):
         e = RasterElement(b'\x01\x02')
         assert e.desc == b'0102'
+        assert str(e) == '0102'
 
     def test_function_call(self):
         e = RasterElement(b'\x01\x02')


### PR DESCRIPTION
In py3, WKTElement.desc() returns string and WKBElement.desc() returns
bytes, so the __str__ implementation in the subclass needs to handle both.

>  str(WKTElement('POINT(1 2)')
AttributeError("'str' object has no attribute 'decode'")