### PR TITLE
Fix ST_AsGeoJSON

### DIFF
--- a/geoalchemy2/functions.py
+++ b/geoalchemy2/functions.py
@@ -81,7 +81,9 @@ class ST_AsGeoJSON(functions.GenericFunction):
         if expr is not None:
             args = [expr] + args
         for idx, element in enumerate(args):
-            if isinstance(element, elements.HasFunction):
+            if isinstance(element, functions.GenericFunction):
+                continue
+            elif isinstance(element, elements.HasFunction):
                 if element.extended:
                     func_name = element.geom_from_extended_version
                     func_args = [element.data]
@@ -719,6 +721,9 @@ _FUNCTIONS = [
      'Returns a geometry that represents the shared portion of geomA and '
      'geomB. The geography implementation does a transform to geometry to do '
      'the intersection and then transform back to WGS84.'),
+
+    ('ST_MakeValid', types.Geometry,
+     'Attempts to make an invalid geometry valid without losing vertices.'),
 
     ('ST_LineMerge', types.Geometry,
      'Returns a (set of) LineString(s) formed by sewing together the '

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -686,6 +686,14 @@ class TestCallFunction():
             "coordinates": [[0, 0], [1, 1]]
         }
 
+        # Test with function inside
+        s1_func = select([func.ST_AsGeoJSON(func.ST_MakeValid(Lake.__table__.c.geom))])
+        r1_func = session.execute(s1_func).scalar()
+        assert loads(r1_func) == {
+            "type": "LineString",
+            "coordinates": [[0, 0], [1, 1]]
+        }
+
     @skip_postgis1(postgis_version)
     @skip_postgis2(postgis_version)
     def test_ST_AsGeoJson_feature(self):
@@ -852,4 +860,15 @@ class TestSTAsGeoJson():
             ':ST_AsGeoJSON_2, :ST_AsGeoJSON_3) '
             'AS "ST_AsGeoJSON_1" FROM "another AWFUL.name for.schema".'
             '"this is.an AWFUL.name"',
+        )
+
+    @skip_postgis1(postgis_version)
+    def test_nested_funcs(self):
+        stmt = select([func.ST_AsGeoJSON(func.ST_MakeValid(func.ST_MakePoint(1, 2)))])
+        self._assert_stmt(
+            stmt,
+            'SELECT '
+            'ST_AsGeoJSON(ST_MakeValid('
+            'ST_MakePoint(:ST_MakePoint_1, :ST_MakePoint_2)'
+            ')) AS "ST_AsGeoJSON_1"',
         )

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -585,6 +585,10 @@ def test_ST_Intersection():
     _test_geometry_returning_func('ST_Intersection')
 
 
+def test_ST_MakeValid():
+    _test_geometry_returning_func('ST_MakeValid')
+
+
 def test_ST_LineMerge():
     _test_geometry_returning_func('ST_LineMerge')
 


### PR DESCRIPTION
Fix ST_AsGeoJSON to do nothing when a sqlalchemy.sql.functions.GenericFunction object is found in arguments.

Fixes #267 