### PR TITLE
Dimension validation

### DIFF
--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -69,6 +69,10 @@ class _GISType(UserDefinedType):
 
         The dimension of the geometry. Default is ``2``.
 
+        When set to ``3`` then the "geometry_type" is constrained to terminate
+        on either ``"Z"`` or ``"M"``. When set to ``4`` then the
+        "geometry_type" must terminate with ``"ZM"``.
+
     ``spatial_index``
 
         Indicate if a spatial index should be created. Default is ``True``.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -50,6 +50,38 @@ class TestGeometry():
         with pytest.raises(ArgumentError):
             Geometry(srid='foo')
 
+    def test_get_col_spec_dimension4D(self):
+        g = Geometry(geometry_type='GEOMETRYZM', srid=900913, dimension=4)
+        assert g.get_col_spec() == 'geometry(GEOMETRYZM,900913)'
+
+    def test_get_col_spec_dimension3DZ(self):
+        g = Geometry(geometry_type='GEOMETRYZ', srid=900913, dimension=3)
+        assert g.get_col_spec() == 'geometry(GEOMETRYZ,900913)'
+
+    def test_get_col_spec_dimension3DM(self):
+        g = Geometry(geometry_type='GEOMETRYM', srid=900913, dimension=3)
+        assert g.get_col_spec() == 'geometry(GEOMETRYM,900913)'
+
+    def test_check_ctor_args_bad_geometry_type_dimension4D(self):
+        with pytest.raises(ArgumentError):
+            Geometry(geometry_type='GEOMETRY', dimension=4)
+
+    def test_check_ctor_args_bad_geometry_type_Z_dimension4D(self):
+        with pytest.raises(ArgumentError):
+            Geometry(geometry_type='GEOMETRYZ', dimension=4)
+
+    def test_check_ctor_args_bad_geometry_type_M_dimension4D(self):
+        with pytest.raises(ArgumentError):
+            Geometry(geometry_type='GEOMETRYM', dimension=4)
+
+    def test_check_ctor_args_bad_geometry_type_dimension3D(self):
+        with pytest.raises(ArgumentError):
+            Geometry(geometry_type='GEOMETRY', dimension=3)
+
+    def test_check_ctor_args_bad_geometry_type_ZM_dimension3D(self):
+        with pytest.raises(ArgumentError):
+            Geometry(geometry_type='GEOMETRYZM', dimension=3)
+
     def test_check_ctor_args_incompatible_arguments(self):
         with pytest.raises(ArgumentError):
             Geometry(geometry_type=None, management=True)


### PR DESCRIPTION
Raise an `exc.ArgumentError` in case of incompatible `geometry_type` and `dimension` parameters. Avoid the issues mentioned in #67 and #157.