### PR TITLE
Add an internal function registry

### DIFF
--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -20,6 +20,9 @@ else:
     BinasciiError = TypeError
 
 
+function_registry = set()
+
+
 class HasFunction(object):
     pass
 
@@ -87,7 +90,7 @@ class _SpatialElement(HasFunction):
         # some ducktyping (e.g. hasattr(element, "copy")) to determine
         # the type of the element.
 
-        if not name.lower().startswith('st_'):
+        if name.lower() not in function_registry:
             raise AttributeError
 
         # We create our own _FunctionGenerator here, and use it in place of

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -811,7 +811,7 @@ class TestCallFunction():
         self._create_one_lake()
 
         s = select([func.ST_UnknownFunction(Lake.__table__.c.geom, 2)])
-        with pytest.raises(ProgrammingError):
+        with pytest.raises(ProgrammingError, match="ST_UnknownFunction"):
             session.execute(s)
 
     def test_unknown_function_element(self):
@@ -824,6 +824,13 @@ class TestCallFunction():
             # "(psycopg2.ProgrammingError) can't adapt type 'WKBElement'"
             # It would be better if it could fail because of a "UndefinedFunction" error
             session.execute(s)
+
+    def test_unknown_function_element_ORM(self):
+        lake_id = self._create_one_lake()
+        lake = session.query(Lake).get(lake_id)
+
+        with pytest.raises(AttributeError):
+            select([lake.geom.ST_UnknownFunction(2)])
 
 
 class TestReflection():


### PR DESCRIPTION
The goal of this PR is to be able to add functions whose names do not start with the `ST_*` prefix (like in #291).