### PR TITLE
Type: Fix Modified check_ctor_args to pass default SRS_ID value in case of null

### DIFF
--- a/geoalchemy2/types/__init__.py
+++ b/geoalchemy2/types/__init__.py
@@ -179,7 +179,7 @@ class _GISType(UserDefinedType):
     @staticmethod
     def check_ctor_args(geometry_type, srid, dimension, use_typmod, nullable):
         try:
-            # passing default SRID is it is NULL from DB
+            # passing default SRID if it is NULL from DB
             srid = int(srid if srid is not None else -1)
         except (ValueError, TypeError):
             raise ArgumentError("srid must be convertible to an integer")

--- a/geoalchemy2/types/__init__.py
+++ b/geoalchemy2/types/__init__.py
@@ -180,8 +180,8 @@ class _GISType(UserDefinedType):
     def check_ctor_args(geometry_type, srid, dimension, use_typmod, nullable):
         try:
             # passing default SRID is it is NULL from DB
-            srid = int(srid or -1)
-        except ValueError:
+            srid = int(srid if srid is not None else -1)
+        except (ValueError, TypeError):
             raise ArgumentError("srid must be convertible to an integer")
         if geometry_type:
             geometry_type = geometry_type.upper()

--- a/geoalchemy2/types/__init__.py
+++ b/geoalchemy2/types/__init__.py
@@ -179,7 +179,8 @@ class _GISType(UserDefinedType):
     @staticmethod
     def check_ctor_args(geometry_type, srid, dimension, use_typmod, nullable):
         try:
-            srid = int(srid)
+            # passing default SRID is it is NULL from DB
+            srid = int(srid or -1)
         except ValueError:
             raise ArgumentError("srid must be convertible to an integer")
         if geometry_type:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -48,6 +48,12 @@ class TestGeometry:
         g = Geometry(srid=None)
         assert g.get_col_spec() == "geometry(GEOMETRY,-1)"
 
+    def test_get_col_spec_invalid_srid(self):
+        with pytest.raises(ArgumentError) as e:
+            g = Geometry(srid="foo")
+            g.get_col_spec()
+        assert str(e.value) == "srid must be convertible to an integer"
+
     def test_get_col_spec_no_typmod(self):
         g = Geometry(geometry_type=None)
         assert g.get_col_spec() == "geometry"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -44,6 +44,10 @@ class TestGeometry:
         g = Geometry(srid=900913)
         assert g.get_col_spec() == "geometry(GEOMETRY,900913)"
 
+    def test_get_col_spec_no_srid(self):
+        g = Geometry(srid=None)
+        assert g.get_col_spec() == "geometry(GEOMETRY,-1)"
+
     def test_get_col_spec_no_typmod(self):
         g = Geometry(geometry_type=None)
         assert g.get_col_spec() == "geometry"


### PR DESCRIPTION
Currently the column conversion from NullType to Geometry by `SQLAlchemy` is failing due to `NULL` `SRS_ID` from the DB. In such scenario, where a null value is received, function should be able to override it by default value of `-1` rather than trying to convert `NoneType` to `int`. This fix takes into consideration failure and override `NoneType` by default value.

Below is the error that occurred due to missing `SRS_ID`.

```bash
  File "/Users/satyamsoni/Documents/alchemy/.venv/lib/python3.11/site-packages/geoalchemy2/types/__init__.py", line 127, in __init__
    geometry_type, srid = self.check_ctor_args(
                          ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/satyamsoni/Documents/alchemy/.venv/lib/python3.11/site-packages/geoalchemy2/types/__init__.py", line 182, in check_ctor_args
    srid = int(srid)
           ^^^^^^^^^
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```
 Post fix this seems to be working fine.

![image](https://github.com/geoalchemy/geoalchemy2/assets/38374728/0eb0f311-91ea-4c2c-96da-35abf6f9a7bb)


### Checklist
<!-- Go over following points. Check them with an `x` if they do apply (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once). -->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the issue).
	- [ ] Please include tests that fail with the `main` branch and pass with the provided fix.
- [ ] A new feature implementation or update an existing feature
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the feature).
	- [ ] Please include tests that cover every lines of the new/updated feature.
	- [ ] Please update the documentation to describe the new/updated feature.

<!-- **Have a nice day!** -->
