### PR TITLE
Do not register functions.GenericFunction for sqlalchemy>=1.3.4

### DIFF
--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -84,6 +84,8 @@ class GenericFunction(functions.GenericFunction):
             type = Geometry
     """
 
+    _register = False
+
     def __init__(self, *args, **kwargs):
         expr = kwargs.pop('expr', None)
         if expr is not None:

--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -84,8 +84,8 @@ class GenericFunction(functions.GenericFunction):
             type = Geometry
     """
 
-    # Set _register to False in order to not register this class in
-    # sqlalchemy.sql.functions._registry. Only its childs will be registered.
+    # Set _register to False in order not to register this class in
+    # sqlalchemy.sql.functions._registry. Only its children will be registered.
     _register = False
 
     def __init__(self, *args, **kwargs):

--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -84,6 +84,8 @@ class GenericFunction(functions.GenericFunction):
             type = Geometry
     """
 
+    # Set _register to False in order to not register this class in
+    # sqlalchemy.sql.functions._registry. Only its childs will be registered.
     _register = False
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Do not register `functions.GenericFunction` in `sqlalchemy.sql.functions._registry` for `sqlalchemy>=1.3.4`.
This is not mandatory but it will be more consistent with sqlalchemy.