### PR TITLE
Change KeyError into AttributeError in the comparator_factory of CompositeType

### DIFF
--- a/geoalchemy2/types.py
+++ b/geoalchemy2/types.py
@@ -370,8 +370,8 @@ class CompositeType(UserDefinedType):
             try:
                 type_ = self.type.typemap[key]
             except KeyError:
-                raise KeyError("Type '%s' doesn't have an attribute: '%s'"
-                               % (self.type, key))
+                raise AttributeError("Type '%s' doesn't have an attribute: '%s'"
+                                     % (self.type, key))
 
             return CompositeElement(self.expr, key, type_)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Additional requirements for running the testsuite and development
+more-itertools!=8.11; python_version == '3.5'
 flake8==3.7.9
 pytest==3.7.4
 pytest-cov==2.5.1

--- a/tests/gallery/test_summarystatsagg.py
+++ b/tests/gallery/test_summarystatsagg.py
@@ -5,6 +5,10 @@ Use CompositeType
 Some functions return composite types. This example shows how to deal with this
 kind of functions.
 """
+import pytest
+from pkg_resources import parse_version
+
+from sqlalchemy import __version__ as SA_VERSION
 from sqlalchemy import Column
 from sqlalchemy import create_engine
 from sqlalchemy import Float
@@ -63,6 +67,10 @@ class TestSTSummaryStatsAgg():
         session.rollback()
         metadata.drop_all()
 
+    @pytest.mark.skipif(
+        parse_version(SA_VERSION) < parse_version("1.4"),
+        reason="requires SQLAlchely>1.4",
+    )
     def test_st_summary_stats_agg(self):
 
         # Create a new raster

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1068,20 +1068,36 @@ class TestSTSummaryStatsAgg():
         session.add(o)
         session.flush()
 
-        # Define the query to compute stats
-        stats_agg = select([
-            func.ST_SummaryStatsAgg(Ocean.__table__.c.rast, 1, True, 1).label("stats")
-        ])
-        stats_agg_alias = stats_agg.alias("stats_agg")
+        if parse_version(SA_VERSION) < parse_version("1.4"):
+            # Define the query to compute stats
+            stats_agg = select([
+                func.ST_SummaryStatsAgg(Ocean.__table__.c.rast, 1, True, 1).label("stats")
+            ])
+            stats_agg_alias = stats_agg.alias("stats_agg")
 
-        # Use these stats
-        query = select([
-            stats_agg_alias.c.stats.count.label("count"),
-            stats_agg_alias.c.stats.sum.label("sum"),
-            stats_agg_alias.c.stats.stddev.label("stddev"),
-            stats_agg_alias.c.stats.min.label("min"),
-            stats_agg_alias.c.stats.max.label("max")
-        ])
+            # Use these stats
+            query = select([
+                stats_agg_alias.c.stats.count.label("count"),
+                stats_agg_alias.c.stats.sum.label("sum"),
+                stats_agg_alias.c.stats.stddev.label("stddev"),
+                stats_agg_alias.c.stats.min.label("min"),
+                stats_agg_alias.c.stats.max.label("max")
+            ])
+        else:
+            # Define the query to compute stats
+            stats_agg = select(
+                func.ST_SummaryStatsAgg(Ocean.__table__.c.rast, 1, True, 1).label("stats")
+            )
+            stats_agg_alias = stats_agg.alias("stats_agg")
+
+            # Use these stats
+            query = select(
+                stats_agg_alias.c.stats.count.label("count"),
+                stats_agg_alias.c.stats.sum.label("sum"),
+                stats_agg_alias.c.stats.stddev.label("stddev"),
+                stats_agg_alias.c.stats.min.label("min"),
+                stats_agg_alias.c.stats.max.label("max")
+            )
 
         # Check the query
         assert str(query) == (


### PR DESCRIPTION
In order to support the 'generative' style of select() of sqlalchemy>=2, the
select() function in sqlalchemy==1.4 checks whether the first argument is an
iterable or not. This check is performed using 'hasattr', which actually calls
'getattr' and catch the AttributeError exceptions. Changing the exception
raised in the comparator_factory thus allows the 'select()' function to detect
that the CompositeType should be processed as a clause, not as a list of
clauses.

Fixes #333 