### PR TITLE
Add default compilation rules to elements and functions

### DIFF
--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -100,8 +100,16 @@ class _SpatialElement(functions.Function):
         raise NotImplementedError()
 
 
+# Default handlers are required for SQLAlchemy < 1.1
+# See more details in https://github.com/geoalchemy/geoalchemy2/issues/213
+@compiles(_SpatialElement)
+def compile_spatialelement_default(element, compiler, **kw):
+    return "{}({})".format(element.name,
+                           compiler.process(element.clauses, **kw))
+
+
 @compiles(_SpatialElement, 'sqlite')
-def compile_spatialelement(element, compiler, **kw):
+def compile_spatialelement_sqlite(element, compiler, **kw):
     return "{}({})".format(element.name.lstrip("ST_"),
                            compiler.process(element.clauses, **kw))
 

--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -729,11 +729,20 @@ _SQLITE_FUNCTIONS = {
 }
 
 
-def _compiles(cls, fn):
-    def _compile(element, compiler, **kw):
+# Default handlers are required for SQLAlchemy < 1.1
+# See more details in https://github.com/geoalchemy/geoalchemy2/issues/213
+def _compiles_default(cls):
+    def _compile_default(element, compiler, **kw):
+        return "{}({})".format(cls, compiler.process(element.clauses, **kw))
+    compiles(globals()[cls])(_compile_default)
+
+
+def _compiles_sqlite(cls, fn):
+    def _compile_sqlite(element, compiler, **kw):
         return "{}({})".format(fn, compiler.process(element.clauses, **kw))
-    compiles(globals()[cls], "sqlite")(_compile)
+    compiles(globals()[cls], "sqlite")(_compile_sqlite)
 
 
 for cls, fn in _SQLITE_FUNCTIONS.items():
-    _compiles(cls, fn)
+    _compiles_default(cls)
+    _compiles_sqlite(cls, fn)


### PR DESCRIPTION
I tried to understand the origin of #213 and when I add default compilers (as the exception hints) it works properly but breaks many tests for `sqlalchemy < 1.1`, so it may be not the proper way to fix this.