### PR TITLE
Raise an AttributeError when calling an attribute of _SpatialElement …

### DIFF
--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -61,6 +61,13 @@ class _SpatialElement(functions.Function):
         # ST_Buffer(ST_GeomFromWKB(:ST_GeomFromWKB_1), :param_1)
         #
 
+        # Function names that don't start with "ST_" are rejected.
+        # This is not to mess up with SQLAlchemy's use of
+        # hasattr/getattr on Column objects.
+
+        if not name.lower().startswith('st_'):
+            raise AttributeError
+
         # We create our own _FunctionGenerator here, and use it in place of
         # SQLAlchemy's "func" object. This is to be able to "bind" the
         # function to the SQL expression. See also GenericFunction above.

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -256,7 +256,7 @@ class TestSelectBindParam():
         rows = results.fetchall()
         geom = rows[0][1]
         assert isinstance(geom, WKBElement)
-        assert geom.extented
+        assert geom.extended
 
         s = Lake.__table__.select().where(Lake.__table__.c.geom == bindparam('geom'))
         results = self.conn.execute(s, geom=geom)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -256,7 +256,7 @@ class TestSelectBindParam():
         rows = results.fetchall()
         geom = rows[0][1]
         assert isinstance(geom, WKBElement)
-        assert geom.extended
+        assert geom.extended is True
 
         s = Lake.__table__.select().where(Lake.__table__.c.geom == bindparam('geom'))
         results = self.conn.execute(s, geom=geom)
@@ -375,7 +375,7 @@ class TestPickle():
         unpickled = pickle.loads(pickled)
         assert unpickled.geom.srid == 4326
         assert str(unpickled.geom) == data_desc
-        assert unpickled.geom.extended
+        assert unpickled.geom.extended is True
         assert unpickled.geom.name == 'ST_GeomFromEWKB'
 
 


### PR DESCRIPTION
Raise an AttributeError when calling an attribute of _SpatialElement that do not starts with the 'st_' prefix, as in the BaseComparator class.

@elemoine do you think it might break something? (it does not break the tests but I am not sure...)