### PR TITLE
Add all geometry constructors

### DIFF
--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -101,6 +101,161 @@ class GenericFunction(functions.GenericFunction):
 
 _FUNCTIONS = [
     #
+    # Geometry Constructors
+    #
+
+    ('ST_BdPolyFromText', types.Geometry,
+     'Construct a Polygon given an arbitrary collection of closed linestrings'
+     'as a MultiLineString Well-Known text representation.'),
+
+    ('ST_BdMPolyFromText', types.Geometry,
+     'Construct a MultiPolygon given an arbitrary collection of closed '
+     'linestrings as a MultiLineString text representation Well-Known text '
+     'representation.'),
+
+    ('ST_Box2dFromGeoHash', types.Geometry,
+     'Return a BOX2D from a GeoHash string.'),
+
+    ('ST_GeogFromText', types.Geography,
+     'Return a specified geography value from Well-Known Text representation '
+     'or extended (WKT).'),
+
+    ('ST_GeographyFromText', types.Geography,
+     'Return a specified geography value from Well-Known Text representation '
+     'or extended (WKT).'),
+
+    ('ST_GeogFromWKB', types.Geography,
+     'Creates a geography instance from a Well-Known Binary geometry '
+     'representation (WKB) or extended Well Known Binary (EWKB).'),
+
+    ('ST_GeomFromTWKB', types.Geometry,
+     'Creates a geometry instance from a TWKB ("Tiny Well-Known Binary") '
+     'geometry representation.'),
+
+    ('ST_GeomCollFromText', types.Geometry,
+     'Makes a collection Geometry from collection WKT with the given SRID. If '
+     'SRID is not given, it defaults to 0.'),
+
+    ('ST_GeomFromEWKB', types.Geometry,
+     'Return a specified ST_Geometry value from Extended Well-Known Binary '
+     'representation (EWKB).'),
+
+    ('ST_GeomFromEWKT', types.Geometry,
+     'Return a specified ST_Geometry value from Extended Well-Known Text '
+     'representation (EWKT).'),
+
+    ('ST_GeometryFromText', types.Geometry,
+     'Return a specified ST_Geometry value from Well-Known Text representation'
+     ' (WKT). This is an alias name for ST_GeomFromText'),
+
+    ('ST_GeomFromGeoHash', types.Geometry,
+     'Return a geometry from a GeoHash string.'),
+
+    ('ST_GeomFromGML', types.Geometry,
+     'Takes as input GML representation of geometry and outputs a PostGIS '
+     'geometry object'),
+
+    ('ST_GeomFromGeoJSON', types.Geometry,
+     'Takes as input a geojson representation of a geometry and outputs a '
+     'PostGIS geometry object'),
+
+    ('ST_GeomFromKML', types.Geometry,
+     'Takes as input KML representation of geometry and outputs a PostGIS '
+     'geometry object'),
+
+    ('ST_GMLToSQL', types.Geometry,
+     'Return a specified ST_Geometry value from GML representation. This is an'
+     ' alias name for ST_GeomFromGML'),
+
+    ('ST_GeomFromText', types.Geometry,
+     'Return a specified ST_Geometry value from Well-Known Text representation'
+     ' (WKT).'),
+
+    ('ST_GeomFromWKB', types.Geometry,
+     'Creates a geometry instance from a Well-Known Binary geometry '
+     'representation (WKB) and optional SRID.'),
+
+    ('ST_LineFromEncodedPolyline', types.Geometry,
+     'Creates a LineString from an Encoded Polyline.'),
+
+    ('ST_LineFromMultiPoint', types.Geometry,
+     'Creates a LineString from a MultiPoint geometry.'),
+
+    ('ST_LineFromText', types.Geometry,
+     'Makes a Geometry from WKT representation with the given SRID. If SRID is'
+     ' not given, it defaults to 0.'),
+
+    ('ST_LineFromWKB', types.Geometry,
+     'Makes a LINESTRING from WKB with the given SRID'),
+
+    ('ST_LinestringFromWKB', types.Geometry,
+     'Makes a geometry from WKB with the given SRID.'),
+
+    ('ST_MakeBox2D', types.Geometry,
+     'Creates a BOX2D defined by the given point geometries.'),
+
+    ('ST_3DMakeBox', types.Geometry,
+     'Creates a BOX3D defined by the given 3d point geometries.'),
+
+    ('ST_MakeLine', types.Geometry,
+     'Creates a Linestring from point, multipoint, or line geometries.'),
+
+    ('ST_MakeEnvelope', types.Geometry,
+     'Creates a rectangular Polygon formed from the given minimums and '
+     'maximums. Input values must be in SRS specified by the SRID.'),
+
+    ('ST_MakePolygon', types.Geometry,
+     'Creates a Polygon formed by the given shell. Input geometries must be '
+     'closed LINESTRINGS.'),
+
+    ('ST_MakePoint', types.Geometry,
+     'Creates a 2D, 3DZ or 4D point geometry.'),
+
+    ('ST_MakePointM', types.Geometry,
+     'Creates a point geometry with an x y and m coordinate.'),
+
+    ('ST_MLineFromText', types.Geometry,
+     'Return a specified ST_MultiLineString value from WKT representation.'),
+
+    ('ST_MPointFromText', types.Geometry,
+     'Makes a Geometry from WKT with the given SRID. If SRID is not given, it '
+     'defaults to 0.'),
+
+    ('ST_MPolyFromText', types.Geometry,
+     'Makes a MultiPolygon Geometry from WKT with the given SRID. If SRID is '
+     'not given, it defaults to 0.'),
+
+    ('ST_Point', types.Geometry,
+     'Returns an ST_Point with the given coordinate values. OGC alias for '
+     'ST_MakePoint.'),
+
+    ('ST_PointFromGeoHash', types.Geometry,
+     'Return a point from a GeoHash string.'),
+
+    ('ST_PointFromText', types.Geometry,
+     'Makes a point Geometry from WKT with the given SRID. If SRID is not '
+     'given, it defaults to unknown.'),
+
+    ('ST_PointFromWKB', types.Geometry,
+     'Makes a geometry from WKB with the given SRID'),
+
+    ('ST_Polygon', types.Geometry,
+     'Returns a polygon built from the specified linestring and SRID.'),
+
+    ('ST_PolygonFromText', types.Geometry,
+     'Makes a Geometry from WKT with the given SRID. If SRID is not given, it '
+     'defaults to 0.'),
+
+    ('ST_WKBToSQL', types.Geometry,
+     'Return a specified ST_Geometry value from Well-Known Binary '
+     'representation (WKB). This is an alias name for ST_GeomFromWKB that '
+     'takes no srid'),
+
+    ('ST_WKTToSQL', types.Geometry,
+     'Return a specified ST_Geometry value from Well-Known Text representation'
+     ' (WKT). This is an alias name for ST_GeomFromText'),
+
+    #
     # Geometry Accessors
     #
 
@@ -499,22 +654,6 @@ _FUNCTIONS = [
     #
     # Raster Constructors
     #
-
-    ('ST_GeomFromText', types.Geometry,
-     'Constructs a PostGIS ST_Geometry object from the OGC Well-Known text '
-     'representation.'),
-
-    ('ST_GeomFromEWKT', types.Geometry,
-     'Constructs a PostGIS ST_Geometry object from the OGC Extended Well-Known '
-     'text (EWKT) representation.'),
-
-    ('ST_GeomFromEWKB', types.Geometry,
-     'Constructs a PostGIS ST_Geometry object from the OGC Extended Well-Known '
-     'binary (EWKB) representation.'),
-
-    ('ST_GeogFromText', types.Geography,
-     'Returns a geography object from the well-known text or extended well-known '
-     'representation.'),
 
     ('ST_AsRaster', types.Raster,
      ('Converts a PostGIS geometry to a PostGIS raster.', 'RT_ST_AsRaster')),

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -32,6 +32,188 @@ def _test_geography_returning_func(name):
            'SELECT ST_AsBinary(%(name)s(:%(name)s_2)) AS "%(name)s_1"' %
            dict(name=name))
 
+#
+# Geometry Constructors
+#
+
+def test_ST_BdPolyFromText():
+    _test_geometry_returning_func('ST_BdPolyFromText')
+
+
+def test_ST_BdMPolyFromText():
+    _test_geometry_returning_func('ST_BdMPolyFromText')
+
+
+def test_ST_Box2dFromGeoHash():
+    _test_geometry_returning_func('ST_Box2dFromGeoHash')
+
+
+def test_ST_GeogFromText():
+    _test_geography_returning_func('ST_GeogFromText')
+
+
+def test_ST_GeographyFromText():
+    _test_geography_returning_func('ST_GeographyFromText')
+
+
+def test_ST_GeogFromWKB():
+    _test_geography_returning_func('ST_GeogFromWKB')
+
+
+def test_ST_GeomFromTWKB():
+    _test_geometry_returning_func('ST_GeomFromTWKB')
+
+
+def test_ST_GeomCollFromText():
+    _test_geometry_returning_func('ST_GeomCollFromText')
+
+
+def test_ST_GeomFromEWKB():
+    _test_geometry_returning_func('ST_GeomFromEWKB')
+
+
+def test_ST_GeomFromEWKT():
+    _test_geometry_returning_func('ST_GeomFromEWKT')
+
+
+def test_ST_GeometryFromText():
+    _test_geometry_returning_func('ST_GeometryFromText')
+
+
+def test_ST_GeomFromGeoHash():
+    _test_geometry_returning_func('ST_GeomFromGeoHash')
+
+
+def test_ST_GeomFromGML():
+    _test_geometry_returning_func('ST_GeomFromGML')
+
+
+def test_ST_GeomFromGeoJSON():
+    _test_geometry_returning_func('ST_GeomFromGeoJSON')
+
+
+def test_ST_GeomFromKML():
+    _test_geometry_returning_func('ST_GeomFromKML')
+
+
+def test_ST_GMLToSQL():
+    _test_geometry_returning_func('ST_GMLToSQL')
+
+
+def test_ST_GeomFromText():
+    _test_geometry_returning_func('ST_GeomFromText')
+
+
+def test_ST_GeomFromWKB():
+    _test_geometry_returning_func('ST_GeomFromWKB')
+
+
+def test_ST_LineFromEncodedPolyline():
+    _test_geometry_returning_func('ST_LineFromEncodedPolyline')
+
+
+def test_ST_LineFromMultiPoint():
+    _test_geometry_returning_func('ST_LineFromMultiPoint')
+
+
+def test_ST_LineFromText():
+    _test_geometry_returning_func('ST_LineFromText')
+
+
+def test_ST_LineFromWKB():
+    _test_geometry_returning_func('ST_LineFromWKB')
+
+
+def test_ST_LinestringFromWKB():
+    _test_geometry_returning_func('ST_LinestringFromWKB')
+
+
+def test_ST_MakeBox2D():
+    _test_geometry_returning_func('ST_MakeBox2D')
+
+
+def test_ST_3DMakeBox():
+    _test_geometry_returning_func('ST_3DMakeBox')
+
+
+def test_ST_MakeLine():
+    _test_geometry_returning_func('ST_MakeLine')
+
+
+def test_ST_MakeEnvelope():
+    _test_geometry_returning_func('ST_MakeEnvelope')
+
+
+def test_ST_MakePolygon():
+    _test_geometry_returning_func('ST_MakePolygon')
+
+
+def test_ST_MakePoint():
+    _test_geometry_returning_func('ST_MakePoint')
+
+
+def test_ST_MakePointM():
+    _test_geometry_returning_func('ST_MakePointM')
+
+
+def test_ST_MLineFromText():
+    _test_geometry_returning_func('ST_MLineFromText')
+
+
+def test_ST_MPointFromText():
+    _test_geometry_returning_func('ST_MPointFromText')
+
+
+def test_ST_MPolyFromText():
+    _test_geometry_returning_func('ST_MPolyFromText')
+
+
+def test_ST_Point():
+    _test_geometry_returning_func('ST_Point')
+
+
+def test_ST_PointFromGeoHash():
+    _test_geometry_returning_func('ST_PointFromGeoHash')
+
+
+def test_ST_PointFromText():
+    _test_geometry_returning_func('ST_PointFromText')
+
+
+def test_ST_PointFromWKB():
+    _test_geometry_returning_func('ST_PointFromWKB')
+
+
+def test_ST_Polygon():
+    _test_geometry_returning_func('ST_Polygon')
+
+
+def test_ST_PolygonFromText():
+    _test_geometry_returning_func('ST_PolygonFromText')
+
+
+def test_ST_WKBToSQL():
+    _test_geometry_returning_func('ST_WKBToSQL')
+
+
+def test_ST_WKTToSQL():
+    _test_geometry_returning_func('ST_WKTToSQL')
+
+#
+# Geometry Accessors
+#
+
+def test_ST_Boundary():
+    _test_geometry_returning_func('ST_Boundary')
+
+
+def test_ST_BoundingDiagonal():
+    _test_geometry_returning_func('ST_BoundingDiagonal')
+
+
+def test_ST_EndPoint():
+    _test_geometry_returning_func('ST_EndPoint')
+
 
 def test_ST_Envelope():
     _test_geometry_returning_func('ST_Envelope')
@@ -45,12 +227,36 @@ def test_ST_GeometryType():
     _test_simple_func('ST_GeometryType')
 
 
+def test_ST_InteriorRingN():
+    _test_geometry_returning_func('ST_InteriorRingN')
+
+
 def test_ST_IsValid():
     _test_simple_func('ST_IsValid')
 
 
 def test_ST_NPoints():
     _test_simple_func('ST_NPoints')
+
+
+def test_ST_PatchN():
+    _test_geometry_returning_func('ST_PatchN')
+
+
+def test_ST_PointN():
+    _test_geometry_returning_func('ST_PointN')
+
+
+def test_ST_Points():
+    _test_geometry_returning_func('ST_Points')
+
+
+def test_ST_SRID():
+    _test_simple_func('ST_SRID')
+
+
+def test_ST_StartPoint():
+    _test_geometry_returning_func('ST_StartPoint')
 
 
 def test_ST_X():
@@ -64,6 +270,152 @@ def test_ST_Y():
 def test_ST_Z():
     _test_simple_func('ST_Z')
 
+#
+# Geometry Editors
+#
+
+def test_ST_AddPoint():
+    _test_geometry_returning_func('ST_AddPoint')
+
+
+def test_ST_Affine():
+    _test_geometry_returning_func('ST_Affine')
+
+
+def test_ST_CollectionExtract():
+    _test_geometry_returning_func('ST_CollectionExtract')
+
+
+def test_ST_CollectionHomogenize():
+    _test_geometry_returning_func('ST_CollectionHomogenize')
+
+
+def test_ST_ExteriorRing():
+    _test_geometry_returning_func('ST_ExteriorRing')
+
+
+def test_ST_Force2D():
+    _test_geometry_returning_func('ST_Force2D')
+
+
+def test_ST_Force3D():
+    _test_geometry_returning_func('ST_Force3D')
+
+
+def test_ST_Force3DM():
+    _test_geometry_returning_func('ST_Force3DM')
+
+
+def test_ST_Force3DZ():
+    _test_geometry_returning_func('ST_Force3DZ')
+
+
+def test_ST_Force4D():
+    _test_geometry_returning_func('ST_Force4D')
+
+
+def test_ST_ForceCollection():
+    _test_geometry_returning_func('ST_ForceCollection')
+
+
+def test_ST_ForceCurve():
+    _test_geometry_returning_func('ST_ForceCurve')
+
+
+def test_ST_ForcePolygonCCW():
+    _test_geometry_returning_func('ST_ForcePolygonCCW')
+
+
+def test_ST_ForcePolygonCW():
+    _test_geometry_returning_func('ST_ForcePolygonCW')
+
+
+def test_ST_ForceRHR():
+    _test_geometry_returning_func('ST_ForceRHR')
+
+
+def test_ST_ForceSFS():
+    _test_geometry_returning_func('ST_ForceSFS')
+
+
+def test_ST_M():
+    _test_simple_func('ST_M')
+
+
+def test_ST_Multi():
+    _test_geometry_returning_func('ST_Multi')
+
+
+def test_ST_Normalize():
+    _test_geometry_returning_func('ST_Normalize')
+
+
+def test_ST_QuantizeCoordinates():
+    _test_geometry_returning_func('ST_QuantizeCoordinates')
+
+
+def test_ST_RemovePoint():
+    _test_geometry_returning_func('ST_RemovePoint')
+
+
+def test_ST_Reverse():
+    _test_geometry_returning_func('ST_Reverse')
+
+
+def test_ST_Rotate():
+    _test_geometry_returning_func('ST_Rotate')
+
+
+def test_ST_RotateX():
+    _test_geometry_returning_func('ST_RotateX')
+
+
+def test_ST_RotateY():
+    _test_geometry_returning_func('ST_RotateY')
+
+
+def test_ST_RotateZ():
+    _test_geometry_returning_func('ST_RotateZ')
+
+
+def test_ST_Scale():
+    _test_geometry_returning_func('ST_Scale')
+
+
+def test_ST_Segmentize():
+    _test_geometry_returning_func('ST_Segmentize')
+
+
+def test_ST_SetPoint():
+    _test_geometry_returning_func('ST_SetPoint')
+
+
+def test_ST_SetSRID():
+    _test_geometry_returning_func('ST_SetSRID')
+
+
+def test_ST_Snap():
+    _test_geometry_returning_func('ST_Snap')
+
+
+def test_ST_SnapToGrid():
+    _test_geometry_returning_func('ST_SnapToGrid')
+
+
+def test_ST_Transform():
+    _test_geometry_returning_func('ST_Transform')
+
+
+def test_ST_Translate():
+    _test_geometry_returning_func('ST_Translate')
+
+
+def test_ST_TransScale():
+    _test_geometry_returning_func('ST_TransScale')
+
+#
+# Geometry Outputs
+#
 
 def test_ST_AsBinary():
     _test_simple_func('ST_AsBinary')
@@ -100,6 +452,9 @@ def test_ST_AsText():
 def test_ST_AsEWKT():
     _test_simple_func('ST_AsEWKT')
 
+#
+# Spatial Relationships and Measurements
+#
 
 def test_ST_Area():
     _test_simple_func('ST_Area')
@@ -181,6 +536,10 @@ def test_ST_Perimeter():
     _test_simple_func('ST_Perimeter')
 
 
+def test_ST_Project():
+    _test_geography_returning_func('ST_Project')
+
+
 def test_ST_Relate():
     _test_simple_func('ST_Relate')
 
@@ -192,6 +551,9 @@ def test_ST_Touches():
 def test_ST_Within():
     _test_simple_func('ST_Within')
 
+#
+# Geometry Processing
+#
 
 def test_ST_Buffer():
     _test_geometry_returning_func('ST_Buffer')
@@ -199,46 +561,6 @@ def test_ST_Buffer():
 
 def test_ST_Difference():
     _test_geometry_returning_func('ST_Difference')
-
-
-def test_ST_Intersection():
-    _test_geometry_returning_func('ST_Intersection')
-
-
-def test_ST_Union():
-    _test_geometry_returning_func('ST_Union')
-
-
-def test_ST_Simplify():
-    _test_geometry_returning_func('ST_Simplify')
-
-
-def test_ST_AddPoint():
-    _test_geometry_returning_func('ST_AddPoint')
-
-
-def test_ST_Affine():
-    _test_geometry_returning_func('ST_Affine')
-
-
-def test_ST_AsRaster():
-    _test_simple_func('ST_AsRaster')
-
-
-def test_ST_Boundary():
-    _test_geometry_returning_func('ST_Boundary')
-
-
-def test_ST_BoundingDiagonal():
-    _test_geometry_returning_func('ST_BoundingDiagonal')
-
-
-def test_ST_CollectionExtract():
-    _test_geometry_returning_func('ST_CollectionExtract')
-
-
-def test_ST_CollectionHomogenize():
-    _test_geometry_returning_func('ST_CollectionHomogenize')
 
 
 def test_ST_Dump():
@@ -249,80 +571,8 @@ def test_ST_DumpPoints():
     _test_simple_func('ST_DumpPoints')
 
 
-def test_ST_EndPoint():
-    _test_geometry_returning_func('ST_EndPoint')
-
-
-def test_ST_ExteriorRing():
-    _test_geometry_returning_func('ST_ExteriorRing')
-
-
-def test_ST_Force2D():
-    _test_geometry_returning_func('ST_Force2D')
-
-
-def test_ST_Force3D():
-    _test_geometry_returning_func('ST_Force3D')
-
-
-def test_ST_Force3DM():
-    _test_geometry_returning_func('ST_Force3DM')
-
-
-def test_ST_Force3DZ():
-    _test_geometry_returning_func('ST_Force3DZ')
-
-
-def test_ST_Force4D():
-    _test_geometry_returning_func('ST_Force4D')
-
-
-def test_ST_ForceCollection():
-    _test_geometry_returning_func('ST_ForceCollection')
-
-
-def test_ST_ForceCurve():
-    _test_geometry_returning_func('ST_ForceCurve')
-
-
-def test_ST_ForcePolygonCCW():
-    _test_geometry_returning_func('ST_ForcePolygonCCW')
-
-
-def test_ST_ForcePolygonCW():
-    _test_geometry_returning_func('ST_ForcePolygonCW')
-
-
-def test_ST_ForceRHR():
-    _test_geometry_returning_func('ST_ForceRHR')
-
-
-def test_ST_ForceSFS():
-    _test_geometry_returning_func('ST_ForceSFS')
-
-
-def test_ST_GeogFromText():
-    _test_geography_returning_func('ST_GeogFromText')
-
-
-def test_ST_GeomFromEWKB():
-    _test_geometry_returning_func('ST_GeomFromEWKB')
-
-
-def test_ST_GeomFromEWKT():
-    _test_geometry_returning_func('ST_GeomFromEWKT')
-
-
-def test_ST_GeomFromText():
-    _test_geometry_returning_func('ST_GeomFromText')
-
-
-def test_ST_Height():
-    _test_simple_func('ST_Height')
-
-
-def test_ST_InteriorRingN():
-    _test_geometry_returning_func('ST_InteriorRingN')
+def test_ST_Intersection():
+    _test_geometry_returning_func('ST_Intersection')
 
 
 def test_ST_LineMerge():
@@ -333,109 +583,36 @@ def test_ST_LineSubstring():
     _test_geometry_returning_func('ST_LineSubstring')
 
 
-def test_ST_M():
-    _test_simple_func('ST_M')
+def test_ST_Simplify():
+    _test_geometry_returning_func('ST_Simplify')
 
 
-def test_ST_Multi():
-    _test_geometry_returning_func('ST_Multi')
+def test_ST_Union():
+    _test_geometry_returning_func('ST_Union')
+
+#
+# Raster Constructors
+#
+
+def test_ST_AsRaster():
+    _test_simple_func('ST_AsRaster')
+
+#
+# Raster Accessors
+#
+
+def test_ST_Height():
+    _test_simple_func('ST_Height')
 
 
-def test_ST_Normalize():
-    _test_geometry_returning_func('ST_Normalize')
+def test_ST_Width():
+    _test_simple_func('ST_Width')
 
-
-def test_ST_PatchN():
-    _test_geometry_returning_func('ST_PatchN')
-
-
-def test_ST_PointN():
-    _test_geometry_returning_func('ST_PointN')
-
-
-def test_ST_Points():
-    _test_geometry_returning_func('ST_Points')
-
-
-def test_ST_Project():
-    _test_geography_returning_func('ST_Project')
-
-
-def test_ST_QuantizeCoordinates():
-    _test_geometry_returning_func('ST_QuantizeCoordinates')
-
-
-def test_ST_RemovePoint():
-    _test_geometry_returning_func('ST_RemovePoint')
-
-
-def test_ST_Reverse():
-    _test_geometry_returning_func('ST_Reverse')
-
-
-def test_ST_Rotate():
-    _test_geometry_returning_func('ST_Rotate')
-
-
-def test_ST_RotateX():
-    _test_geometry_returning_func('ST_RotateX')
-
-
-def test_ST_RotateY():
-    _test_geometry_returning_func('ST_RotateY')
-
-
-def test_ST_RotateZ():
-    _test_geometry_returning_func('ST_RotateZ')
-
-
-def test_ST_SRID():
-    _test_simple_func('ST_SRID')
-
-
-def test_ST_Scale():
-    _test_geometry_returning_func('ST_Scale')
-
-
-def test_ST_Segmentize():
-    _test_geometry_returning_func('ST_Segmentize')
-
-
-def test_ST_SetPoint():
-    _test_geometry_returning_func('ST_SetPoint')
-
-
-def test_ST_SetSRID():
-    _test_geometry_returning_func('ST_SetSRID')
-
-
-def test_ST_Snap():
-    _test_geometry_returning_func('ST_Snap')
-
-
-def test_ST_SnapToGrid():
-    _test_geometry_returning_func('ST_SnapToGrid')
-
-
-def test_ST_StartPoint():
-    _test_geometry_returning_func('ST_StartPoint')
-
-
-def test_ST_TransScale():
-    _test_geometry_returning_func('ST_TransScale')
-
-
-def test_ST_Transform():
-    _test_geometry_returning_func('ST_Transform')
-
-
-def test_ST_Translate():
-    _test_geometry_returning_func('ST_Translate')
-
+#
+# Raster Pixel Accessors and Setters
+#
 
 def test_ST_Value():
     _test_simple_func('ST_Value')
 
 
-def test_ST_Width():
-    _test_simple_func('ST_Width')

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -32,10 +32,10 @@ def _test_geography_returning_func(name):
            'SELECT ST_AsBinary(%(name)s(:%(name)s_2)) AS "%(name)s_1"' %
            dict(name=name))
 
+
 #
 # Geometry Constructors
 #
-
 def test_ST_BdPolyFromText():
     _test_geometry_returning_func('ST_BdPolyFromText')
 
@@ -199,10 +199,10 @@ def test_ST_WKBToSQL():
 def test_ST_WKTToSQL():
     _test_geometry_returning_func('ST_WKTToSQL')
 
+
 #
 # Geometry Accessors
 #
-
 def test_ST_Boundary():
     _test_geometry_returning_func('ST_Boundary')
 
@@ -270,10 +270,10 @@ def test_ST_Y():
 def test_ST_Z():
     _test_simple_func('ST_Z')
 
+
 #
 # Geometry Editors
 #
-
 def test_ST_AddPoint():
     _test_geometry_returning_func('ST_AddPoint')
 
@@ -413,10 +413,10 @@ def test_ST_Translate():
 def test_ST_TransScale():
     _test_geometry_returning_func('ST_TransScale')
 
+
 #
 # Geometry Outputs
 #
-
 def test_ST_AsBinary():
     _test_simple_func('ST_AsBinary')
 
@@ -452,10 +452,10 @@ def test_ST_AsText():
 def test_ST_AsEWKT():
     _test_simple_func('ST_AsEWKT')
 
+
 #
 # Spatial Relationships and Measurements
 #
-
 def test_ST_Area():
     _test_simple_func('ST_Area')
 
@@ -551,10 +551,10 @@ def test_ST_Touches():
 def test_ST_Within():
     _test_simple_func('ST_Within')
 
+
 #
 # Geometry Processing
 #
-
 def test_ST_Buffer():
     _test_geometry_returning_func('ST_Buffer')
 
@@ -590,17 +590,17 @@ def test_ST_Simplify():
 def test_ST_Union():
     _test_geometry_returning_func('ST_Union')
 
+
 #
 # Raster Constructors
 #
-
 def test_ST_AsRaster():
     _test_simple_func('ST_AsRaster')
+
 
 #
 # Raster Accessors
 #
-
 def test_ST_Height():
     _test_simple_func('ST_Height')
 
@@ -608,11 +608,9 @@ def test_ST_Height():
 def test_ST_Width():
     _test_simple_func('ST_Width')
 
+
 #
 # Raster Pixel Accessors and Setters
 #
-
 def test_ST_Value():
     _test_simple_func('ST_Value')
-
-


### PR DESCRIPTION
Add all Geometry constructors.
Reorder the tests so that they are in the same order as the function definitions.

Fixes #156 