### PR TITLE
CI: Fix Pypy job

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -33,7 +33,7 @@ jobs:
           {"pkg_name": "python==3.10.*", "flag": "3.10"},
           {"pkg_name": "python==3.11.*", "flag": "3.11"},
           {"pkg_name": "python==3.12.*", "flag": "3.12"},
-          {"pkg_name": "pypy3.8", "flag": "pypy3.8"},
+          {"pkg_name": "pypy3.10", "flag": "pypy3.10"},
         ]
 
     # The type of runner that the job will run on

--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -154,7 +154,7 @@ jobs:
         PYTEST_MARIADB_DB_URL: mariadb://gis:gis@127.0.0.1:3308/gis
       run: |
         export PYTEST_ADDOPTS='--require-all-dialects'
-        if [[ ${{ matrix.python-version.flag }} == 'pypy3.8' ]]; then
+        if [[ ${{ matrix.python-version.flag }} == 'pypy3.10' ]]; then
           export PYTEST_ADDOPTS=${PYTEST_ADDOPTS}' --ignore=tests/gallery/test_insert_raster.py'
         fi;
         # Run the unit test suite with SQLAlchemy=1.4.* and then with the latest version of SQLAlchemy

--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -153,9 +153,12 @@ jobs:
         PYTEST_MYSQL_DB_URL: mysql://gis:gis@127.0.0.1:3307/gis
         PYTEST_MARIADB_DB_URL: mariadb://gis:gis@127.0.0.1:3308/gis
       run: |
-        export PYTEST_ADDOPTS='--require-all-dialects'
         if [[ ${{ matrix.python-version.flag }} == 'pypy3.10' ]]; then
           export PYTEST_ADDOPTS=${PYTEST_ADDOPTS}' --ignore=tests/gallery/test_insert_raster.py'
+          export PYTEST_SPATIALITE3_DB_URL="FAILING URL"
+          export PYTEST_SPATIALITE4_DB_URL="FAILING URL"
+        else
+          export PYTEST_ADDOPTS='--require-all-dialects'
         fi;
         # Run the unit test suite with SQLAlchemy=1.4.* and then with the latest version of SQLAlchemy
         tox -vv

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
     3.10: py310-sqla{14, latest}
     3.11: py311-sqla{14, latest}, docs
     3.12: py312-sqla{14, latest}
-    pypy-3.8: pypy3-sqla{14, latest}
+    pypy-3.10: pypy3-sqla{14, latest}
 
 [testenv]
 passenv=


### PR DESCRIPTION
For unknown reasons the SQLite driver sometimes causes Segmentation Faults in CI with Pypy so we disable it for the Pypy job.