### PR TITLE
Do not assume the "public" schema

### DIFF
--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -59,7 +59,6 @@ def _setup_ddl_event_listeners():
 
             if event == 'before-drop':
                 # Drop the managed Geometry columns
-                table_schema = table.schema or 'public'
                 for c in gis_cols:
                     if bind.dialect.name == 'sqlite':
                         drop_func = 'DiscardGeometryColumn'
@@ -78,7 +77,6 @@ def _setup_ddl_event_listeners():
             # Restore original column list including managed Geometry columns
             table.columns = table.info.pop('_saved_columns')
 
-            table_schema = table.schema or 'public'
             for c in table.c:
                 # Add the managed Geometry columns with AddGeometryColumn()
                 if isinstance(c.type, Geometry) and c.type.management is True:
@@ -105,10 +103,15 @@ def _setup_ddl_event_listeners():
                         stmt = stmt.execution_options(autocommit=True)
                         bind.execute(stmt)
                     elif bind.dialect.name == 'postgresql':
-                        bind.execute('CREATE INDEX "idx_%s_%s" ON "%s"."%s" '
-                                     'USING GIST ("%s")' %
-                                     (table.name, c.name, table_schema,
-                                      table.name, c.name))
+                        if table.schema:
+                            bind.execute('CREATE INDEX "idx_%s_%s" ON "%s"."%s" '
+                                         'USING GIST ("%s")' %
+                                         (table.name, c.name, table.schema,
+                                          table.name, c.name))
+                        else:
+                            bind.execute('CREATE INDEX "idx_%s_%s" ON "%s" '
+                                         'USING GIST ("%s")' %
+                                         (table.name, c.name, table.name, c.name))
                     else:
                         raise ArgumentError('dialect {} is not supported'.format(bind.dialect.name))
 
@@ -117,10 +120,15 @@ def _setup_ddl_event_listeners():
                 # Note the use of ST_ConvexHull since most raster operators are
                 # based on the convex hull of the rasters.
                 if isinstance(c.type, Raster) and c.type.spatial_index is True:
-                    bind.execute('CREATE INDEX "idx_%s_%s" ON "%s"."%s" '
-                                 'USING GIST (ST_ConvexHull("%s"))' %
-                                 (table.name, c.name, table_schema,
-                                  table.name, c.name))
+                    if table.schema:
+                        bind.execute('CREATE INDEX "idx_%s_%s" ON "%s"."%s" '
+                                     'USING GIST (ST_ConvexHull("%s"))' %
+                                     (table.name, c.name, table.schema,
+                                      table.name, c.name))
+                    else:
+                        bind.execute('CREATE INDEX "idx_%s_%s" ON "%s" '
+                                     'USING GIST (ST_ConvexHull("%s"))' %
+                                     (table.name, c.name, table.name, c.name))
 
         elif event == 'after-drop':
             # Restore original column list including managed Geometry columns


### PR DESCRIPTION
This PR aims to fix #230, where GeoAlchemy assumes that the schema is "public" when no schema is specified by the user.

Closes #230.