### PR TITLE
Add use_typmod option for AddGeometryColumn

### DIFF
--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -72,15 +72,18 @@ def _setup_ddl_event_listeners():
             for c in table.c:
                 # Add the managed Geometry columns with AddGeometryColumn()
                 if isinstance(c.type, Geometry) and c.type.management is True:
-                    stmt = select([
-                        func.AddGeometryColumn(
-                            table_schema,
-                            table.name,
-                            c.name,
-                            c.type.srid,
-                            c.type.geometry_type,
-                            c.type.dimension
-                        )])
+                    args = [
+                        table_schema,
+                        table.name,
+                        c.name,
+                        c.type.srid,
+                        c.type.geometry_type,
+                        c.type.dimension
+                    ]
+                    if c.type.use_typmod is not None:
+                        args.append(c.type.use_typmod)
+
+                    stmt = select([func.AddGeometryColumn(*args)])
                     stmt = stmt.execution_options(autocommit=True)
                     bind.execute(stmt)
 

--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -74,6 +74,15 @@ class _GISType(UserDefinedType):
         ``False``. Note that this option has no effect for
         :class:`geoalchemy2.types.Geography`.
 
+    ``use_typmod``
+
+        By default PostgreSQL type modifiers are used to create the geometry
+        column. To use check constraints instead set ``use_typmod`` to
+        ``False``. By default this option is not included in the call to
+        ``AddGeometryColumn``. Note that this option is only taken
+        into account if ``management`` is set to ``True`` and is only available
+        for PostGIS 2.x.
+
     """
 
     name = None
@@ -93,12 +102,13 @@ class _GISType(UserDefinedType):
         geometry/geography columns. """
 
     def __init__(self, geometry_type='GEOMETRY', srid=-1, dimension=2,
-                 spatial_index=True, management=False):
+                 spatial_index=True, management=False, use_typmod=None):
         self.geometry_type = geometry_type.upper()
         self.srid = int(srid)
         self.dimension = dimension
         self.spatial_index = spatial_index
         self.management = management
+        self.use_typmod = use_typmod
         self.extended = self.as_binary == 'ST_AsEWKB'
 
     def get_col_spec(self):


### PR DESCRIPTION
[AddGeometryColumn](http://postgis.net/docs/AddGeometryColumn.html) has a parameter `use_typmod` which when set to `false` will create explicit constraints for dimension, SRID and geometry type instead of relying on the build-in types (for PostGIS 2.x).

This PR proposes to add a parameter `use_typmod` to `_GISType` which will be passed on to `AddGeometryColumn`.