### PR TITLE
Redefine the geometry_type/dimension consistency checks

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -44,37 +44,29 @@ class TestGeometry():
         with pytest.raises(ArgumentError):
             Geometry(srid='foo')
 
-    def test_get_col_spec_dimension4D(self):
-        g = Geometry(geometry_type='GEOMETRYZM', srid=900913, dimension=4)
+    def test_get_col_spec_geometryzm(self):
+        g = Geometry(geometry_type='GEOMETRYZM', srid=900913)
         assert g.get_col_spec() == 'geometry(GEOMETRYZM,900913)'
 
-    def test_get_col_spec_dimension3DZ(self):
-        g = Geometry(geometry_type='GEOMETRYZ', srid=900913, dimension=3)
+    def test_get_col_spec_geometryz(self):
+        g = Geometry(geometry_type='GEOMETRYZ', srid=900913)
         assert g.get_col_spec() == 'geometry(GEOMETRYZ,900913)'
 
-    def test_get_col_spec_dimension3DM(self):
-        g = Geometry(geometry_type='GEOMETRYM', srid=900913, dimension=3)
+    def test_get_col_spec_geometrym(self):
+        g = Geometry(geometry_type='GEOMETRYM', srid=900913)
         assert g.get_col_spec() == 'geometry(GEOMETRYM,900913)'
 
-    def test_check_ctor_args_bad_geometry_type_dimension4D(self):
+    def test_check_ctor_args_management_zm(self):
         with pytest.raises(ArgumentError):
-            Geometry(geometry_type='GEOMETRY', dimension=4)
+            Geometry(geometry_type='POINTZM', management=True)
 
-    def test_check_ctor_args_bad_geometry_type_Z_dimension4D(self):
+    def test_check_ctor_args_management_z(self):
         with pytest.raises(ArgumentError):
-            Geometry(geometry_type='GEOMETRYZ', dimension=4)
+            Geometry(geometry_type='POINTZ', dimension=2, management=True)
 
-    def test_check_ctor_args_bad_geometry_type_M_dimension4D(self):
+    def test_check_ctor_args_management_m(self):
         with pytest.raises(ArgumentError):
-            Geometry(geometry_type='GEOMETRYM', dimension=4)
-
-    def test_check_ctor_args_bad_geometry_type_dimension3D(self):
-        with pytest.raises(ArgumentError):
-            Geometry(geometry_type='GEOMETRY', dimension=3)
-
-    def test_check_ctor_args_bad_geometry_type_ZM_dimension3D(self):
-        with pytest.raises(ArgumentError):
-            Geometry(geometry_type='GEOMETRYZM', dimension=3)
+            Geometry(geometry_type='POINTM', dimension=2, management=True)
 
     def test_check_ctor_args_incompatible_arguments(self):
         with pytest.raises(ArgumentError):


### PR DESCRIPTION
This PR redefines the geometry_type/dimension consistency checks in the `check_ctor_args` function.

A few things to note:

* `dimension` is actually not used when not using `AddGeometryColumn`, so there's no point checking that `dimension` is consistent with `geometry_type` when `management` is `False`
* when `AddGeometryColumn` is used there are constraints in the setting of `geometry_type` and `dimension`.  `AddGeometryColumn` does not support `ZM` geometry types. And when the geometry type ends with `M` or `Z` the dimension must be set to `3`.

Fixes #227.