### PR TITLE
Replace pkg_resources usage with packaging + importlib.metadata

### DIFF
--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -451,15 +451,9 @@ try:
     import importlib.metadata
     __version__ = importlib.metadata.version('GeoAlchemy2')
 except ImportError:
-    pass
-
-try:
-    if __version__ == "UNKNOWN VERSION":
+    try:
         from pkg_resources import DistributionNotFound
         from pkg_resources import get_distribution
-        try:
-            __version__ = get_distribution('GeoAlchemy2').version
-        except DistributionNotFound:  # pragma: no cover
-            pass  # pragma: no cover
-except ImportError:  # pragma: no cover
-    pass  # pragma: no cover
+        __version__ = get_distribution('GeoAlchemy2').version
+    except (DistributionNotFound, ImportError):  # pragma: no cover
+        pass  # pragma: no cover

--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -449,11 +449,19 @@ __version__ = "UNKNOWN VERSION"
 # back to pkg_resources for Python 3.7 support
 try:
     import importlib.metadata
-    __version__ = importlib.metadata.version('GeoAlchemy2')
 except ImportError:
     try:
         from pkg_resources import DistributionNotFound
         from pkg_resources import get_distribution
-        __version__ = get_distribution('GeoAlchemy2').version
-    except (DistributionNotFound, ImportError):  # pragma: no cover
-        pass  # pragma: no cover
+    except ImportError:  # pragma: no cover
+        pass
+    else:
+        try:
+            __version__ = get_distribution('GeoAlchemy2').version
+        except DistributionNotFound:  # pragma: no cover
+            pass
+else:
+    try:
+        __version__ = importlib.metadata.version('GeoAlchemy2')
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+        pass

--- a/geoalchemy2/__init__.py
+++ b/geoalchemy2/__init__.py
@@ -443,12 +443,23 @@ def load_spatialite(dbapi_conn, connection_record):
 
 # Get version number
 __version__ = "UNKNOWN VERSION"
+
+# Attempt to use importlib.metadata first because it's much faster
+# though it's only available in Python 3.8+ so we'll need to fall
+# back to pkg_resources for Python 3.7 support
 try:
-    from pkg_resources import DistributionNotFound
-    from pkg_resources import get_distribution
-    try:
-        __version__ = get_distribution('GeoAlchemy2').version
-    except DistributionNotFound:  # pragma: no cover
-        pass  # pragma: no cover
+    import importlib.metadata
+    __version__ = importlib.metadata.version('GeoAlchemy2')
+except ImportError:
+    pass
+
+try:
+    if __version__ == "UNKNOWN VERSION":
+        from pkg_resources import DistributionNotFound
+        from pkg_resources import get_distribution
+        try:
+            __version__ = get_distribution('GeoAlchemy2').version
+        except DistributionNotFound:  # pragma: no cover
+            pass  # pragma: no cover
 except ImportError:  # pragma: no cover
     pass  # pragma: no cover

--- a/geoalchemy2/shape.py
+++ b/geoalchemy2/shape.py
@@ -8,12 +8,12 @@ This module provides utility functions for integrating with Shapely.
 """
 import shapely.wkb
 import shapely.wkt
-from pkg_resources import parse_version
+from packaging import version
 
 from .elements import WKBElement
 from .elements import WKTElement
 
-if parse_version(shapely.__version__) < parse_version("1.7"):  # pragma: no cover
+if version.parse(shapely.__version__) < version.parse('1.7'):
     ######################################################################
     # Backport function from Shapely 1.7
     from shapely.geometry.base import geom_factory

--- a/geoalchemy2/shape.py
+++ b/geoalchemy2/shape.py
@@ -13,7 +13,7 @@ from packaging import version
 from .elements import WKBElement
 from .elements import WKTElement
 
-if version.parse(shapely.__version__) < version.parse('1.7'):
+if version.parse(shapely.__version__) < version.parse('1.7'):  # pragma: no cover
     ######################################################################
     # Backport function from Shapely 1.7
     from shapely.geometry.base import geom_factory

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ passenv=
 setenv=
     COVERAGE_FILE = {env:COVERAGE_FILE:.coverage-{envname}}
     EXPECTED_COV = 91
-    pypy3: EXPECTED_COV = 78
+    pypy3: EXPECTED_COV = 77
 deps=
     alembic
     sqla14: SQLAlchemy==1.4.*


### PR DESCRIPTION
`geoalchemy2` is currently fairly slow to import (with and without `__pycache__` being built) and, more importantly, it seems gets substantially slower as the Python environment gets larger. **This is not an issue with `geoalchemy2` itself though**. `SQLAlchemy` is the main culprit for the slow baseline import time and `pkg_resources` is the culprit for the environment size-dependent import time (see: https://github.com/pypa/setuptools/issues/926). 

The PR does two things:
1. Replaces the use of `pkg_resources` in `shape.py` with `packaging` (an existing dependency)
2. Attempts to use `importlib.metadata` instead of `pkg_resources` in `__init__.py`, falling back to `pkg_resources` if you're using Python <3.8

Profiling import time before and after these changes:
```
Tiny (43M):
    Before: 0.332
    After: 0.252

Medium (383M):
    Before: 0.419
    After: 0.319

Large (478M):
    Before: 0.429
    After: 0.308

X-Large (600M):
    Before: 0.462
    After: 0.316 (1.5x speedup)
```
The profiling was done in 4 different `virtualenv`s, covering a range of environment sizes (arbitrarily named here). Tiny is just what's in `requirement-rtd.txt` plus `shapely`: [requirements.tiny.txt](https://github.com/geoalchemy/geoalchemy2/files/9200680/requirements.tiny.txt), and the other environments are real example requirements files from internal projects (not included here but available upon request).

These times were produced simply using: 
```bash
time python -c "import geoalchemy2; import geoalchemy2.shape;"
```

Additionally, here are some visualizations of the `python -X importtime` outputs for the same profiling command in the X-Large environment:
Before:
![Screen Shot 2022-07-27 at 11 50 16 AM](https://user-images.githubusercontent.com/48448372/181292384-f9595c6b-4cf1-49ff-8e3e-45a9168b4e1c.png)

After:
![Screen Shot 2022-07-27 at 11 50 06 AM](https://user-images.githubusercontent.com/48448372/181292411-32a57a82-3b34-4e8a-8810-d17526d33b8c.png)
