### PR TITLE
Update postgresql.py

### DIFF
--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -25,4 +25,7 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, RasterElement):
         return "%s" % (bindvalue.data)
     else:
-        return bindvalue
+        try:
+            return str(bindvalue)
+        except TypeError:
+            return bindvalue


### PR DESCRIPTION
Feat: Converting types to str

### Description
Postgis allows user to create geometry using a string containing geojson. In SQLAlchemy there is no option to add a type converter for asyncpg, so when writing to the database geojson, which is represented by dict type, an error appears. I decided that converting any types to str is the right solution
