### PR TITLE
Add checks to _GISType constructor

### DIFF
--- a/geoalchemy2/exc.py
+++ b/geoalchemy2/exc.py
@@ -1,0 +1,12 @@
+""" Exceptions used with GeoAlchemy2.
+"""
+
+
+class GeoAlchemyError(Exception):
+    """ Generic error class. """
+
+
+class ArgumentError(GeoAlchemyError):
+    """ Raised when an invalid or conflicting function argument is
+    supplied.
+    """

--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -15,6 +15,7 @@ from sqlalchemy.dialects.postgresql.base import ischema_names
 
 from .comparator import BaseComparator, Comparator
 from .elements import WKBElement, WKTElement, RasterElement, CompositeElement
+from .exc import ArgumentError
 
 
 class _GISType(UserDefinedType):
@@ -109,12 +110,10 @@ class _GISType(UserDefinedType):
 
     def __init__(self, geometry_type='GEOMETRY', srid=-1, dimension=2,
                  spatial_index=True, management=False, use_typmod=None):
+        geometry_type, srid = self.check_ctor_args(
+            geometry_type, srid, management, use_typmod)
         self.geometry_type = geometry_type
-        self.srid = int(srid)
-        if self.geometry_type:
-            self.geometry_type = self.geometry_type.upper()
-        elif self.srid > 0:
-            warnings.warn('srid not enforced when geometry_type is None')
+        self.srid = srid
         self.dimension = dimension
         self.spatial_index = spatial_index
         self.management = management
@@ -146,6 +145,24 @@ class _GISType(UserDefinedType):
             else:
                 return bindvalue
         return process
+
+    @staticmethod
+    def check_ctor_args(geometry_type, srid, management, use_typmod):
+        try:
+            srid = int(srid)
+        except ValueError:
+            raise ArgumentError('srid must be convertible to an integer')
+        if geometry_type:
+            geometry_type = geometry_type.upper()
+        else:
+            if management:
+                raise ArgumentError('geometry_type set to None not compatible '
+                                    'with management')
+            if srid > 0:
+                warnings.warn('srid not enforced when geometry_type is None')
+        if use_typmod and not management:
+            warnings.warn('use_typmod ignored when management is False')
+        return geometry_type, srid
 
 
 class Geometry(_GISType):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,7 @@ import re
 from sqlalchemy import Table, MetaData, Column
 from sqlalchemy.sql import select, insert, func
 from geoalchemy2.types import Geometry, Geography, Raster
+from geoalchemy2.exc import ArgumentError
 
 
 def eq_sql(a, b):
@@ -38,6 +39,22 @@ class TestGeometry():
     def test_get_col_spec_no_typmod(self):
         g = Geometry(geometry_type=None)
         assert g.get_col_spec() == 'geometry'
+
+    def test_check_ctor_args_bad_srid(self):
+        with pytest.raises(ArgumentError):
+            Geometry(srid='foo')
+
+    def test_check_ctor_args_incompatible_arguments(self):
+        with pytest.raises(ArgumentError):
+            Geometry(geometry_type=None, management=True)
+
+    def test_check_ctor_args_srid_not_enforced(self):
+        with pytest.warns(UserWarning):
+            Geometry(geometry_type=None, srid=4326)
+
+    def test_check_ctor_args_use_typmod_ignored(self):
+        with pytest.warns(UserWarning):
+            Geometry(management=False, use_typmod=True)
 
     def test_column_expression(self, geometry_table):
         s = select([geometry_table.c.geom])


### PR DESCRIPTION
This PR add checks for the arguments passed to the `_GISType` constructor.

@tsauerwein, what do you think about that? I think it's a good idea to catch errors as early as possible, and warn the user when appropriate.