### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.rst
+include *.txt


### PR DESCRIPTION
Hey-lo,

I'm helping to maintain a copy of `geolachemy2` built using [`conda`](http://conda.pydata.org/) as part [conda-forge](http://conda-forge.github.io/). (The repo is [here](https://github.com/conda-forge/geoalchemy2-feedstock).) When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution. This new MANIFEST.in should make sure that the license file -plus other `.txt` and `.rst` files- are bundled with the source.