### PR TITLE
Fix: Pass through keyword args for create_geospatial_table(). Fixes: #532

### DIFF
--- a/geoalchemy2/alembic_helpers.py
+++ b/geoalchemy2/alembic_helpers.py
@@ -535,6 +535,7 @@ def create_geo_table(context, revision, op):
             schema=op.schema,
             _namespace_metadata=op._namespace_metadata,
             _constraints_included=op._constraints_included,
+            **op.kw,
         )
     else:
         new_op = op


### PR DESCRIPTION
### Description

The Alembic helpers registering a `create_geospatial_table` operation did not pass additional  keyword arguments to the operation. Additional user-provided arguments like `postgres_partition_by` would therefore get lost when using the `geoalchemy2.alembic_helpers.writer` helper function. Fixes: #532

### Checklist
<!-- Go over following points. Check them with an `x` if they do apply (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once). -->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- [x] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the issue).
	- [ ] Please include tests that fail with the `main` branch and pass with the provided fix.
- [ ] A new feature implementation or update an existing feature
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the feature).
	- [ ] Please include tests that cover every lines of the new/updated feature.
	- [ ] Please update the documentation to describe the new/updated feature.