### PR TITLE
WIP: separate SQL elements from value objects

### DIFF
--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -54,7 +54,9 @@ from sqlalchemy.sql import functions
 from sqlalchemy.ext.compiler import compiles
 
 from . import types
+from . import elements
 
+from sqlalchemy import bindparam
 
 class GenericFunction(functions.GenericFunction):
     """
@@ -92,6 +94,14 @@ class GenericFunction(functions.GenericFunction):
         expr = kwargs.pop('expr', None)
         if expr is not None:
             args = (expr,) + args
+
+        args = [
+            bindparam(elem.name, unique=True, value=elem,
+                      type_=types._GISType(from_text=elem.name, name=elem.name))
+            if isinstance(elem, elements.HasFunction) else elem
+            for elem in args
+        ]
+
         functions.GenericFunction.__init__(self, *args, **kwargs)
 
 


### PR DESCRIPTION
The WKTElement, WKBElement, and Raster objects are returned
as value objects from the database by the types
defined in geoalchemy2.types.  similarly, these objects are
established as stateful value objects that are placed into
INSERT, UPDATE etc. statements, and then the _GISType is
responsible for turning these into an appropriate SQL
expression in the bind_expression() method.

However, these value objects are also made to subclass
sqlalchemy.sql.functions.FunctionElement, which means they also
behave as SQL expressions.

This is an architectural mistake as a SQL expression and a data value
are two different things, and SQLAlchemy can't otherwise intelligently
distinguish between an object that is applying both roles leading
to the issue with UPDATE we see at
https://github.com/sqlalchemy/sqlalchemy/issues/5093.

This PR illustrates a partial POC with a very quick way to break out
the "SQL-function-ness" from these value objects, and to instead
store the "SQL function" as an instance variable that is then
consulted by the _GISType.   Basic tests pass except for the one
involving "raster" which seems to be similar but I just wanted to
get the basic idea demonstrated.

Ideally, the WKTElement / WKBElement / Raster objects would behave
as pure value objects and not have any SQL rendering information within
them; the type objects should handle coming up with the correct
functions.Function object for each one at SQL time.

This is also related to #247 which attempted to fix the above
SQLAlchemy issue, except it can't really work because as long as
WK[TB]Element are SQL expressions, the ORM will not treat these
as value objects.