### PR TITLE
fix: handle mysql schemas in column reflection

### DIFF
--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -29,6 +29,7 @@ def reflect_geometry_column(inspector, table, column_info):
         return
 
     column_name = column_info.get("name")
+    schema = table.schema or inspector.default_schema_name
 
     # Check geometry type, SRID and if the column is nullable
     geometry_type_query = """SELECT DATA_TYPE, SRS_ID, IS_NULLABLE
@@ -36,8 +37,8 @@ def reflect_geometry_column(inspector, table, column_info):
         WHERE TABLE_NAME = '{}' and COLUMN_NAME = '{}'""".format(
         table.name, column_name
     )
-    if table.schema is not None:
-        geometry_type_query += """ and table_schema = '{}'""".format(table.schema)
+    if schema is not None:
+        geometry_type_query += """ and table_schema = '{}'""".format(schema)
     geometry_type, srid, nullable_str = inspector.bind.execute(text(geometry_type_query)).one()
     is_nullable = str(nullable_str).lower() == "yes"
 
@@ -51,8 +52,8 @@ def reflect_geometry_column(inspector, table, column_info):
         WHERE TABLE_NAME = '{}' and COLUMN_NAME = '{}'""".format(
         table.name, column_name
     )
-    if table.schema is not None:
-        has_index_query += """ and TABLE_SCHEMA = '{}'""".format(table.schema)
+    if schema is not None:
+        has_index_query += """ and TABLE_SCHEMA = '{}'""".format(schema)
     spatial_index_res = inspector.bind.execute(text(has_index_query)).scalar()
     spatial_index = str(spatial_index_res).lower() == "spatial"
 

--- a/tests/schema_fixtures.py
+++ b/tests/schema_fixtures.py
@@ -183,7 +183,7 @@ def IndexTestWithoutSchema(base):
 
 
 @pytest.fixture
-def reflection_tables_metadata():
+def reflection_tables_metadata(engine):
     metadata = MetaData()
     base = declarative_base(metadata=metadata)
 
@@ -192,8 +192,9 @@ def reflection_tables_metadata():
         id = Column(Integer, primary_key=True)
         geom = Column(Geometry(geometry_type="LINESTRING", srid=4326))
         geom_no_idx = Column(Geometry(geometry_type="LINESTRING", srid=4326, spatial_index=False))
-        geom_z = Column(Geometry(geometry_type="LINESTRINGZ", srid=4326, dimension=3))
-        geom_m = Column(Geometry(geometry_type="LINESTRINGM", srid=4326, dimension=3))
-        geom_zm = Column(Geometry(geometry_type="LINESTRINGZM", srid=4326, dimension=4))
+        if engine.dialect.name != "mysql":
+            geom_z = Column(Geometry(geometry_type="LINESTRINGZ", srid=4326, dimension=3))
+            geom_m = Column(Geometry(geometry_type="LINESTRINGM", srid=4326, dimension=3))
+            geom_zm = Column(Geometry(geometry_type="LINESTRINGZM", srid=4326, dimension=4))
 
     return metadata


### PR DESCRIPTION
Proposed fix for #442 .

In the end I edited only the MySQL part.

Schema management (per DB) for postgre is a bit different and non fully-qualified tables are not always considered to be in `public` schema. 

@adrien-berchet had some trouble wrapping my head around all the fixtures, tried to simplify a bit what was made in the test suite I edited.

