### PR TITLE
fix  pickle can't handle.

### DIFF
--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -131,6 +131,7 @@ class _GISType(UserDefinedType):
     def result_processor(self, dialect, coltype):
         def process(value):
             if value is not None:
+                value = str(value)
                 return WKBElement(value, srid=self.srid,
                                   extended=self.extended)
         return process


### PR DESCRIPTION
fix the PostGIS returns a Buffer object for geometry columns, which pickle can't handle.

objects = session.query(MyGeoObject).all()
pickle.dumps(objects)

You'll get :

TypeError: can't pickle buffer objects

The problem is that PostGIS returns a Buffer object for geometry columns, which pickle can't handle.