### PR TITLE
Support WKBElement as bind values

### DIFF
--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -155,10 +155,20 @@ class _GISType(UserDefinedType):
                 else:
                     return 'SRID=%d;%s' % (bindvalue.srid, bindvalue.data)
             elif isinstance(bindvalue, WKBElement):
-                if not SHAPELY:
-                    raise ArgumentError('Shapely required for handling WKBElement bind values')
-                shape = to_shape(bindvalue)
-                return 'SRID=%d;%s' % (bindvalue.srid, shape.wkt)
+                if dialect.name == 'sqlite' or not bindvalue.extended:
+                    # With SpatiaLite or when the WKBElement includes a WKB value rather
+                    # than a EWKB value we use Shapely to convert the WKBElement to an
+                    # EWKT string
+                    if not SHAPELY:
+                        raise ArgumentError('Shapely is required for handling WKBElement bind '
+                                            'values when using SpatiaLite or when the bind value '
+                                            'is a WKB rather than an EWKB')
+                    shape = to_shape(bindvalue)
+                    return 'SRID=%d;%s' % (bindvalue.srid, shape.wkt)
+                else:
+                    # PostGIS ST_GeomFromEWKT works with EWKT strings as well
+                    # as EWKB hex strings
+                    return bindvalue.desc
             else:
                 return bindvalue
         return process

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -226,6 +226,25 @@ class TestSelectBindParam():
         srid = session.execute(row[1].ST_SRID()).scalar()
         assert srid == 4326
 
+    def test_select_bindparam_WKBElement_extented(self):
+        s = Lake.__table__.select()
+        results = self.conn.execute(s)
+        rows = results.fetchall()
+        geom = rows[0][1]
+        assert isinstance(geom, WKBElement)
+        assert geom.extented
+
+        s = Lake.__table__.select().where(Lake.__table__.c.geom == bindparam('geom'))
+        results = self.conn.execute(s, geom=geom)
+        rows = results.fetchall()
+
+        row = rows[0]
+        assert isinstance(row[1], WKBElement)
+        wkt = session.execute(row[1].ST_AsText()).scalar()
+        assert wkt == 'LINESTRING(0 0,1 1)'
+        srid = session.execute(row[1].ST_SRID()).scalar()
+        assert srid == 4326
+
 
 class TestInsertionORM():
 

--- a/tests/test_functional_spatialite.py
+++ b/tests/test_functional_spatialite.py
@@ -72,11 +72,8 @@ class TestInsertionCore():
         # the Geometry type's bind_processor and bind_expression functions.
         conn.execute(Lake.__table__.insert(), [
             {'geom': 'SRID=4326;LINESTRING(0 0,1 1)'},
-            {'geom': WKTElement('LINESTRING(0 0,2 2)', srid=4326)}
-
-            # Having WKBElement objects as bind values is not supported, so
-            # the following does not work:
-            # {'geom': from_shape(LineString([[0, 0], [3, 3]], srid=4326)}
+            {'geom': WKTElement('LINESTRING(0 0,2 2)', srid=4326)},
+            {'geom': from_shape(LineString([[0, 0], [3, 3]]), srid=4326)}
         ])
 
         results = conn.execute(Lake.__table__.select())
@@ -93,6 +90,13 @@ class TestInsertionCore():
         assert isinstance(row[1], WKBElement)
         wkt = session.execute(row[1].ST_AsText()).scalar()
         assert wkt == 'LINESTRING(0 0, 2 2)'
+        srid = session.execute(row[1].ST_SRID()).scalar()
+        assert srid == 4326
+
+        row = rows[2]
+        assert isinstance(row[1], WKBElement)
+        wkt = session.execute(row[1].ST_AsText()).scalar()
+        assert wkt == 'LINESTRING(0 0, 3 3)'
         srid = session.execute(row[1].ST_SRID()).scalar()
         assert srid == 4326
 


### PR DESCRIPTION
GeoAlchemy does not currently support WKBElement objects as bind values. We even have a [a comment in the tests](https://github.com/geoalchemy/geoalchemy2/blob/3b4041620907b5cc0a387eb15749d53251e89e77/tests/test_functional.py#L158-L160) for that issue.

Also, Issue #220 has recently revealed problems with lazy spatial relationships because of that lack.

This PR fixes the problem by extending the `bind_processor` function, making it support WKBElement bind-values. The function relies on Shapely for converting the WKBElement into a WKT string. It just throws an exception when Shapely is not available.
