### PR TITLE
Fix warnings in preparation for SQLAlchemy v2.0

### DIFF
--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -93,7 +93,7 @@ def _setup_ddl_event_listeners():
                     if bind.dialect.name == 'sqlite':
                         args.append(not c.type.nullable)
 
-                    stmt = select([func.AddGeometryColumn(*args)])
+                    stmt = select(func.AddGeometryColumn(*args))
                     stmt = stmt.execution_options(autocommit=True)
                     bind.execute(stmt)
 
@@ -101,7 +101,7 @@ def _setup_ddl_event_listeners():
                 if isinstance(c.type, (Geometry, Geography)) and \
                         c.type.spatial_index is True:
                     if bind.dialect.name == 'sqlite':
-                        stmt = select([func.CreateSpatialIndex(table.name, c.name)])
+                        stmt = select(func.CreateSpatialIndex(table.name, c.name))
                         stmt = stmt.execution_options(autocommit=True)
                         bind.execute(stmt)
                     elif bind.dialect.name == 'postgresql':

--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -23,6 +23,7 @@ from packaging import version
 
 SQLALCHEMY_VERSION_BEFORE_14 = version.parse(sqlalchemy.__version__) < version.parse("1.4")
 
+
 def _setup_ddl_event_listeners():
     @event.listens_for(Table, "before_create")
     def before_create(target, connection, **kw):

--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -69,7 +69,7 @@ def _setup_ddl_event_listeners():
                     args = [table.schema] if table.schema else []
                     args.extend([table.name, c.name])
 
-                    stmt = select([getattr(func, drop_func)(*args)])
+                    stmt = select(getattr(func, drop_func)(*args))
                     stmt = stmt.execution_options(autocommit=True)
                     bind.execute(stmt)
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         'SQLAlchemy>=1.1',
+        'packaging'
     ],
     entry_points="""
     # -*- Entry points: -*-


### PR DESCRIPTION
We are currently in the process of updating our application in preparation for SQLAlchemy v2.0. The current release of SQLAlchemy is v1.4, which has an environment variable setting (`SQLALCHEMY_WARN_20=1`) which will enable warnings for functionality that will be removed in SQLAlchemy v2.0.

I found that a couple of lines of code in geoalchemy2 emitted a warning in this situation.

```
  /Users/robin/anaconda3/envs/pepys_sa14/lib/python3.8/site-packages/geoalchemy2/__init__.py:96: RemovedIn20Warning: The legacy calling style of select() is deprecated and will be removed in SQLAlchemy 2.0.  Please use the new calling style described at select(). (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    stmt = select([func.AddGeometryColumn(*args)])
```

```
  /Users/robin/anaconda3/envs/pepys_sa14/lib/python3.8/site-packages/geoalchemy2/__init__.py:104: RemovedIn20Warning: The legacy calling style of select() is deprecated and will be removed in SQLAlchemy 2.0.  Please use the new calling style described at select(). (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    stmt = select([func.CreateSpatialIndex(table.name, c.name)])
```

Fixing this is really easy - as it just involves removing the square brackets surrounding the function call.

This fix works fine in SQLAlchemy versions prior to 1.4 as well.