### PR TITLE
Update pytest and sudoer right in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+sudo: true
+dist: trusty
+
 addons:
   postgresql: 9.3
   apt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Additional requirements for running the testsuite and development
 pycodestyle==2.2.0
 flake8==3.2.0
-pytest==3.6.0
+pytest==3.7.4
 pytest-cov==2.5.1
 
 Shapely>=1.3.0


### PR DESCRIPTION
@elemoine this seems to fix the issue you came across here:
https://github.com/geoalchemy/geoalchemy2/pull/193

Basically arguments and plugins were not passed to the main function. I don't know why exactly, but updating pytest solves the issue.

I also had to allow sudo in the travis config, see:
https://travis-ci.com/loicgasser/geoalchemy2/jobs/143524095

see also travis doc here:
https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system