### PR TITLE
Fix SpatialElement.__str__ on Python 3

### DIFF
--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -39,13 +39,11 @@ class _SpatialElement(object):
         self.extented = extended
 
     def __str__(self):
-        if not PY3:
-            return self.desc
-        return self.desc.decode('utf-8')
+        return self.desc
 
     def __repr__(self):
-        return "<%s at 0x%x; %r>" % \
-            (self.__class__.__name__, id(self), str(self))  # pragma: no cover
+        return "<%s at 0x%x; %s>" % \
+            (self.__class__.__name__, id(self), self)  # pragma: no cover
 
     def __getattr__(self, name):
         #
@@ -115,7 +113,11 @@ class WKBElement(_SpatialElement, functions.Function):
         """
         This element's description string.
         """
-        return binascii.hexlify(self.data)
+        desc = binascii.hexlify(self.data)
+        if PY3:
+            # hexlify returns a bytes object on py3
+            desc = str(desc, encoding="utf-8")
+        return desc
 
 
 class RasterElement(FunctionElement):
@@ -145,6 +147,10 @@ class RasterElement(FunctionElement):
         This element's description string.
         """
         desc = binascii.hexlify(self.data)
+        if PY3:
+            # hexlify returns a bytes object on py3
+            desc = str(desc, encoding="utf-8")
+
         if len(desc) < 30:
             return desc
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -113,7 +113,7 @@ class TestWKBElement():
 
     def test_desc(self):
         e = WKBElement(b'\x01\x02', extended=True)
-        assert e.desc == b'0102'
+        assert e.desc == '0102'
 
     def test_function_call(self):
         e = WKBElement(b'\x01\x02', extended=True)
@@ -135,7 +135,7 @@ class TestExtendedWKBElement():
 
     def test_desc(self):
         e = WKBElement(b'\x01\x02')
-        assert e.desc == b'0102'
+        assert e.desc == '0102'
 
     def test_function_call(self):
         e = WKBElement(b'\x01\x02')
@@ -157,7 +157,7 @@ class TestRasterElement():
 
     def test_desc(self):
         e = RasterElement(b'\x01\x02')
-        assert e.desc == b'0102'
+        assert e.desc == '0102'
 
     def test_function_call(self):
         e = RasterElement(b'\x01\x02')


### PR DESCRIPTION
This is an alternative to https://github.com/geoalchemy/geoalchemy2/pull/129, as discussed with @b11z. Thank you @b11z for the initial patch.