### PR TITLE
Bigquery

### DIFF
--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -123,6 +123,8 @@ def _setup_ddl_event_listeners():
                         q = text(sql)
 
                         bind.execute(q)
+                    elif bind.dialect.name == 'bigquery':
+                        pass  # No indexes for BigQuery
                     else:
                         raise ArgumentError('dialect {} is not supported'.format(bind.dialect.name))
 

--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -296,10 +296,6 @@ class Geography(_GISType):
     """ The ``FromText`` geography constructor. Used by the parent class'
         ``bind_expression`` method. """
 
-    from_binary = 'ST_GeogFromWKB'
-    """ The ``FromBinary`` geography constructor. Used by the parent class'
-        ``bind_expression`` method. """
-
     as_binary = 'ST_AsBinary'
     """ The "as binary" function to use. Used by the parent class'
         ``column_expression`` method. """

--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -123,10 +123,6 @@ class _GISType(UserDefinedType):
     """ The name of "from text" function for this type.
         Set in subclasses. """
 
-    from_binary = None
-    """ The name of "from binary" function for this type.
-        Set in subclasses. """
-
     as_binary = None
     """ The name of the "as binary" function for this type.
         Set in subclasses. """

--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -189,7 +189,7 @@ class _GISType(UserDefinedType):
                 if (dialect.name == 'sqlite' or
                     dialect.name == 'bigquery' or
                     not bindvalue.extended
-                ):
+                    ):
                     # With SpatiaLite or when the WKBElement includes a WKB value rather
                     # than a EWKB value we use Shapely to convert the WKBElement to an
                     # EWKT string


### PR DESCRIPTION
This PR adds support for BigQuery. (Changes will also be needed in in the BigQuery SQLAlchemy dialect.) It adds some special cases similar to those for sqlite.

I could add geography support without these change, but that would require [subclassing geoalchemy2 classes](https://github.com/jimfulton/python-bigquery-sqlalchemy/blob/geoalchemy/sqlalchemy_bigquery/geography.py), which I'd prefer not to do.

BigQuery only supports one projection, WGS84, SRID 4326, and functions that accept `SRID` arguments in PostGIS don't in BigQuery.  Also, BigQuery doesn't support geometry, or have `ST_GEOM...' functions.

I'd like to get a read on whether the approach is acceptable. If it is, then I'll add tests and finish the BigQuery change before making this a non-draft PR.
