### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ flake8==3.7.9
 pytest==3.7.4
 pytest-cov==2.5.1
 
-Shapely>=1.3.0, <1.7
+Shapely>=1.3.0 ; implementation_name != "pypy"
+Shapely>=1.3.0, !=1.7.0 ; implementation_name == "pypy"


### PR DESCRIPTION
We forced `shapely<1.7` in requirements because it fails with Pypy but now it is only restricted for Pypy.