### PR TITLE
Adapt code style to new version of flake8/pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - pip install tox
 
   # Install flake8 style checker
-  - pip install flake8
+  - pip install -r requirements.txt
 
 before_script:
   # Create database user "gis"

--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -108,4 +108,6 @@ def _setup_ddl_event_listeners():
         elif event == 'after-drop':
             # Restore original column list including managed Geometry columns
             table.columns = table.info.pop('_saved_columns')
+
+
 _setup_ddl_event_listeners()

--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -258,6 +258,7 @@ class GeometryDump(CompositeType):
     typemap = {'path': postgresql.ARRAY(Integer), 'geom': Geometry}
     """ Dictionary defining the contents of a ``geometry_dump``. """
 
+
 # Register Geometry, Geography and Raster to SQLAlchemy's Postgres reflection
 # subsystem.
 ischema_names['geometry'] = Geometry

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@
 -e .
 
 # Additional requirements for running the testsuite and development
-flake8
-pytest
-pytest-cov
+pycodestyle==2.2.0
+flake8==3.2.0
+pytest==3.0.4
+pytest-cov==2.4.0
 
 Shapely>=1.3.0


### PR DESCRIPTION
A new version of flake8 and pycodestyle was released on Monday, which broke the Travis build. This PR fixes the linter issues.

Also I am proposing to pin down the versions of the development dependencies to have a reproducible build.