### PR TITLE
Fix docstring for overlaps_or_above

### DIFF
--- a/geoalchemy2/comparator.py
+++ b/geoalchemy2/comparator.py
@@ -184,7 +184,7 @@ class Comparator(BaseComparator):
 
     def overlaps_or_above(self, other):
         """
-        The ``|&>`` operator. A's BBOX overlaps or is to the right of B's.
+        The ``|&>`` operator. A's BBOX overlaps or is above B's.
         """
         return self.operate(OVERLAPS_OR_ABOVE, other,
                             result_type=sqltypes.Boolean)


### PR DESCRIPTION
It is just a minor fix in a docstring: instead of comparing to see if it is to the right, we are comparing to see if it is above.