### PR TITLE
setup.py needs to know about geoalchemy2.dialects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     },
     license="MIT",
     python_requires=">=3.7",
-    packages=find_namespace_packages(include=["geoalchemy2"]),
+    packages=find_namespace_packages(include=["geoalchemy2", "geoalchemy2.dialects"]),
     include_package_data=True,
     zip_safe=False,
     setup_requires=["setuptools_scm"],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     },
     license="MIT",
     python_requires=">=3.7",
-    packages=find_namespace_packages(include=["geoalchemy2", "geoalchemy2.dialects"]),
+    packages=find_namespace_packages(include=["geoalchemy2*"]),
     include_package_data=True,
     zip_safe=False,
     setup_requires=["setuptools_scm"],


### PR DESCRIPTION
If geoalchemy2.dialects is missing from the packages line of setup.py then then building will either show a big warning, or miss the geoalchemy2.dialects package entirely.