### PR TITLE
Add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setup(
     author='Eric Lemoine',
     author_email='eric.lemoine@gmail.com',
     url='https://geoalchemy-2.readthedocs.io/en/latest/',
+    project_urls={
+        'Source': 'https://github.com/geoalchemy/geoalchemy2',
+    },
     license='MIT',
     python_requires=">=3.6",
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests', 'doc']),


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)