### PR TITLE
Feat: Improve cross-dialect WKB/WKT and EWKB handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,11 @@ dmypy.json
 # Miscellaneous
 *.csv
 *.sh
+*.svg
 *.txt
+!test_container/run.sh
+!test_container/start.sh
+!test_container/stop.sh
 !test_container/helpers/configure_postgres.sh
 !test_container/helpers/configure_mysql.sh
 !test_container/helpers/configure_mariadb.sh
@@ -78,3 +82,4 @@ dmypy.json
 issues
 mylocal_db/
 uv.lock
+worktrees

--- a/TEST.rst
+++ b/TEST.rst
@@ -95,6 +95,9 @@ Install the Python dependencies::
     $ pip install -r requirements.txt -r requirements-mypy.txt
     $ pip install psycopg2-binary pyodbc "Shapely>=1.3.0"
 
+The manual requirements include ``wkb-wkt-converter>=0.6.1``, which provides
+the WKB/EWKB conversion helpers used by the tests and runtime bind processors.
+
 The tox environments also install these full-suite dependencies from ``tox.ini``:
 ``psycopg2-binary`` and ``pyodbc`` on CPython, ``psycopg2cffi`` on PyPy, and
 ``Shapely`` for shape conversion tests.

--- a/TEST.rst
+++ b/TEST.rst
@@ -19,11 +19,16 @@ When you are finished the containers and associated data can be removed.
 Install and run the container::
 
     $ ./test_container/build.sh
+    $ ./test_container/start.sh
     $ ./test_container/run.sh
 
 Or run a command directly in the runner container::
 
     $ ./test_container/run.sh tox --workdir /output -v run
+
+The ``run.sh`` script automatically starts the database services first when they
+are not already running. If the services are already running, it only starts a
+temporary ``runner`` container for the requested command.
 
 Run the tests inside the container::
 
@@ -41,6 +46,10 @@ or inside an interactive shell::
 You can combine `py310`, `py311`, `py312`, `py313`, or `pypy3` with `sqla14` or
 `sqlalatest` to run the tests for Python 3.10, 3.11, 3.12, 3.13, or PyPy with
 SQLAlchemy 1.4 or 2.*.
+
+Stop the database services while keeping the containers and cached test output::
+
+    $ ./test_container/stop.sh
 
 Remove the container and associated data::
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,6 +98,7 @@ pygments_style = "sphinx"
 
 # -- Options for Autodoc ---------------------------------------------------
 autodoc_default_options = {"exclude-members": "inherit_cache"}
+autodoc_inherit_docstrings = False
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/geoalchemy2/_wkb_wkt.py
+++ b/geoalchemy2/_wkb_wkt.py
@@ -7,15 +7,114 @@ but centralising the mapping keeps that policy explicit for callers.
 
 from __future__ import annotations
 
+import struct
+
 from wkb_wkt_converter import to_hex_wkb as _to_hex_wkb
 from wkb_wkt_converter import to_wkb as _to_wkb
 from wkb_wkt_converter import to_wkt as _to_wkt
 from wkb_wkt_converter import wkb_to_wkt_split_srid
 from wkb_wkt_converter import wkt_to_wkb_split_srid
 
+_EWKB_SRID_FLAG = 0x20000000
+_EWKB_M_FLAG = 0x40000000
+_EWKB_Z_FLAG = 0x80000000
+_EWKB_TYPE_FLAGS = _EWKB_SRID_FLAG | _EWKB_M_FLAG | _EWKB_Z_FLAG
+_WKB_HEADER_LENGTH = 5
+_EWKB_HEADER_LENGTH = 9
+_SIMPLE_WKB_TYPES = frozenset({1, 2, 3})
+
 
 def _srid_arg(srid: int | None) -> int | bool:
     return srid if srid is not None and srid > 0 else False
+
+
+def _header_bytes(source, length: int) -> bytes:
+    if isinstance(source, str):
+        if len(source) < length * 2:
+            raise ValueError("WKB value is too short to read header")
+        return bytes.fromhex(source[: length * 2])
+
+    if len(source) < length:
+        raise ValueError("WKB value is too short to read header")
+
+    data = source[:length]
+    return data.tobytes() if isinstance(data, memoryview) else bytes(data)
+
+
+def _unpack_wkb_header(source) -> tuple[int, str, int, int | None]:
+    header = _header_bytes(source, _WKB_HEADER_LENGTH)
+    byte_order = header[0]
+    if byte_order not in (0, 1):
+        raise ValueError(f"Invalid WKB byte order marker: {byte_order}")
+
+    endian = "little" if byte_order else "big"
+    marker = "<I" if byte_order else ">I"
+    wkb_type = struct.unpack(marker, header[1:5])[0]
+    srid = None
+    if wkb_type & _EWKB_SRID_FLAG:
+        srid_header = _header_bytes(source, _EWKB_HEADER_LENGTH)
+        srid = struct.unpack(marker, srid_header[5:9])[0]
+    return byte_order, endian, wkb_type, srid
+
+
+def _can_header_rewrite_type(wkb_type: int) -> bool:
+    return (wkb_type & ~_EWKB_TYPE_FLAGS) in _SIMPLE_WKB_TYPES
+
+
+def can_header_rewrite(source) -> bool:
+    """Return whether SRID edits can be done without parsing nested geometry."""
+    _, _, wkb_type, _ = _unpack_wkb_header(source)
+    return _can_header_rewrite_type(wkb_type)
+
+
+def wkb_srid(source) -> int | None:
+    """Return the embedded EWKB SRID without parsing the full geometry."""
+    _, _, _, srid = _unpack_wkb_header(source)
+    return srid
+
+
+def to_wkb_no_srid_header(source):
+    """Strip the EWKB SRID with a header rewrite when that is equivalent."""
+    byte_order, endian, wkb_type, srid = _unpack_wkb_header(source)
+    if not _can_header_rewrite_type(wkb_type):
+        return to_wkb_no_srid(source)
+    if srid is None:
+        return source
+
+    wkb_type &= ~_EWKB_SRID_FLAG
+    type_bytes = wkb_type.to_bytes(4, endian)
+    if isinstance(source, str):
+        return source[:2] + type_bytes.hex() + source[_EWKB_HEADER_LENGTH * 2 :]
+
+    buffer = bytearray()
+    buffer.append(byte_order)
+    buffer.extend(type_bytes)
+    buffer.extend(source[_EWKB_HEADER_LENGTH:])
+    return memoryview(buffer)
+
+
+def to_ewkb_header(source, srid: int):
+    """Embed or replace an EWKB SRID with a header rewrite when equivalent."""
+    if srid <= 0:
+        return to_wkb_no_srid_header(source)
+
+    byte_order, endian, wkb_type, embedded_srid = _unpack_wkb_header(source)
+    if not _can_header_rewrite_type(wkb_type):
+        return to_wkb(source, srid=srid)
+    wkb_type |= _EWKB_SRID_FLAG
+    type_bytes = wkb_type.to_bytes(4, endian)
+    srid_bytes = srid.to_bytes(4, endian)
+    payload_offset = _EWKB_HEADER_LENGTH if embedded_srid is not None else _WKB_HEADER_LENGTH
+
+    if isinstance(source, str):
+        return source[:2] + type_bytes.hex() + srid_bytes.hex() + source[payload_offset * 2 :]
+
+    buffer = bytearray()
+    buffer.append(byte_order)
+    buffer.extend(type_bytes)
+    buffer.extend(srid_bytes)
+    buffer.extend(source[payload_offset:])
+    return memoryview(buffer)
 
 
 def to_wkb(source, srid: int | None = None) -> bytes:

--- a/geoalchemy2/_wkb_wkt.py
+++ b/geoalchemy2/_wkb_wkt.py
@@ -22,7 +22,9 @@ def is_known_srid(srid: int | None) -> bool:
 
 
 def _srid_arg(srid: int | None) -> int | bool:
-    return srid if is_known_srid(srid) else False
+    if srid is None or not is_known_srid(srid):
+        return False
+    return srid
 
 
 def wkb_srid(source) -> int | None:

--- a/geoalchemy2/_wkb_wkt.py
+++ b/geoalchemy2/_wkb_wkt.py
@@ -1,120 +1,46 @@
 """Private wrappers around :mod:`wkb_wkt_converter`.
 
 GeoAlchemy2 uses ``-1`` and sometimes ``0`` as "unknown/no SRID" sentinels in
-Python objects and SQL compilation. The converter accepts those values in 0.5,
+Python objects and SQL compilation. The converter accepts those values,
 but centralising the mapping keeps that policy explicit for callers.
 """
 
 from __future__ import annotations
 
-import struct
-
+from wkb_wkt_converter import to_ewkb_header as _to_ewkb_header
 from wkb_wkt_converter import to_hex_wkb as _to_hex_wkb
 from wkb_wkt_converter import to_wkb as _to_wkb
+from wkb_wkt_converter import to_wkb_no_srid_header as _to_wkb_no_srid_header
 from wkb_wkt_converter import to_wkt as _to_wkt
+from wkb_wkt_converter import wkb_header_srid as _wkb_header_srid
 from wkb_wkt_converter import wkb_to_wkt_split_srid
 from wkb_wkt_converter import wkt_to_wkb_split_srid
-
-_EWKB_SRID_FLAG = 0x20000000
-_EWKB_M_FLAG = 0x40000000
-_EWKB_Z_FLAG = 0x80000000
-_EWKB_TYPE_FLAGS = _EWKB_SRID_FLAG | _EWKB_M_FLAG | _EWKB_Z_FLAG
-_WKB_HEADER_LENGTH = 5
-_EWKB_HEADER_LENGTH = 9
-_SIMPLE_WKB_TYPES = frozenset({1, 2, 3})
 
 
 def _srid_arg(srid: int | None) -> int | bool:
     return srid if srid is not None and srid > 0 else False
 
 
-def _header_bytes(source, length: int) -> bytes:
-    if isinstance(source, str):
-        if len(source) < length * 2:
-            raise ValueError("WKB value is too short to read header")
-        return bytes.fromhex(source[: length * 2])
-
-    if len(source) < length:
-        raise ValueError("WKB value is too short to read header")
-
-    data = source[:length]
-    return data.tobytes() if isinstance(data, memoryview) else bytes(data)
-
-
-def _unpack_wkb_header(source) -> tuple[int, str, int, int | None]:
-    header = _header_bytes(source, _WKB_HEADER_LENGTH)
-    byte_order = header[0]
-    if byte_order not in (0, 1):
-        raise ValueError(f"Invalid WKB byte order marker: {byte_order}")
-
-    endian = "little" if byte_order else "big"
-    marker = "<I" if byte_order else ">I"
-    wkb_type = struct.unpack(marker, header[1:5])[0]
-    srid = None
-    if wkb_type & _EWKB_SRID_FLAG:
-        srid_header = _header_bytes(source, _EWKB_HEADER_LENGTH)
-        srid = struct.unpack(marker, srid_header[5:9])[0]
-    return byte_order, endian, wkb_type, srid
-
-
-def _can_header_rewrite_type(wkb_type: int) -> bool:
-    return (wkb_type & ~_EWKB_TYPE_FLAGS) in _SIMPLE_WKB_TYPES
-
-
-def can_header_rewrite(source) -> bool:
-    """Return whether SRID edits can be done without parsing nested geometry."""
-    _, _, wkb_type, _ = _unpack_wkb_header(source)
-    return _can_header_rewrite_type(wkb_type)
-
-
 def wkb_srid(source) -> int | None:
     """Return the embedded EWKB SRID without parsing the full geometry."""
-    _, _, _, srid = _unpack_wkb_header(source)
-    return srid
+    return _wkb_header_srid(source)
 
 
 def to_wkb_no_srid_header(source):
-    """Strip the EWKB SRID with a header rewrite when that is equivalent."""
-    byte_order, endian, wkb_type, srid = _unpack_wkb_header(source)
-    if not _can_header_rewrite_type(wkb_type):
-        return to_wkb_no_srid(source)
-    if srid is None:
-        return source
-
-    wkb_type &= ~_EWKB_SRID_FLAG
-    type_bytes = wkb_type.to_bytes(4, endian)
-    if isinstance(source, str):
-        return source[:2] + type_bytes.hex() + source[_EWKB_HEADER_LENGTH * 2 :]
-
-    buffer = bytearray()
-    buffer.append(byte_order)
-    buffer.extend(type_bytes)
-    buffer.extend(source[_EWKB_HEADER_LENGTH:])
-    return memoryview(buffer)
+    """Strip the EWKB SRID with native header rewrite/full-conversion fallback."""
+    try:
+        return _to_wkb_no_srid_header(source)
+    except ValueError as exc:
+        if "unexpected end of data reading u32" in str(exc):
+            raise ValueError("WKB value is too short to read header") from None
+        raise
 
 
 def to_ewkb_header(source, srid: int):
-    """Embed or replace an EWKB SRID with a header rewrite when equivalent."""
+    """Embed or replace an EWKB SRID with native header rewrite/full-conversion fallback."""
     if srid <= 0:
         return to_wkb_no_srid_header(source)
-
-    byte_order, endian, wkb_type, embedded_srid = _unpack_wkb_header(source)
-    if not _can_header_rewrite_type(wkb_type):
-        return to_wkb(source, srid=srid)
-    wkb_type |= _EWKB_SRID_FLAG
-    type_bytes = wkb_type.to_bytes(4, endian)
-    srid_bytes = srid.to_bytes(4, endian)
-    payload_offset = _EWKB_HEADER_LENGTH if embedded_srid is not None else _WKB_HEADER_LENGTH
-
-    if isinstance(source, str):
-        return source[:2] + type_bytes.hex() + srid_bytes.hex() + source[payload_offset * 2 :]
-
-    buffer = bytearray()
-    buffer.append(byte_order)
-    buffer.extend(type_bytes)
-    buffer.extend(srid_bytes)
-    buffer.extend(source[payload_offset:])
-    return memoryview(buffer)
+    return _to_ewkb_header(source, srid)
 
 
 def to_wkb(source, srid: int | None = None) -> bytes:

--- a/geoalchemy2/_wkb_wkt.py
+++ b/geoalchemy2/_wkb_wkt.py
@@ -1,0 +1,64 @@
+"""Private wrappers around :mod:`wkb_wkt_converter`.
+
+GeoAlchemy2 uses ``-1`` and sometimes ``0`` as "unknown/no SRID" sentinels in
+Python objects and SQL compilation. The converter accepts those values in 0.5,
+but centralising the mapping keeps that policy explicit for callers.
+"""
+
+from __future__ import annotations
+
+from wkb_wkt_converter import to_hex_wkb as _to_hex_wkb
+from wkb_wkt_converter import to_wkb as _to_wkb
+from wkb_wkt_converter import to_wkt as _to_wkt
+from wkb_wkt_converter import wkb_to_wkt_split_srid
+from wkb_wkt_converter import wkt_to_wkb_split_srid
+
+
+def _srid_arg(srid: int | None) -> int | bool:
+    return srid if srid is not None and srid > 0 else False
+
+
+def to_wkb(source, srid: int | None = None) -> bytes:
+    """Convert to WKB/EWKB, embedding only positive SRIDs."""
+    return _to_wkb(source, srid=_srid_arg(srid))
+
+
+def to_wkb_no_srid(source) -> bytes:
+    """Convert to plain WKB, stripping any embedded SRID."""
+    return _to_wkb(source, srid=False)
+
+
+def to_wkt(source, srid: int | None = None, *, normalize_wkt: bool = False) -> str:
+    """Convert to WKT/EWKT, prefixing only positive SRIDs."""
+    return _to_wkt(source, srid=_srid_arg(srid), normalize_wkt=normalize_wkt)
+
+
+def to_wkt_no_srid(source, *, normalize_wkt: bool = False) -> str:
+    """Convert to plain WKT, stripping any SRID prefix."""
+    return _to_wkt(source, srid=False, normalize_wkt=normalize_wkt)
+
+
+def to_wkt_for_column(source, srid: int | None, *, normalize_wkt: bool = False) -> str:
+    """Convert to WKT/EWKT, preserving source SRID unless the column has one."""
+    return _to_wkt(
+        source,
+        srid=srid if srid is not None and srid > 0 else None,
+        normalize_wkt=normalize_wkt,
+    )
+
+
+def to_hex_wkb_no_srid(source) -> str:
+    """Convert to plain hex WKB, stripping any embedded SRID."""
+    return _to_hex_wkb(source, srid=False)
+
+
+def split_wkb_srid(source) -> tuple[str, int | None]:
+    """Return ``(plain_wkt, embedded_srid)`` for WKB/EWKB input."""
+    if isinstance(source, str):
+        source = bytes.fromhex(source)
+    return wkb_to_wkt_split_srid(source)
+
+
+def split_wkt_srid(source: str) -> tuple[bytes, int | None]:
+    """Return ``(plain_wkb, srid)`` for WKT/EWKT input."""
+    return wkt_to_wkb_split_srid(source)

--- a/geoalchemy2/_wkb_wkt.py
+++ b/geoalchemy2/_wkb_wkt.py
@@ -17,8 +17,12 @@ from wkb_wkt_converter import wkb_to_wkt_split_srid
 from wkb_wkt_converter import wkt_to_wkb_split_srid
 
 
+def is_known_srid(srid: int | None) -> bool:
+    return srid is not None and srid > 0
+
+
 def _srid_arg(srid: int | None) -> int | bool:
-    return srid if srid is not None and srid > 0 else False
+    return srid if is_known_srid(srid) else False
 
 
 def wkb_srid(source) -> int | None:
@@ -38,7 +42,7 @@ def to_wkb_no_srid_header(source):
 
 def to_ewkb_header(source, srid: int):
     """Embed or replace an EWKB SRID with native header rewrite/full-conversion fallback."""
-    if srid <= 0:
+    if not is_known_srid(srid):
         return to_wkb_no_srid_header(source)
     return _to_ewkb_header(source, srid)
 
@@ -67,7 +71,7 @@ def to_wkt_for_column(source, srid: int | None, *, normalize_wkt: bool = False) 
     """Convert to WKT/EWKT, preserving source SRID unless the column has one."""
     return _to_wkt(
         source,
-        srid=srid if srid is not None and srid > 0 else None,
+        srid=srid if is_known_srid(srid) else None,
         normalize_wkt=normalize_wkt,
     )
 

--- a/geoalchemy2/admin/dialects/common.py
+++ b/geoalchemy2/admin/dialects/common.py
@@ -5,8 +5,10 @@ from packaging import version
 from sqlalchemy import Column
 from sqlalchemy import String
 from sqlalchemy.sql import expression
+from sqlalchemy.sql.elements import BindParameter
 from sqlalchemy.types import TypeDecorator
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.types import Geometry
 
@@ -108,8 +110,13 @@ def after_drop(table, bind, **kw):
 
 def compile_bin_literal(wkb_clause):
     """Compile a binary literal for WKBElement."""
+    if not hasattr(wkb_clause, "value"):
+        return wkb_clause
+
     wkb_data = wkb_clause.value
-    if isinstance(wkb_data, (bytes, memoryview, WKBElement)):
+    if isinstance(wkb_data, (bytes, bytearray, memoryview, WKBElement)):
+        if isinstance(wkb_data, bytearray):
+            wkb_data = bytes(wkb_data)
         if isinstance(wkb_data, memoryview):
             wkb_data = wkb_data.tobytes()
         if isinstance(wkb_data, bytes):
@@ -124,3 +131,44 @@ def compile_bin_literal(wkb_clause):
             unique=True,
         )
     return wkb_clause
+
+
+def _is_auto_constructor_bindparam(clause, constructor_name):
+    return (
+        isinstance(clause, BindParameter)
+        and getattr(clause, "unique", False)
+        and getattr(clause, "_orig_key", None) == constructor_name
+    )
+
+
+def _has_known_literal_srid(clause):
+    if not hasattr(clause, "value"):
+        return True
+
+    try:
+        return _wkb_wkt.is_known_srid(int(clause.value))
+    except (TypeError, ValueError):
+        return True
+
+
+def unwrap_wkb_constructor_clauses(clauses):
+    if len(clauses) != 1:
+        return clauses, None
+
+    from geoalchemy2 import functions
+
+    inner_constructor = clauses[0]
+    constructor_names = (
+        ("ST_GeomFromWKB", functions.ST_GeomFromWKB),
+        ("ST_GeomFromEWKB", functions.ST_GeomFromEWKB),
+    )
+    for constructor_name, constructor_class in constructor_names:
+        if not isinstance(inner_constructor, constructor_class):
+            continue
+        inner_clauses = list(inner_constructor.clauses)
+        if inner_clauses and _is_auto_constructor_bindparam(inner_clauses[0], constructor_name):
+            if len(inner_clauses) > 1 and not _has_known_literal_srid(inner_clauses[1]):
+                inner_clauses = inner_clauses[:1]
+            return inner_clauses, inner_constructor
+
+    return clauses, None

--- a/geoalchemy2/admin/dialects/geopackage.py
+++ b/geoalchemy2/admin/dialects/geopackage.py
@@ -405,6 +405,22 @@ def _compile_GeomFromWKB_gpkg(element, compiler, *, identifier, **kw):
         return f"{identifier}({prefix}{compiled}{suffix})"
 
 
+def _compile_GeomFromEWKB_gpkg(element, compiler, *, identifier, **kw):
+    clauses = list(element.clauses)
+
+    if kw.get("literal_binds", False):
+        wkb_clause = compile_bin_literal(clauses[0])
+        prefix = "unhex("
+        suffix = ")"
+    else:
+        wkb_clause = clauses[0]
+        prefix = ""
+        suffix = ""
+
+    compiled = compiler.process(wkb_clause, **kw)
+    return f"{identifier}({prefix}{compiled}{suffix})"
+
+
 @compiles(functions.ST_GeomFromWKB, "geopackage")  # type: ignore
 def _gpkg_ST_GeomFromWKB(element, compiler, **kw):
     return _compile_GeomFromWKB_gpkg(element, compiler, identifier="GeomFromWKB", **kw)
@@ -412,4 +428,4 @@ def _gpkg_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "geopackage")  # type: ignore
 def _gpkg_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_gpkg(element, compiler, identifier="GeomFromEWKB", **kw)
+    return _compile_GeomFromEWKB_gpkg(element, compiler, identifier="GeomFromEWKB", **kw)

--- a/geoalchemy2/admin/dialects/geopackage.py
+++ b/geoalchemy2/admin/dialects/geopackage.py
@@ -387,11 +387,20 @@ def _gpkg_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "geopackage")  # type: ignore
 def _gpkg_ST_GeomFromEWKB(element, compiler, **kw):
+    wkb_clause = next(iter(element.clauses), None)
+    wkb_type = getattr(wkb_clause, "type", None)
+    # Geometry bind expressions already use the GeoPackage bind processor for EWKB hex.
+    use_geometry_ewkb_processor = (
+        isinstance(wkb_type, Geometry)
+        and "ewkb" in (getattr(wkb_type, "from_text", "") or "").lower()
+    )
+    coerce_ewkb = kw.get("literal_binds", False) or not use_geometry_ewkb_processor
+
     return _compile_GeomFromWKB_SQLite(
         element,
         compiler,
         identifier="GeomFromEWKB",
         include_srid=False,
-        coerce_ewkb=True,
+        coerce_ewkb=coerce_ewkb,
         **kw,
     )

--- a/geoalchemy2/admin/dialects/geopackage.py
+++ b/geoalchemy2/admin/dialects/geopackage.py
@@ -16,9 +16,9 @@ from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _format_select_args
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
-from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
 from geoalchemy2.admin.dialects.sqlite import _SQLITE_FUNCTIONS
+from geoalchemy2.admin.dialects.sqlite import _compile_GeomFromWKB_SQLite
 from geoalchemy2.admin.dialects.sqlite import get_col_dim
 from geoalchemy2.admin.dialects.sqlite import load_spatialite_driver
 from geoalchemy2.types import Geography
@@ -380,52 +380,18 @@ def create_spatial_ref_sys_view(bind):
     )
 
 
-def _compile_GeomFromWKB_gpkg(element, compiler, *, identifier, **kw):
-    # Store the SRID
-    clauses = list(element.clauses)
-    try:
-        srid = clauses[1].value
-    except (IndexError, TypeError, ValueError):
-        srid = element.type.srid
-
-    if kw.get("literal_binds", False):
-        wkb_clause = compile_bin_literal(clauses[0])
-        prefix = "unhex("
-        suffix = ")"
-    else:
-        wkb_clause = clauses[0]
-        prefix = ""
-        suffix = ""
-
-    compiled = compiler.process(wkb_clause, **kw)
-
-    if srid > 0:
-        return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
-    else:
-        return f"{identifier}({prefix}{compiled}{suffix})"
-
-
-def _compile_GeomFromEWKB_gpkg(element, compiler, *, identifier, **kw):
-    clauses = list(element.clauses)
-
-    if kw.get("literal_binds", False):
-        wkb_clause = compile_bin_literal(clauses[0])
-        prefix = "unhex("
-        suffix = ")"
-    else:
-        wkb_clause = clauses[0]
-        prefix = ""
-        suffix = ""
-
-    compiled = compiler.process(wkb_clause, **kw)
-    return f"{identifier}({prefix}{compiled}{suffix})"
-
-
 @compiles(functions.ST_GeomFromWKB, "geopackage")  # type: ignore
 def _gpkg_ST_GeomFromWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_gpkg(element, compiler, identifier="GeomFromWKB", **kw)
+    return _compile_GeomFromWKB_SQLite(element, compiler, identifier="GeomFromWKB", **kw)
 
 
 @compiles(functions.ST_GeomFromEWKB, "geopackage")  # type: ignore
 def _gpkg_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromEWKB_gpkg(element, compiler, identifier="GeomFromEWKB", **kw)
+    return _compile_GeomFromWKB_SQLite(
+        element,
+        compiler,
+        identifier="GeomFromEWKB",
+        include_srid=False,
+        coerce_ewkb=True,
+        **kw,
+    )

--- a/geoalchemy2/admin/dialects/mariadb.py
+++ b/geoalchemy2/admin/dialects/mariadb.py
@@ -4,11 +4,13 @@ from sqlalchemy.ext.compiler import compiles
 
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import compile_bin_literal
-from geoalchemy2.admin.dialects.mysql import _coerce_ewkb_clause_to_wkb
+from geoalchemy2.admin.dialects.mysql import _compile_srid_arg
+from geoalchemy2.admin.dialects.mysql import _prepare_ewkb_wkb_clause
 from geoalchemy2.admin.dialects.mysql import after_create  # noqa
 from geoalchemy2.admin.dialects.mysql import after_drop  # noqa
 from geoalchemy2.admin.dialects.mysql import before_create  # noqa
 from geoalchemy2.admin.dialects.mysql import before_drop  # noqa
+from geoalchemy2.admin.dialects.mysql import before_execute  # noqa
 from geoalchemy2.admin.dialects.mysql import reflect_geometry_column  # noqa
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
@@ -92,14 +94,16 @@ def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
     # Store the SRID
     clauses = list(element.clauses)
     inferred_srid = None
+    dynamic_srid_clause = None
     if coerce_ewkb:
-        wkb_value_clause, inferred_srid = _coerce_ewkb_clause_to_wkb(clauses[0], as_hex=True)
+        clauses, wkb_value_clause, inferred_srid, dynamic_srid_clause = _prepare_ewkb_wkb_clause(
+            element,
+            compiler,
+            as_hex=True,
+            **kw,
+        )
     else:
         wkb_value_clause = clauses[0]
-    try:
-        srid = clauses[1].value
-    except (IndexError, TypeError, ValueError):
-        srid = inferred_srid if inferred_srid is not None else element.type.srid
 
     wkb_clause = wkb_value_clause
     if kw.get("literal_binds", False):
@@ -108,9 +112,17 @@ def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
     suffix = ")"
 
     compiled = compiler.process(wkb_clause, **kw)
+    compiled_srid = _compile_srid_arg(
+        element,
+        clauses,
+        inferred_srid,
+        dynamic_srid_clause,
+        compiler,
+        **kw,
+    )
 
-    if srid > 0:
-        return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
+    if compiled_srid is not None:
+        return f"{identifier}({prefix}{compiled}{suffix}, {compiled_srid})"
     else:
         return f"{identifier}({prefix}{compiled}{suffix})"
 

--- a/geoalchemy2/admin/dialects/mariadb.py
+++ b/geoalchemy2/admin/dialects/mariadb.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.compiler import compiles
 
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import compile_bin_literal
+from geoalchemy2.admin.dialects.mysql import _coerce_ewkb_clause_to_wkb
 from geoalchemy2.admin.dialects.mysql import after_create  # noqa
 from geoalchemy2.admin.dialects.mysql import after_drop  # noqa
 from geoalchemy2.admin.dialects.mysql import before_create  # noqa
@@ -86,16 +87,23 @@ def _compile_GeomFromText_MariaDB(element, compiler, **kw):
     return res
 
 
-def _compile_GeomFromWKB_MariaDB(element, compiler, **kw):
+def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
     identifier = "ST_GeomFromWKB"
     # Store the SRID
     clauses = list(element.clauses)
+    inferred_srid = None
+    if coerce_ewkb:
+        wkb_value_clause, inferred_srid = _coerce_ewkb_clause_to_wkb(clauses[0], as_hex=True)
+    else:
+        wkb_value_clause = clauses[0]
     try:
         srid = clauses[1].value
     except (IndexError, TypeError, ValueError):
-        srid = element.type.srid
+        srid = inferred_srid if inferred_srid is not None else element.type.srid
 
-    wkb_clause = compile_bin_literal(clauses[0]) if kw.get("literal_binds", False) else clauses[0]
+    wkb_clause = wkb_value_clause
+    if kw.get("literal_binds", False):
+        wkb_clause = compile_bin_literal(wkb_value_clause)
     prefix = "unhex("
     suffix = ")"
 
@@ -124,4 +132,4 @@ def _MariaDB_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "mariadb")  # type: ignore
 def _MariaDB_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_MariaDB(element, compiler, **kw)
+    return _compile_GeomFromWKB_MariaDB(element, compiler, coerce_ewkb=True, **kw)

--- a/geoalchemy2/admin/dialects/mariadb.py
+++ b/geoalchemy2/admin/dialects/mariadb.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.compiler import compiles
 
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import compile_bin_literal
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
 from geoalchemy2.admin.dialects.mysql import _compile_srid_arg
 from geoalchemy2.admin.dialects.mysql import _prepare_ewkb_wkb_clause
 from geoalchemy2.admin.dialects.mysql import after_create  # noqa
@@ -93,6 +94,8 @@ def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
     identifier = "ST_GeomFromWKB"
     # Store the SRID
     clauses = list(element.clauses)
+    if kw.get("literal_binds", False):
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
     inferred_srid = None
     dynamic_srid_clause = None
     if coerce_ewkb:

--- a/geoalchemy2/admin/dialects/mariadb.py
+++ b/geoalchemy2/admin/dialects/mariadb.py
@@ -20,6 +20,8 @@ from geoalchemy2.elements import WKTElement
 def _cast(param):
     if isinstance(param, memoryview):
         param = param.tobytes()
+    if isinstance(param, bytearray):
+        param = bytes(param)
     if isinstance(param, bytes):
         param = WKBElement(param)
     if isinstance(param, WKBElement):

--- a/geoalchemy2/admin/dialects/mssql.py
+++ b/geoalchemy2/admin/dialects/mssql.py
@@ -21,6 +21,7 @@ from sqlalchemy.types import LargeBinary
 from sqlalchemy.types import TypeDecorator
 from sqlalchemy.types import UnicodeText
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
@@ -589,8 +590,7 @@ def _process_wkt_value(value, strip_srid=False):
     elif isinstance(value, (WKBElement, bytes, bytearray, memoryview)):
         value = _to_mssql_wkt(value)
     if isinstance(value, str) and strip_srid:
-        wkt_match = WKTElement._REMOVE_SRID.match(value)
-        value = wkt_match.group(3)
+        value = _wkb_wkt.to_wkt_no_srid(value)
     if isinstance(value, str):
         value = _normalize_wkt_for_mssql(value)
 
@@ -625,9 +625,9 @@ def _process_wkb_value(value, extended=False):
     if value is None:
         return None
     if isinstance(value, WKBElement):
-        value = value.as_wkb().data if extended else value.data
+        value = _wkb_wkt.to_wkb_no_srid(value.data) if extended else value.data
     elif extended:
-        value = WKBElement(value, extended=None).as_wkb().data
+        value = _wkb_wkt.to_wkb_no_srid(value)
     if isinstance(value, memoryview):
         value = value.tobytes()
 
@@ -642,8 +642,8 @@ def _process_ewkb_srid_value(value, default_srid=0):
         return value.srid if value.srid >= 0 else default_srid
 
     if isinstance(value, (bytes, bytearray, memoryview, str)):
-        srid = WKBElement(value, extended=None).srid
-        return srid if srid >= 0 else default_srid
+        _, srid = _wkb_wkt.split_wkb_srid(value)
+        return srid if srid is not None and srid >= 0 else default_srid
 
     return default_srid
 
@@ -822,9 +822,9 @@ def _infer_srid_from_wkb_clause(wkb_clause, default_srid, extended=False):
     if isinstance(value, WKBElement):
         return value.srid if value.srid >= 0 else default_srid
 
-    if extended and isinstance(value, (bytes, bytearray, memoryview)):
-        srid = WKBElement(value, extended=None).srid
-        return srid if srid >= 0 else default_srid
+    if extended and isinstance(value, (bytes, bytearray, memoryview, str)):
+        _, srid = _wkb_wkt.split_wkb_srid(value)
+        return srid if srid is not None and srid >= 0 else default_srid
 
     return default_srid
 

--- a/geoalchemy2/admin/dialects/mssql.py
+++ b/geoalchemy2/admin/dialects/mssql.py
@@ -642,7 +642,7 @@ def _process_ewkb_srid_value(value, default_srid=0):
         return value.srid if value.srid >= 0 else default_srid
 
     if isinstance(value, (bytes, bytearray, memoryview, str)):
-        _, srid = _wkb_wkt.split_wkb_srid(value)
+        srid = _wkb_wkt.wkb_srid(value)
         return srid if srid is not None and srid >= 0 else default_srid
 
     return default_srid
@@ -823,7 +823,7 @@ def _infer_srid_from_wkb_clause(wkb_clause, default_srid, extended=False):
         return value.srid if value.srid >= 0 else default_srid
 
     if extended and isinstance(value, (bytes, bytearray, memoryview, str)):
-        _, srid = _wkb_wkt.split_wkb_srid(value)
+        srid = _wkb_wkt.wkb_srid(value)
         return srid if srid is not None and srid >= 0 else default_srid
 
     return default_srid

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -3,6 +3,7 @@
 from sqlalchemy import text
 from sqlalchemy.dialects.mysql.base import ischema_names as _mysql_ischema_names
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import expression
 from sqlalchemy.sql.sqltypes import NullType
 
 from geoalchemy2 import functions
@@ -10,6 +11,7 @@ from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
+from geoalchemy2.elements import WKBElement
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 
@@ -187,29 +189,68 @@ def _compile_GeomFromText_MySql(element, compiler, **kw):
         return f"{identifier}({compiled})"
 
 
-def _compile_GeomFromWKB_MySql(element, compiler, **kw):
+def _coerce_ewkb_clause_to_wkb(wkb_clause, *, as_hex=False):
+    try:
+        wkb_data = wkb_clause.value
+    except AttributeError:
+        return wkb_clause, None
+
+    if isinstance(wkb_data, WKBElement):
+        wkb_element = wkb_data.as_wkb()
+    elif isinstance(wkb_data, (bytes, memoryview, str)):
+        wkb_element = WKBElement(wkb_data).as_wkb()
+    else:
+        return wkb_clause, None
+
+    wkb_data = wkb_element.desc if as_hex else wkb_element.data
+    srid = wkb_element.srid if wkb_element.srid > 0 else None
+
+    if isinstance(wkb_data, memoryview):
+        wkb_data = wkb_data.tobytes()
+    if isinstance(wkb_data, str) and not as_hex:
+        wkb_data = WKBElement._data_from_desc(wkb_data)
+
+    bindparam_args = {
+        "key": wkb_clause.key,
+        "value": wkb_data,
+        "unique": True,
+    }
+    if not as_hex:
+        bindparam_args["type_"] = wkb_clause.type
+
+    return expression.bindparam(**bindparam_args), srid
+
+
+def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewkb=False, **kw):
+    identifier = identifier or element.identifier
+
     # Store the SRID
     clauses = list(element.clauses)
+    inferred_srid = None
+    if coerce_ewkb:
+        wkb_value_clause, inferred_srid = _coerce_ewkb_clause_to_wkb(clauses[0])
+    else:
+        wkb_value_clause = clauses[0]
     try:
         srid = clauses[1].value
     except (IndexError, TypeError, ValueError):
-        srid = element.type.srid
+        srid = inferred_srid if inferred_srid is not None else element.type.srid
 
     if kw.get("literal_binds", False):
-        wkb_clause = compile_bin_literal(clauses[0])
+        wkb_clause = compile_bin_literal(wkb_value_clause)
         prefix = "unhex("
         suffix = ")"
     else:
-        wkb_clause = clauses[0]
+        wkb_clause = wkb_value_clause
         prefix = ""
         suffix = ""
 
     compiled = compiler.process(wkb_clause, **kw)
 
     if srid > 0:
-        return f"{element.identifier}({prefix}{compiled}{suffix}, {srid})"
+        return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
     else:
-        return f"{element.identifier}({prefix}{compiled}{suffix})"
+        return f"{identifier}({prefix}{compiled}{suffix})"
 
 
 @compiles(functions.ST_GeomFromText, "mysql")  # type: ignore
@@ -229,4 +270,6 @@ def _MySQL_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "mysql")  # type: ignore
 def _MySQL_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_MySql(element, compiler, **kw)
+    return _compile_GeomFromWKB_MySql(
+        element, compiler, identifier="ST_GeomFromWKB", coerce_ewkb=True, **kw
+    )

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -22,6 +22,7 @@ from sqlalchemy.types import TypeDecorator
 
 from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
@@ -225,13 +226,13 @@ def _ewkb_srid(value, *, default_srid=0):
         value = bytes(value)
 
     if isinstance(value, WKBElement):
-        if value.srid > 0:
+        if is_known_srid(value.srid):
             return value.srid
         value = value.data
 
     if isinstance(value, (bytes, bytearray, memoryview, str)):
         srid = _wkb_wkt.wkb_srid(value)
-        if srid is not None and srid > 0:
+        if is_known_srid(srid):
             return srid
 
     return default_srid
@@ -362,10 +363,7 @@ def _mapping_may_need_dynamic_ewkb(parameters):
 
 
 def _parameters_may_need_dynamic_ewkb(multiparams, params):
-    if _mapping_may_need_dynamic_ewkb(params):
-        return True
-
-    for parameters in multiparams or ():  # noqa: SIM110
+    for parameters in _iter_parameter_mappings(multiparams, params):  # noqa: SIM110
         if _mapping_may_need_dynamic_ewkb(parameters):
             return True
 
@@ -456,11 +454,11 @@ def _default_srid_from_type(spatial_type):
 
 
 def _needs_dynamic_ewkb_split(default_srid):
-    return default_srid <= 0
+    return not is_known_srid(default_srid)
 
 
 def _is_fixed_srid_ewkb_dml_bind(wkb_clause, fixed_srid):
-    if fixed_srid is None or fixed_srid <= 0:
+    if not is_known_srid(fixed_srid):
         return False
     if not (
         getattr(wkb_clause, "_is_crud", False)
@@ -509,7 +507,7 @@ def _prepare_ewkb_wkb_clause(element, compiler, *, as_hex=False, **kw):
         )
     elif user_bind and not kw.get("literal_binds", False):
         fixed_srid = None
-        if len(clauses) == 1 and default_srid > 0:
+        if len(clauses) == 1 and is_known_srid(default_srid):
             fixed_srid = default_srid
         if _is_fixed_srid_ewkb_dml_bind(original_wkb_clause, fixed_srid):
             wkb_value_clause = original_wkb_clause
@@ -543,7 +541,7 @@ def _compile_srid_clause(srid_clause, compiler, **kw):
             srid = int(value)
         except (TypeError, ValueError):
             return compiler.process(srid_clause, **kw)
-        return str(srid) if srid > 0 else None
+        return str(srid) if is_known_srid(srid) else None
     return compiler.process(srid_clause, **kw)
 
 
@@ -554,7 +552,7 @@ def _compile_srid_arg(element, clauses, inferred_srid, dynamic_srid_clause, comp
         return _compile_srid_clause(clauses[1], compiler, **kw)
 
     srid = inferred_srid if inferred_srid is not None else element.type.srid
-    return str(srid) if srid > 0 else None
+    return str(srid) if is_known_srid(srid) else None
 
 
 def _dml_ewkb_spatial_columns(clauseelement):
@@ -820,6 +818,10 @@ def _iter_parameter_mappings(multiparams, params):
     for parameters in multiparams or ():
         if isinstance(parameters, Mapping):
             yield parameters
+        elif isinstance(parameters, (list, tuple)):
+            for row in parameters:
+                if isinstance(row, Mapping):
+                    yield row
 
 
 def _source_bind_candidate_keys(source_bind):
@@ -914,6 +916,30 @@ def _expand_mysql_dynamic_ewkb_param_mapping(parameters, dynamic_bind_mappings):
     return expanded_parameters, changed
 
 
+def _expand_mysql_dynamic_ewkb_param_container(parameters, dynamic_bind_mappings):
+    if isinstance(parameters, Mapping):
+        return _expand_mysql_dynamic_ewkb_param_mapping(parameters, dynamic_bind_mappings)
+
+    if not isinstance(parameters, (list, tuple)):
+        return parameters, False
+
+    expanded_values = []
+    changed = False
+    for value in parameters:
+        expanded_value, value_changed = _expand_mysql_dynamic_ewkb_param_mapping(
+            value,
+            dynamic_bind_mappings,
+        )
+        expanded_values.append(expanded_value)
+        changed = changed or value_changed
+
+    if not changed:
+        return parameters, False
+    if isinstance(parameters, tuple):
+        return tuple(expanded_values), True
+    return expanded_values, True
+
+
 def before_execute(conn, clauseelement, multiparams, params, execution_options):
     if isinstance(clauseelement, TextClause):
         return clauseelement, multiparams, params
@@ -941,7 +967,7 @@ def before_execute(conn, clauseelement, multiparams, params, execution_options):
     if multiparams:
         expanded_values = []
         for value in multiparams:
-            expanded_value, value_changed = _expand_mysql_dynamic_ewkb_param_mapping(
+            expanded_value, value_changed = _expand_mysql_dynamic_ewkb_param_container(
                 value,
                 dynamic_bind_mappings,
             )
@@ -965,7 +991,7 @@ def _compile_GeomFromText_MySql(element, compiler, **kw):
     compiled = compiler.process(element.clauses, **kw)
     srid = element.type.srid
 
-    if srid > 0:
+    if is_known_srid(srid):
         return f"{identifier}({compiled}, {srid})"
     else:
         return f"{identifier}({compiled})"
@@ -978,11 +1004,11 @@ def _coerce_ewkb_clause_to_wkb(wkb_clause, *, as_hex=False):
         return wkb_clause, None
 
     if isinstance(wkb_data, WKBElement):
-        srid = wkb_data.srid if wkb_data.srid > 0 else None
+        srid = wkb_data.srid if is_known_srid(wkb_data.srid) else None
         wkb_data = wkb_data.data
     elif isinstance(wkb_data, (bytes, bytearray, memoryview, str)):
         srid = _wkb_wkt.wkb_srid(wkb_data)
-        srid = srid if srid is not None and srid > 0 else None
+        srid = srid if is_known_srid(srid) else None
     else:
         return wkb_clause, None
 

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -227,7 +227,7 @@ def _ewkb_srid(value, *, default_srid=0):
         value = value.data
 
     if isinstance(value, (bytes, bytearray, memoryview, str)):
-        _, srid = _wkb_wkt.split_wkb_srid(value)
+        srid = _wkb_wkt.wkb_srid(value)
         if srid is not None and srid >= 0:
             return srid
 
@@ -929,7 +929,7 @@ def _coerce_ewkb_clause_to_wkb(wkb_clause, *, as_hex=False):
         srid = wkb_data.srid if wkb_data.srid > 0 else None
         wkb_data = wkb_data.data
     elif isinstance(wkb_data, (bytes, bytearray, memoryview, str)):
-        _, srid = _wkb_wkt.split_wkb_srid(wkb_data)
+        srid = _wkb_wkt.wkb_srid(wkb_data)
         srid = srid if srid is not None and srid > 0 else None
     else:
         return wkb_clause, None

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -29,6 +29,7 @@ from geoalchemy2.admin.dialects.common import setup_create_drop
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
+from geoalchemy2.types.dialects.common import _validate_wkb_bindvalue_srid
 
 # Register Geometry, Geography and Raster to SQLAlchemy's reflection subsystems.
 _mysql_ischema_names["geometry"] = Geometry
@@ -200,9 +201,11 @@ def register_mysql_mapping(mapping):
 register_mysql_mapping(_MYSQL_FUNCTIONS)
 
 
-def _ewkb_to_wkb_data(value, *, as_hex=False):
+def _ewkb_to_wkb_data(value, *, as_hex=False, fixed_srid=None):
     if value is None:
         return None
+
+    _validate_wkb_bindvalue_srid(value, fixed_srid)
 
     if isinstance(value, bytearray):
         value = bytes(value)
@@ -238,16 +241,17 @@ class _MySQLEWKBBindType(TypeDecorator):
     impl = LargeBinary
     cache_ok = True
 
-    def __init__(self, *, as_hex=False):
+    def __init__(self, *, as_hex=False, fixed_srid=None):
         super().__init__()
         self.as_hex = as_hex
+        self.fixed_srid = fixed_srid
 
     def load_dialect_impl(self, dialect):
         impl = String() if self.as_hex else LargeBinary()
         return dialect.type_descriptor(impl)
 
     def process_bind_param(self, value, dialect):
-        return _ewkb_to_wkb_data(value, as_hex=self.as_hex)
+        return _ewkb_to_wkb_data(value, as_hex=self.as_hex, fixed_srid=self.fixed_srid)
 
 
 class _MySQLDynamicEWKBSRIDBindType(TypeDecorator):
@@ -296,7 +300,13 @@ def _is_mysql_auto_constructor_bindparam(clause, constructor_name):
     )
 
 
-def _coerce_ewkb_bind_clause_to_wkb(wkb_clause, *, as_hex=False, literal=False):
+def _coerce_ewkb_bind_clause_to_wkb(
+    wkb_clause,
+    *,
+    as_hex=False,
+    literal=False,
+    fixed_srid=None,
+):
     if not hasattr(wkb_clause, "value"):
         return wkb_clause
 
@@ -304,7 +314,10 @@ def _coerce_ewkb_bind_clause_to_wkb(wkb_clause, *, as_hex=False, literal=False):
         wkb_clause, _ = _coerce_ewkb_clause_to_wkb(wkb_clause, as_hex=as_hex)
         return wkb_clause
 
-    return expression.type_coerce(wkb_clause, _MySQLEWKBBindType(as_hex=as_hex))
+    return expression.type_coerce(
+        wkb_clause,
+        _MySQLEWKBBindType(as_hex=as_hex, fixed_srid=fixed_srid),
+    )
 
 
 def _mysql_dynamic_ewkb_bind_identifier(source_bind):
@@ -442,11 +455,32 @@ def _default_srid_from_type(spatial_type):
     return srid if srid >= 0 else 0
 
 
+def _needs_dynamic_ewkb_split(default_srid):
+    return default_srid <= 0
+
+
+def _is_fixed_srid_ewkb_dml_bind(wkb_clause, fixed_srid):
+    if fixed_srid is None or fixed_srid <= 0:
+        return False
+    if not (
+        getattr(wkb_clause, "_is_crud", False)
+        or getattr(wkb_clause, "_is_clone_of", None) is not None
+    ):
+        return False
+
+    spatial_type = getattr(wkb_clause, "type", None)
+    return (
+        getattr(spatial_type, "from_text", None) == "ST_GeomFromEWKB"
+        and getattr(spatial_type, "srid", None) == fixed_srid
+    )
+
+
 def _prepare_ewkb_wkb_clause(element, compiler, *, as_hex=False, **kw):
     clauses = list(element.clauses)
     original_wkb_clause = clauses[0]
     inferred_srid = None
     dynamic_srid_clause = None
+    default_srid = _default_srid(element)
     split_disabled = bool(
         getattr(compiler, "execution_options", {}).get(
             _MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION,
@@ -463,17 +497,28 @@ def _prepare_ewkb_wkb_clause(element, compiler, *, as_hex=False, **kw):
     if (
         user_bind
         and len(clauses) == 1
+        and _needs_dynamic_ewkb_split(default_srid)
         and not kw.get("literal_binds", False)
         and not split_disabled
     ):
         wkb_value_clause, dynamic_srid_clause = _get_mysql_dynamic_ewkb_bind_clauses(
             original_wkb_clause,
             compiler,
-            default_srid=_default_srid(element),
+            default_srid=default_srid,
             as_hex=as_hex,
         )
     elif user_bind and not kw.get("literal_binds", False):
-        wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(original_wkb_clause, as_hex=as_hex)
+        fixed_srid = None
+        if len(clauses) == 1 and default_srid > 0:
+            fixed_srid = default_srid
+        if _is_fixed_srid_ewkb_dml_bind(original_wkb_clause, fixed_srid):
+            wkb_value_clause = original_wkb_clause
+        else:
+            wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
+                original_wkb_clause,
+                as_hex=as_hex,
+                fixed_srid=fixed_srid,
+            )
     else:
         wkb_value_clause, inferred_srid = _coerce_ewkb_clause_to_wkb(
             original_wkb_clause,
@@ -663,6 +708,8 @@ def _collect_mysql_dynamic_ewkb_dml_source_binds(clauseelement):
 
         default_srid = _default_srid_from_type(spatial_columns[column_key])
         if _is_bindparam_clause(value):
+            if not _needs_dynamic_ewkb_split(default_srid):
+                continue
             source_bind = value
         elif isinstance(value, functions.ST_GeomFromEWKB):
             clauses = list(value.clauses)
@@ -672,6 +719,8 @@ def _collect_mysql_dynamic_ewkb_dml_source_binds(clauseelement):
                 continue
             source_bind = clauses[0]
             default_srid = _default_srid(value)
+            if not _needs_dynamic_ewkb_split(default_srid):
+                continue
         else:
             continue
 
@@ -685,6 +734,8 @@ def _collect_mysql_dynamic_ewkb_dml_source_binds(clauseelement):
         if column_key in represented_spatial_columns:
             continue
         default_srid = _default_srid_from_type(spatial_type)
+        if not _needs_dynamic_ewkb_split(default_srid):
+            continue
         source_bind = expression.bindparam(column_key)
         bind_key = (_mysql_dynamic_ewkb_bind_identifier(source_bind), default_srid)
         if bind_key in seen_bind_keys:
@@ -712,6 +763,8 @@ def _collect_mysql_dynamic_ewkb_source_binds_uncached(clauseelement):
             continue
 
         default_srid = _default_srid(element)
+        if not _needs_dynamic_ewkb_split(default_srid):
+            continue
         bind_key = (_mysql_dynamic_ewkb_bind_identifier(clauses[0]), default_srid)
         if bind_key in seen_bind_keys:
             continue

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -1,10 +1,24 @@
 """This module defines specific functions for MySQL dialect."""
 
+import contextlib
+import hashlib
+import re
+import weakref
+from collections.abc import Mapping
+from typing import Any
+
 from sqlalchemy import text
 from sqlalchemy.dialects.mysql.base import ischema_names as _mysql_ischema_names
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
+from sqlalchemy.sql import visitors
+from sqlalchemy.sql.elements import BindParameter
+from sqlalchemy.sql.elements import TextClause
 from sqlalchemy.sql.sqltypes import NullType
+from sqlalchemy.types import Integer
+from sqlalchemy.types import LargeBinary
+from sqlalchemy.types import String
+from sqlalchemy.types import TypeDecorator
 
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
@@ -36,6 +50,13 @@ _POSSIBLE_TYPES = [
     "multipolygon",
     "geometrycollection",
 ]
+
+_MYSQL_DYNAMIC_EWKB_KEY_PREFIX = "_geoalchemy2_mysql_ewkb"
+_MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION = "geoalchemy2_mysql_disable_dynamic_ewkb_split"
+_MYSQL_WKB_HEX = re.compile(r"^[0-9A-Fa-f]+$")
+_MYSQL_DYNAMIC_EWKB_SOURCE_BIND_CACHE: weakref.WeakKeyDictionary[Any, tuple[Any, ...]] = (
+    weakref.WeakKeyDictionary()
+)
 
 
 def reflect_geometry_column(inspector, table, column_info):
@@ -178,6 +199,701 @@ def register_mysql_mapping(mapping):
 register_mysql_mapping(_MYSQL_FUNCTIONS)
 
 
+def _ewkb_to_wkb_data(value, *, as_hex=False):
+    if value is None:
+        return None
+
+    if isinstance(value, bytearray):
+        value = bytes(value)
+
+    if isinstance(value, WKBElement):
+        wkb_element = value.as_wkb()
+    else:
+        wkb_element = WKBElement(value, extended=None).as_wkb()
+
+    wkb_data = wkb_element.desc if as_hex else wkb_element.data
+    if isinstance(wkb_data, memoryview):
+        return wkb_data.tobytes()
+    if isinstance(wkb_data, str) and not as_hex:
+        return WKBElement._data_from_desc(wkb_data)
+    return wkb_data
+
+
+def _ewkb_srid(value, *, default_srid=0):
+    if value is None:
+        return default_srid
+
+    if isinstance(value, bytearray):
+        value = bytes(value)
+
+    if isinstance(value, WKBElement):
+        if value.srid >= 0:
+            return value.srid
+        value = value.data
+
+    if isinstance(value, (bytes, memoryview, str)):
+        srid = WKBElement(value, extended=None).srid
+        if srid >= 0:
+            return srid
+
+    return default_srid
+
+
+class _MySQLEWKBBindType(TypeDecorator):
+    impl = LargeBinary
+    cache_ok = True
+
+    def __init__(self, *, as_hex=False):
+        super().__init__()
+        self.as_hex = as_hex
+
+    def load_dialect_impl(self, dialect):
+        impl = String() if self.as_hex else LargeBinary()
+        return dialect.type_descriptor(impl)
+
+    def process_bind_param(self, value, dialect):
+        return _ewkb_to_wkb_data(value, as_hex=self.as_hex)
+
+
+class _MySQLDynamicEWKBSRIDBindType(TypeDecorator):
+    impl = Integer
+    cache_ok = True
+
+    def __init__(self, *, default_srid=0):
+        super().__init__()
+        self.default_srid = default_srid
+
+    def process_bind_param(self, value, dialect):
+        return _ewkb_srid(value, default_srid=self.default_srid)
+
+
+class _MySQLDynamicEWKBCallable:
+    def __init__(self, source_callable):
+        self.source_callable = source_callable
+        self._consumer_count = 2
+        self._pending = None
+        self._remaining = 0
+
+    def add_consumers(self, count):
+        self._consumer_count += count
+
+    def __call__(self):
+        if self._remaining == 0:
+            self._pending = self.source_callable()
+            self._remaining = self._consumer_count
+
+        self._remaining -= 1
+        value = self._pending
+        if self._remaining == 0:
+            self._pending = None
+        return value
+
+
+def _is_bindparam_clause(clause):
+    return isinstance(clause, BindParameter)
+
+
+def _is_mysql_auto_constructor_bindparam(clause, constructor_name):
+    return (
+        _is_bindparam_clause(clause)
+        and getattr(clause, "unique", False)
+        and getattr(clause, "_orig_key", None) == constructor_name
+    )
+
+
+def _coerce_ewkb_bind_clause_to_wkb(wkb_clause, *, as_hex=False, literal=False):
+    if not hasattr(wkb_clause, "value"):
+        return wkb_clause
+
+    if literal:
+        wkb_clause, _ = _coerce_ewkb_clause_to_wkb(wkb_clause, as_hex=as_hex)
+        return wkb_clause
+
+    return expression.type_coerce(wkb_clause, _MySQLEWKBBindType(as_hex=as_hex))
+
+
+def _mysql_dynamic_ewkb_bind_identifier(source_bind):
+    return getattr(source_bind, "_identifying_key", source_bind.key)
+
+
+def _mysql_dynamic_ewkb_bind_keys(source_bind, default_srid=0):
+    source_name = getattr(source_bind, "_orig_key", None) or source_bind.key
+    source_name = str(source_name)
+    source_key = str(source_bind.key)
+    key_token = re.sub(r"[^0-9A-Za-z_]+", "_", source_name).strip("_") or "param"
+    srid_token = re.sub(r"[^0-9A-Za-z_]+", "_", str(default_srid)).strip("_") or "0"
+    key_digest = hashlib.sha1(f"{source_key}:{default_srid}".encode()).hexdigest()[:8]
+    key_base = f"{_MYSQL_DYNAMIC_EWKB_KEY_PREFIX}_{key_token}_srid_{srid_token}_{key_digest}"
+    return f"{key_base}_wkb", f"{key_base}_srid"
+
+
+def _is_wkb_hex(value):
+    value = value.strip()
+    return (
+        len(value) >= 10
+        and len(value) % 2 == 0
+        and value[:2] in {"00", "01"}
+        and _MYSQL_WKB_HEX.match(value) is not None
+    )
+
+
+def _value_may_need_dynamic_ewkb(value):
+    if value is None:
+        return True
+    if isinstance(value, (bytes, bytearray, memoryview, WKBElement)):
+        return True
+    if isinstance(value, str):
+        return _is_wkb_hex(value)
+    return False
+
+
+def _mapping_may_need_dynamic_ewkb(parameters):
+    return isinstance(parameters, Mapping) and any(
+        _value_may_need_dynamic_ewkb(value) for value in parameters.values()
+    )
+
+
+def _parameters_may_need_dynamic_ewkb(multiparams, params):
+    if _mapping_may_need_dynamic_ewkb(params):
+        return True
+
+    for parameters in multiparams or ():  # noqa: SIM110
+        if _mapping_may_need_dynamic_ewkb(parameters):
+            return True
+
+    return False
+
+
+def _make_mysql_dynamic_ewkb_bind_clauses(
+    wkb_clause,
+    *,
+    default_srid=0,
+    as_hex=False,
+    shared_callable=None,
+):
+    wkb_key, srid_key = _mysql_dynamic_ewkb_bind_keys(wkb_clause, default_srid=default_srid)
+    bind_kwargs = {
+        "required": wkb_clause.required,
+    }
+    if getattr(wkb_clause, "callable", None) is not None:
+        if shared_callable is None:
+            shared_callable = _MySQLDynamicEWKBCallable(wkb_clause.callable)
+        bind_kwargs["callable_"] = shared_callable
+    elif not wkb_clause.required:
+        bind_kwargs["value"] = getattr(wkb_clause, "value", None)
+
+    return (
+        expression.bindparam(
+            key=wkb_key,
+            type_=_MySQLEWKBBindType(as_hex=as_hex),
+            **bind_kwargs,
+        ),
+        expression.bindparam(
+            key=srid_key,
+            type_=_MySQLDynamicEWKBSRIDBindType(default_srid=default_srid),
+            **bind_kwargs,
+        ),
+    )
+
+
+def _get_mysql_dynamic_ewkb_bind_clauses(
+    wkb_clause,
+    compiler,
+    *,
+    default_srid=0,
+    as_hex=False,
+):
+    cache = getattr(compiler, "_geoalchemy2_mysql_dynamic_ewkb_bind_cache", None)
+    if cache is None:
+        cache = {}
+        compiler._geoalchemy2_mysql_dynamic_ewkb_bind_cache = cache
+
+    cache_key = (_mysql_dynamic_ewkb_bind_identifier(wkb_clause), default_srid, as_hex)
+    if cache_key not in cache:
+        shared_callable = None
+        if getattr(wkb_clause, "callable", None) is not None:
+            callable_cache = getattr(
+                compiler,
+                "_geoalchemy2_mysql_dynamic_ewkb_callable_cache",
+                None,
+            )
+            if callable_cache is None:
+                callable_cache = {}
+                compiler._geoalchemy2_mysql_dynamic_ewkb_callable_cache = callable_cache
+
+            callable_key = _mysql_dynamic_ewkb_bind_identifier(wkb_clause)
+            shared_callable = callable_cache.get(callable_key)
+            if shared_callable is None:
+                shared_callable = _MySQLDynamicEWKBCallable(wkb_clause.callable)
+                callable_cache[callable_key] = shared_callable
+            else:
+                shared_callable.add_consumers(2)
+
+        cache[cache_key] = _make_mysql_dynamic_ewkb_bind_clauses(
+            wkb_clause,
+            default_srid=default_srid,
+            as_hex=as_hex,
+            shared_callable=shared_callable,
+        )
+    return cache[cache_key]
+
+
+def _default_srid(element):
+    return _default_srid_from_type(element.type)
+
+
+def _default_srid_from_type(spatial_type):
+    srid = getattr(spatial_type, "srid", -1)
+    return srid if srid >= 0 else 0
+
+
+def _prepare_ewkb_wkb_clause(element, compiler, *, as_hex=False, **kw):
+    clauses = list(element.clauses)
+    original_wkb_clause = clauses[0]
+    inferred_srid = None
+    dynamic_srid_clause = None
+    split_disabled = bool(
+        getattr(compiler, "execution_options", {}).get(
+            _MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION,
+            False,
+        )
+    )
+    user_bind = _is_bindparam_clause(
+        original_wkb_clause
+    ) and not _is_mysql_auto_constructor_bindparam(
+        original_wkb_clause,
+        "ST_GeomFromEWKB",
+    )
+
+    if (
+        user_bind
+        and len(clauses) == 1
+        and not kw.get("literal_binds", False)
+        and not split_disabled
+    ):
+        wkb_value_clause, dynamic_srid_clause = _get_mysql_dynamic_ewkb_bind_clauses(
+            original_wkb_clause,
+            compiler,
+            default_srid=_default_srid(element),
+            as_hex=as_hex,
+        )
+    elif user_bind and not kw.get("literal_binds", False):
+        wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(original_wkb_clause, as_hex=as_hex)
+    else:
+        wkb_value_clause, inferred_srid = _coerce_ewkb_clause_to_wkb(
+            original_wkb_clause,
+            as_hex=as_hex,
+        )
+
+    return clauses, wkb_value_clause, inferred_srid, dynamic_srid_clause
+
+
+def _compile_srid_clause(srid_clause, compiler, **kw):
+    if _is_bindparam_clause(srid_clause) and not (
+        _is_mysql_auto_constructor_bindparam(srid_clause, "ST_GeomFromEWKB")
+        or _is_mysql_auto_constructor_bindparam(srid_clause, "ST_GeomFromWKB")
+    ):
+        return compiler.process(srid_clause, **kw)
+
+    if hasattr(srid_clause, "value"):
+        value = srid_clause.value
+        if value is None:
+            return compiler.process(srid_clause, **kw)
+        try:
+            srid = int(value)
+        except (TypeError, ValueError):
+            return compiler.process(srid_clause, **kw)
+        return str(srid) if srid > 0 else None
+    return compiler.process(srid_clause, **kw)
+
+
+def _compile_srid_arg(element, clauses, inferred_srid, dynamic_srid_clause, compiler, **kw):
+    if dynamic_srid_clause is not None:
+        return compiler.process(dynamic_srid_clause, **kw)
+    if len(clauses) > 1:
+        return _compile_srid_clause(clauses[1], compiler, **kw)
+
+    srid = inferred_srid if inferred_srid is not None else element.type.srid
+    return str(srid) if srid > 0 else None
+
+
+def _dml_ewkb_spatial_columns(clauseelement):
+    table = getattr(clauseelement, "table", None)
+    if table is None:
+        return {}
+
+    spatial_columns = {}
+    for column in table.columns:
+        from_text = getattr(column.type, "from_text", None)
+        if from_text == "ST_GeomFromEWKB":
+            spatial_columns[column.key] = column.type
+    return spatial_columns
+
+
+def _column_key(value):
+    return getattr(value, "key", value)
+
+
+def _iter_dml_value_pairs(value_container, table):
+    if isinstance(value_container, Mapping):
+        yield from value_container.items()
+        return
+
+    if isinstance(value_container, (list, tuple)):
+        if value_container and all(
+            isinstance(item, tuple) and len(item) == 2 for item in value_container
+        ):
+            yield from value_container
+            return
+
+        yield from zip(table.columns, value_container, strict=False)
+
+
+def _iter_dml_source_bind_pairs(clauseelement):
+    table = getattr(clauseelement, "table", None)
+
+    values = getattr(clauseelement, "_values", None) or {}
+    if values:
+        yield from _iter_dml_value_pairs(values, table)
+
+    ordered_values = getattr(clauseelement, "_ordered_values", None) or ()
+    if ordered_values:
+        yield from _iter_dml_value_pairs(ordered_values, table)
+
+    for multi_values in getattr(clauseelement, "_multi_values", ()) or ():
+        for values in multi_values:
+            yield from _iter_dml_value_pairs(values, table)
+
+
+def _wrap_mysql_ewkb_dml_value(column_key, value, spatial_columns):
+    column_key = _column_key(column_key)
+    spatial_type = spatial_columns.get(column_key)
+    if spatial_type is None or not _is_bindparam_clause(value):
+        return value, False
+    if isinstance(value, functions.ST_GeomFromEWKB):
+        return value, False
+    return functions.ST_GeomFromEWKB(value, type_=spatial_type), True
+
+
+def _wrap_mysql_ewkb_dml_value_container(value_container, table, spatial_columns):
+    if isinstance(value_container, Mapping):
+        changed = False
+        wrapped_values = {}
+        for column_key, value in value_container.items():
+            wrapped_value, value_changed = _wrap_mysql_ewkb_dml_value(
+                column_key,
+                value,
+                spatial_columns,
+            )
+            wrapped_values[column_key] = wrapped_value
+            changed = changed or value_changed
+        return wrapped_values, changed
+
+    if isinstance(value_container, (list, tuple)):
+        if value_container and all(
+            isinstance(item, tuple) and len(item) == 2 for item in value_container
+        ):
+            changed = False
+            wrapped_values = []
+            for column_key, value in value_container:
+                wrapped_value, value_changed = _wrap_mysql_ewkb_dml_value(
+                    column_key,
+                    value,
+                    spatial_columns,
+                )
+                wrapped_values.append((column_key, wrapped_value))
+                changed = changed or value_changed
+            return wrapped_values, changed
+
+        changed = False
+        wrapped_values = []
+        for column, value in zip(table.columns, value_container, strict=False):
+            wrapped_value, value_changed = _wrap_mysql_ewkb_dml_value(
+                column,
+                value,
+                spatial_columns,
+            )
+            wrapped_values.append(wrapped_value)
+            changed = changed or value_changed
+        return wrapped_values, changed
+
+    return value_container, False
+
+
+def _wrap_mysql_ewkb_multi_values(clauseelement):
+    multi_values = getattr(clauseelement, "_multi_values", ()) or ()
+    if not multi_values:
+        return clauseelement
+
+    spatial_columns = _dml_ewkb_spatial_columns(clauseelement)
+    if not spatial_columns:
+        return clauseelement
+
+    table = getattr(clauseelement, "table", None)
+    changed = False
+    wrapped_multi_values = []
+    for multi_value in multi_values:
+        wrapped_multi_value = []
+        for value_container in multi_value:
+            wrapped_value_container, value_changed = _wrap_mysql_ewkb_dml_value_container(
+                value_container,
+                table,
+                spatial_columns,
+            )
+            wrapped_multi_value.append(wrapped_value_container)
+            changed = changed or value_changed
+        wrapped_multi_values.append(wrapped_multi_value)
+
+    if not changed:
+        return clauseelement
+
+    wrapped_clauseelement = clauseelement._generate()
+    wrapped_clauseelement._multi_values = tuple(wrapped_multi_values)
+    return wrapped_clauseelement
+
+
+def _collect_mysql_dynamic_ewkb_dml_source_binds(clauseelement):
+    spatial_columns = _dml_ewkb_spatial_columns(clauseelement)
+    if not spatial_columns:
+        return ()
+
+    source_binds = []
+    seen_bind_keys = set()
+    has_value_containers = False
+    for column_key, value in _iter_dml_source_bind_pairs(clauseelement):
+        has_value_containers = True
+        column_key = _column_key(column_key)
+        if column_key not in spatial_columns:
+            continue
+
+        default_srid = _default_srid_from_type(spatial_columns[column_key])
+        if _is_bindparam_clause(value):
+            source_bind = value
+        elif isinstance(value, functions.ST_GeomFromEWKB):
+            clauses = list(value.clauses)
+            if len(clauses) != 1 or not _is_bindparam_clause(clauses[0]):
+                continue
+            if _is_mysql_auto_constructor_bindparam(clauses[0], "ST_GeomFromEWKB"):
+                continue
+            source_bind = clauses[0]
+            default_srid = _default_srid(value)
+        else:
+            continue
+
+        bind_key = (_mysql_dynamic_ewkb_bind_identifier(source_bind), default_srid)
+        if bind_key in seen_bind_keys:
+            continue
+        seen_bind_keys.add(bind_key)
+        source_binds.append((source_bind, default_srid))
+
+    if has_value_containers:
+        return tuple(source_binds)
+
+    for column_key, spatial_type in spatial_columns.items():
+        default_srid = _default_srid_from_type(spatial_type)
+        source_bind = expression.bindparam(column_key)
+        bind_key = (_mysql_dynamic_ewkb_bind_identifier(source_bind), default_srid)
+        if bind_key in seen_bind_keys:
+            continue
+        seen_bind_keys.add(bind_key)
+        source_binds.append((source_bind, default_srid))
+
+    return tuple(source_binds)
+
+
+def _collect_mysql_dynamic_ewkb_source_binds_uncached(clauseelement):
+    if not hasattr(clauseelement, "get_children"):
+        return ()
+
+    source_binds = []
+    seen_bind_keys = set()
+    for element in visitors.iterate(clauseelement):
+        if not isinstance(element, functions.ST_GeomFromEWKB):
+            continue
+
+        clauses = list(element.clauses)
+        if len(clauses) != 1 or not _is_bindparam_clause(clauses[0]):
+            continue
+        if _is_mysql_auto_constructor_bindparam(clauses[0], "ST_GeomFromEWKB"):
+            continue
+
+        default_srid = _default_srid(element)
+        bind_key = (_mysql_dynamic_ewkb_bind_identifier(clauses[0]), default_srid)
+        if bind_key in seen_bind_keys:
+            continue
+        seen_bind_keys.add(bind_key)
+        source_binds.append((clauses[0], default_srid))
+
+    for source_bind, default_srid in _collect_mysql_dynamic_ewkb_dml_source_binds(clauseelement):
+        bind_key = (_mysql_dynamic_ewkb_bind_identifier(source_bind), default_srid)
+        if bind_key in seen_bind_keys:
+            continue
+        seen_bind_keys.add(bind_key)
+        source_binds.append((source_bind, default_srid))
+
+    return tuple(source_binds)
+
+
+def _collect_mysql_dynamic_ewkb_source_binds(clauseelement):
+    try:
+        return _MYSQL_DYNAMIC_EWKB_SOURCE_BIND_CACHE[clauseelement]
+    except KeyError:
+        pass
+    except TypeError:
+        return _collect_mysql_dynamic_ewkb_source_binds_uncached(clauseelement)
+
+    source_binds = _collect_mysql_dynamic_ewkb_source_binds_uncached(clauseelement)
+    with contextlib.suppress(TypeError):
+        _MYSQL_DYNAMIC_EWKB_SOURCE_BIND_CACHE[clauseelement] = source_binds
+    return source_binds
+
+
+def _compile_mysql_statement_bind_name_map(clauseelement, dialect):
+    if not hasattr(clauseelement, "compile"):
+        return {}
+
+    if hasattr(clauseelement, "execution_options"):
+        clauseelement = clauseelement.execution_options(
+            **{_MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION: True}
+        )
+
+    compiled = clauseelement.compile(dialect=dialect)
+    bind_name_map = {}
+    for bind, compiled_name in compiled.bind_names.items():
+        bind_name_map.setdefault(
+            getattr(bind, "_identifying_key", bind.key),
+            compiled_name,
+        )
+    return bind_name_map
+
+
+def _iter_parameter_mappings(multiparams, params):
+    if isinstance(params, Mapping):
+        yield params
+    for parameters in multiparams or ():
+        if isinstance(parameters, Mapping):
+            yield parameters
+
+
+def _parameters_include_any_key(multiparams, params, keys):
+    keys = tuple(key for key in keys if key is not None)
+    if not keys:
+        return False
+
+    for parameters in _iter_parameter_mappings(multiparams, params):
+        if any(key in parameters for key in keys):
+            return True
+    return False
+
+
+def _source_bind_candidate_keys(source_bind):
+    candidate_keys = []
+    for candidate_key in (source_bind.key, getattr(source_bind, "_orig_key", None)):
+        if candidate_key is not None and candidate_key not in candidate_keys:
+            candidate_keys.append(candidate_key)
+    return candidate_keys
+
+
+def _get_mysql_dynamic_ewkb_bind_mappings(clauseelement, dialect, multiparams=(), params=None):
+    source_binds = _collect_mysql_dynamic_ewkb_source_binds(clauseelement)
+    if not source_binds:
+        return ()
+
+    if params is None:
+        params = {}
+
+    statement_bind_name_map = None
+    dynamic_bind_mappings = []
+    for source_bind, default_srid in source_binds:
+        source_identifier = _mysql_dynamic_ewkb_bind_identifier(source_bind)
+        candidate_keys = _source_bind_candidate_keys(source_bind)
+        if not _parameters_include_any_key(multiparams, params, candidate_keys):
+            if statement_bind_name_map is None:
+                statement_bind_name_map = _compile_mysql_statement_bind_name_map(
+                    clauseelement,
+                    dialect,
+                )
+            compiled_name = statement_bind_name_map.get(source_identifier)
+            if compiled_name is not None and compiled_name not in candidate_keys:
+                candidate_keys.append(compiled_name)
+
+        wkb_key, srid_key = _mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=default_srid,
+        )
+        dynamic_bind_mappings.append((tuple(candidate_keys), wkb_key, srid_key))
+
+    return tuple(dynamic_bind_mappings)
+
+
+def _expand_mysql_dynamic_ewkb_param_mapping(parameters, dynamic_bind_mappings):
+    if not isinstance(parameters, Mapping):
+        return parameters, False
+
+    expanded_parameters = parameters
+    changed = False
+    for source_keys, wkb_key, srid_key in dynamic_bind_mappings:
+        source_key = next((key for key in source_keys if key in parameters), None)
+        if source_key is None:
+            continue
+
+        if wkb_key in parameters and srid_key in parameters:
+            continue
+
+        if expanded_parameters is parameters:
+            expanded_parameters = dict(parameters)
+
+        source_value = parameters[source_key]
+        expanded_parameters.setdefault(wkb_key, source_value)
+        expanded_parameters.setdefault(srid_key, source_value)
+        changed = True
+
+    return expanded_parameters, changed
+
+
+def before_execute(conn, clauseelement, multiparams, params, execution_options):
+    if isinstance(clauseelement, TextClause):
+        return clauseelement, multiparams, params
+
+    has_multi_values = bool(getattr(clauseelement, "_multi_values", ()) or ())
+    if has_multi_values:
+        clauseelement = _wrap_mysql_ewkb_multi_values(clauseelement)
+    if not _parameters_may_need_dynamic_ewkb(multiparams, params):
+        return clauseelement, multiparams, params
+
+    dynamic_bind_mappings = _get_mysql_dynamic_ewkb_bind_mappings(
+        clauseelement,
+        conn.dialect,
+        multiparams,
+        params,
+    )
+    if not dynamic_bind_mappings:
+        return clauseelement, multiparams, params
+
+    multiparams_changed = False
+    expanded_multiparams = multiparams
+    if multiparams:
+        expanded_values = []
+        for value in multiparams:
+            expanded_value, value_changed = _expand_mysql_dynamic_ewkb_param_mapping(
+                value,
+                dynamic_bind_mappings,
+            )
+            expanded_values.append(expanded_value)
+            multiparams_changed = multiparams_changed or value_changed
+        if multiparams_changed:
+            expanded_multiparams = tuple(expanded_values)
+
+    expanded_params, params_changed = _expand_mysql_dynamic_ewkb_param_mapping(
+        params,
+        dynamic_bind_mappings,
+    )
+
+    if multiparams_changed or params_changed:
+        return clauseelement, expanded_multiparams, expanded_params
+    return clauseelement, multiparams, params
+
+
 def _compile_GeomFromText_MySql(element, compiler, **kw):
     identifier = "ST_GeomFromText"
     compiled = compiler.process(element.clauses, **kw)
@@ -227,14 +943,15 @@ def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewk
     # Store the SRID
     clauses = list(element.clauses)
     inferred_srid = None
+    dynamic_srid_clause = None
     if coerce_ewkb:
-        wkb_value_clause, inferred_srid = _coerce_ewkb_clause_to_wkb(clauses[0])
+        clauses, wkb_value_clause, inferred_srid, dynamic_srid_clause = _prepare_ewkb_wkb_clause(
+            element,
+            compiler,
+            **kw,
+        )
     else:
         wkb_value_clause = clauses[0]
-    try:
-        srid = clauses[1].value
-    except (IndexError, TypeError, ValueError):
-        srid = inferred_srid if inferred_srid is not None else element.type.srid
 
     if kw.get("literal_binds", False):
         wkb_clause = compile_bin_literal(wkb_value_clause)
@@ -246,9 +963,17 @@ def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewk
         suffix = ""
 
     compiled = compiler.process(wkb_clause, **kw)
+    compiled_srid = _compile_srid_arg(
+        element,
+        clauses,
+        inferred_srid,
+        dynamic_srid_clause,
+        compiler,
+        **kw,
+    )
 
-    if srid > 0:
-        return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
+    if compiled_srid is not None:
+        return f"{identifier}({prefix}{compiled}{suffix}, {compiled_srid})"
     else:
         return f"{identifier}({prefix}{compiled}{suffix})"
 

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -770,17 +770,6 @@ def _iter_parameter_mappings(multiparams, params):
             yield parameters
 
 
-def _parameters_include_any_key(multiparams, params, keys):
-    keys = tuple(key for key in keys if key is not None)
-    if not keys:
-        return False
-
-    for parameters in _iter_parameter_mappings(multiparams, params):
-        if any(key in parameters for key in keys):
-            return True
-    return False
-
-
 def _source_bind_candidate_keys(source_bind):
     candidate_keys = []
     for candidate_key in (source_bind.key, getattr(source_bind, "_orig_key", None)):
@@ -789,20 +778,47 @@ def _source_bind_candidate_keys(source_bind):
     return candidate_keys
 
 
+def _collect_present_mysql_dynamic_ewkb_parameter_keys(
+    multiparams,
+    params,
+    candidate_key_groups,
+):
+    present_keys = set()
+    for candidate_keys in candidate_key_groups:
+        if not candidate_keys:
+            continue
+
+        for parameters in _iter_parameter_mappings(multiparams, params):
+            present_key = next((key for key in candidate_keys if key in parameters), None)
+            if present_key is not None:
+                present_keys.add(present_key)
+                break
+    return present_keys
+
+
 def _get_mysql_dynamic_ewkb_bind_mappings(clauseelement, dialect, multiparams=(), params=None):
     source_binds = _collect_mysql_dynamic_ewkb_source_binds(clauseelement)
     if not source_binds:
         return ()
 
-    if params is None:
-        params = {}
+    candidate_key_groups = [
+        _source_bind_candidate_keys(source_bind) for source_bind, _ in source_binds
+    ]
+    present_parameter_keys = _collect_present_mysql_dynamic_ewkb_parameter_keys(
+        multiparams,
+        params,
+        candidate_key_groups,
+    )
 
     statement_bind_name_map = None
     dynamic_bind_mappings = []
-    for source_bind, default_srid in source_binds:
+    for (source_bind, default_srid), candidate_keys in zip(
+        source_binds,
+        candidate_key_groups,
+        strict=False,
+    ):
         source_identifier = _mysql_dynamic_ewkb_bind_identifier(source_bind)
-        candidate_keys = _source_bind_candidate_keys(source_bind)
-        if not _parameters_include_any_key(multiparams, params, candidate_keys):
+        if not present_parameter_keys.intersection(candidate_keys):
             if statement_bind_name_map is None:
                 statement_bind_name_map = _compile_mysql_statement_bind_name_map(
                     clauseelement,
@@ -849,10 +865,13 @@ def _expand_mysql_dynamic_ewkb_param_mapping(parameters, dynamic_bind_mappings):
 def before_execute(conn, clauseelement, multiparams, params, execution_options):
     if isinstance(clauseelement, TextClause):
         return clauseelement, multiparams, params
+    if execution_options.get(_MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION, False):
+        return clauseelement, multiparams, params
 
     has_multi_values = bool(getattr(clauseelement, "_multi_values", ()) or ())
     if has_multi_values:
         clauseelement = _wrap_mysql_ewkb_multi_values(clauseelement)
+
     if not _parameters_may_need_dynamic_ewkb(multiparams, params):
         return clauseelement, multiparams, params
 

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -27,6 +27,7 @@ from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
@@ -475,6 +476,8 @@ def _is_fixed_srid_ewkb_dml_bind(wkb_clause, fixed_srid):
 
 def _prepare_ewkb_wkb_clause(element, compiler, *, as_hex=False, **kw):
     clauses = list(element.clauses)
+    if kw.get("literal_binds", False):
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
     original_wkb_clause = clauses[0]
     inferred_srid = None
     dynamic_srid_clause = None
@@ -1033,6 +1036,8 @@ def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewk
 
     # Store the SRID
     clauses = list(element.clauses)
+    if kw.get("literal_binds", False):
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
     inferred_srid = None
     dynamic_srid_clause = None
     if coerce_ewkb:

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -222,13 +222,13 @@ def _ewkb_srid(value, *, default_srid=0):
         value = bytes(value)
 
     if isinstance(value, WKBElement):
-        if value.srid >= 0:
+        if value.srid > 0:
             return value.srid
         value = value.data
 
     if isinstance(value, (bytes, bytearray, memoryview, str)):
         srid = _wkb_wkt.wkb_srid(value)
-        if srid is not None and srid >= 0:
+        if srid is not None and srid > 0:
             return srid
 
     return default_srid

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -20,6 +20,7 @@ from sqlalchemy.types import LargeBinary
 from sqlalchemy.types import String
 from sqlalchemy.types import TypeDecorator
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
@@ -207,16 +208,10 @@ def _ewkb_to_wkb_data(value, *, as_hex=False):
         value = bytes(value)
 
     if isinstance(value, WKBElement):
-        wkb_element = value.as_wkb()
-    else:
-        wkb_element = WKBElement(value, extended=None).as_wkb()
-
-    wkb_data = wkb_element.desc if as_hex else wkb_element.data
-    if isinstance(wkb_data, memoryview):
-        return wkb_data.tobytes()
-    if isinstance(wkb_data, str) and not as_hex:
-        return WKBElement._data_from_desc(wkb_data)
-    return wkb_data
+        value = value.data
+    if as_hex:
+        return _wkb_wkt.to_hex_wkb_no_srid(value).lower()
+    return _wkb_wkt.to_wkb_no_srid(value)
 
 
 def _ewkb_srid(value, *, default_srid=0):
@@ -231,9 +226,9 @@ def _ewkb_srid(value, *, default_srid=0):
             return value.srid
         value = value.data
 
-    if isinstance(value, (bytes, memoryview, str)):
-        srid = WKBElement(value, extended=None).srid
-        if srid >= 0:
+    if isinstance(value, (bytes, bytearray, memoryview, str)):
+        _, srid = _wkb_wkt.split_wkb_srid(value)
+        if srid is not None and srid >= 0:
             return srid
 
     return default_srid
@@ -912,19 +907,18 @@ def _coerce_ewkb_clause_to_wkb(wkb_clause, *, as_hex=False):
         return wkb_clause, None
 
     if isinstance(wkb_data, WKBElement):
-        wkb_element = wkb_data.as_wkb()
-    elif isinstance(wkb_data, (bytes, memoryview, str)):
-        wkb_element = WKBElement(wkb_data).as_wkb()
+        srid = wkb_data.srid if wkb_data.srid > 0 else None
+        wkb_data = wkb_data.data
+    elif isinstance(wkb_data, (bytes, bytearray, memoryview, str)):
+        _, srid = _wkb_wkt.split_wkb_srid(wkb_data)
+        srid = srid if srid is not None and srid > 0 else None
     else:
         return wkb_clause, None
 
-    wkb_data = wkb_element.desc if as_hex else wkb_element.data
-    srid = wkb_element.srid if wkb_element.srid > 0 else None
-
-    if isinstance(wkb_data, memoryview):
-        wkb_data = wkb_data.tobytes()
-    if isinstance(wkb_data, str) and not as_hex:
-        wkb_data = WKBElement._data_from_desc(wkb_data)
+    if as_hex:
+        wkb_data = _wkb_wkt.to_hex_wkb_no_srid(wkb_data).lower()
+    else:
+        wkb_data = _wkb_wkt.to_wkb_no_srid(wkb_data)
 
     bindparam_args = {
         "key": wkb_clause.key,

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -654,12 +654,12 @@ def _collect_mysql_dynamic_ewkb_dml_source_binds(clauseelement):
 
     source_binds = []
     seen_bind_keys = set()
-    has_value_containers = False
+    represented_spatial_columns = set()
     for column_key, value in _iter_dml_source_bind_pairs(clauseelement):
-        has_value_containers = True
         column_key = _column_key(column_key)
         if column_key not in spatial_columns:
             continue
+        represented_spatial_columns.add(column_key)
 
         default_srid = _default_srid_from_type(spatial_columns[column_key])
         if _is_bindparam_clause(value):
@@ -681,10 +681,9 @@ def _collect_mysql_dynamic_ewkb_dml_source_binds(clauseelement):
         seen_bind_keys.add(bind_key)
         source_binds.append((source_bind, default_srid))
 
-    if has_value_containers:
-        return tuple(source_binds)
-
     for column_key, spatial_type in spatial_columns.items():
+        if column_key in represented_spatial_columns:
+            continue
         default_srid = _default_srid_from_type(spatial_type)
         source_bind = expression.bindparam(column_key)
         bind_key = (_mysql_dynamic_ewkb_bind_identifier(source_bind), default_srid)

--- a/geoalchemy2/admin/dialects/postgresql.py
+++ b/geoalchemy2/admin/dialects/postgresql.py
@@ -184,7 +184,7 @@ def after_drop(table, bind, **kw):
         table.columns = saved_cols
 
 
-def _compile_GeomFromWKB_Postgresql(element, compiler, **kw):
+def _compile_GeomFromWKB_Postgresql(element, compiler, *, include_srid=True, **kw):
     # Store the SRID
     clauses = list(element.clauses)
     try:
@@ -203,7 +203,7 @@ def _compile_GeomFromWKB_Postgresql(element, compiler, **kw):
 
     compiled = compiler.process(wkb_clause, **kw)
 
-    if srid > 0:
+    if include_srid and srid > 0:
         return f"{element.identifier}({prefix}{compiled}{suffix}, {srid})"
     else:
         return f"{element.identifier}({prefix}{compiled}{suffix})"
@@ -216,4 +216,4 @@ def _PostgreSQL_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "postgresql")  # type: ignore
 def _PostgreSQL_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_Postgresql(element, compiler, **kw)
+    return _compile_GeomFromWKB_Postgresql(element, compiler, include_srid=False, **kw)

--- a/geoalchemy2/admin/dialects/postgresql.py
+++ b/geoalchemy2/admin/dialects/postgresql.py
@@ -6,18 +6,23 @@ from sqlalchemy import Index
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql.base import ischema_names as _postgresql_ischema_names
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import expression
 from sqlalchemy.sql import func
 from sqlalchemy.sql import select
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _format_select_args
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
+from geoalchemy2.elements import WKBElement
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
+from geoalchemy2.types.dialects.common import as_binary_ewkb
 
 _SQLALCHEMY_VERSION_BEFORE_2 = version.parse(sqlalchemy.__version__) < version.parse("2")
 
@@ -187,12 +192,28 @@ def after_drop(table, bind, **kw):
 def _compile_GeomFromWKB_Postgresql(element, compiler, *, include_srid=True, **kw):
     # Store the SRID
     clauses = list(element.clauses)
+    if kw.get("literal_binds", False):
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
     try:
         srid = clauses[1].value
     except (IndexError, TypeError, ValueError):
         srid = element.type.srid
 
     if kw.get("literal_binds", False):
+        if not include_srid and hasattr(clauses[0], "value") and clauses[0].value is not None:
+            value = clauses[0].value
+            embedded_srid = None
+            try:
+                embedded_source = value.data if isinstance(value, WKBElement) else value
+                embedded_srid = _wkb_wkt.wkb_srid(embedded_source)
+            except (TypeError, ValueError):
+                pass
+            column_srid = None if _wkb_wkt.is_known_srid(embedded_srid) else srid
+            clauses[0] = expression.bindparam(
+                key=clauses[0].key,
+                value=as_binary_ewkb(value, column_srid=column_srid),
+                unique=True,
+            )
         wkb_clause = compile_bin_literal(clauses[0])
         prefix = "decode("
         suffix = ", 'hex')"

--- a/geoalchemy2/admin/dialects/postgresql.py
+++ b/geoalchemy2/admin/dialects/postgresql.py
@@ -9,6 +9,8 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
 from sqlalchemy.sql import func
 from sqlalchemy.sql import select
+from sqlalchemy.types import LargeBinary
+from sqlalchemy.types import TypeDecorator
 
 from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
@@ -30,6 +32,35 @@ _SQLALCHEMY_VERSION_BEFORE_2 = version.parse(sqlalchemy.__version__) < version.p
 _postgresql_ischema_names["geometry"] = Geometry
 _postgresql_ischema_names["geography"] = Geography
 _postgresql_ischema_names["raster"] = Raster
+
+
+class _PostgreSQLEWKBBindType(TypeDecorator):
+    """Bind runtime ST_GeomFromEWKB values as EWKB bytes."""
+
+    impl = LargeBinary
+    cache_ok = True
+
+    def __init__(self, column_srid=None):
+        super().__init__()
+        self.column_srid = column_srid
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        embedded_srid = None
+        try:
+            embedded_source = value.data if isinstance(value, WKBElement) else value
+            embedded_srid = _wkb_wkt.wkb_srid(embedded_source)
+        except (TypeError, ValueError):
+            pass
+        column_srid = None if _wkb_wkt.is_known_srid(embedded_srid) else self.column_srid
+        return as_binary_ewkb(value, column_srid=column_srid)
+
+
+def _uses_ewkb_geometry_bind_processor(clause):
+    spatial_type = getattr(clause, "type", None)
+    from_text = getattr(spatial_type, "from_text", "") or ""
+    return isinstance(spatial_type, Geometry) and "ewkb" in from_text.lower()
 
 
 def check_management(column):
@@ -219,10 +250,25 @@ def _compile_GeomFromWKB_Postgresql(element, compiler, *, include_srid=True, **k
         suffix = ", 'hex')"
     else:
         wkb_clause = clauses[0]
+        skip_bind_expression = False
+        if (
+            not include_srid
+            and _wkb_wkt.is_known_srid(srid)
+            and not _uses_ewkb_geometry_bind_processor(wkb_clause)
+        ):
+            wkb_clause = expression.type_coerce(
+                wkb_clause,
+                _PostgreSQLEWKBBindType(column_srid=srid),
+            )
+        elif not include_srid and _uses_ewkb_geometry_bind_processor(wkb_clause):
+            skip_bind_expression = True
         prefix = ""
         suffix = ""
 
-    compiled = compiler.process(wkb_clause, **kw)
+    process_kw = dict(kw)
+    if not kw.get("literal_binds", False) and skip_bind_expression:
+        process_kw["skip_bind_expression"] = True
+    compiled = compiler.process(wkb_clause, **process_kw)
 
     if include_srid and srid > 0:
         return f"{element.identifier}({prefix}{compiled}{suffix}, {srid})"

--- a/geoalchemy2/admin/dialects/sqlite.py
+++ b/geoalchemy2/admin/dialects/sqlite.py
@@ -400,7 +400,7 @@ def register_sqlite_mapping(mapping):
 register_sqlite_mapping(_SQLITE_FUNCTIONS)
 
 
-def _compile_GeomFromWKB_SQLite(element, compiler, *, identifier, **kw):
+def _compile_GeomFromWKB_SQLite(element, compiler, *, identifier, include_srid=True, **kw):
     element.identifier = identifier
 
     # Store the SRID
@@ -422,7 +422,7 @@ def _compile_GeomFromWKB_SQLite(element, compiler, *, identifier, **kw):
 
     compiled = compiler.process(wkb_clause, **kw)
 
-    if srid > 0:
+    if include_srid and srid > 0:
         return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
     else:
         return f"{identifier}({prefix}{compiled}{suffix})"
@@ -435,4 +435,6 @@ def _SQLite_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "sqlite")  # type: ignore
 def _SQLite_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_SQLite(element, compiler, identifier="GeomFromEWKB", **kw)
+    return _compile_GeomFromWKB_SQLite(
+        element, compiler, identifier="GeomFromEWKB", include_srid=False, **kw
+    )

--- a/geoalchemy2/admin/dialects/sqlite.py
+++ b/geoalchemy2/admin/dialects/sqlite.py
@@ -23,7 +23,7 @@ from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
 from geoalchemy2.types import _DummyGeometry
 from geoalchemy2.types.dialects.common import as_binary_ewkb
-from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import as_ewkb_hex
 from geoalchemy2.utils import authorized_values_in_docstring
 
 # Register Geometry, Geography and Raster to SQLAlchemy's reflection subsystems.
@@ -412,10 +412,14 @@ class _SpatialiteEWKBHexBindType(TypeDecorator):
     impl = String
     cache_ok = True
 
+    def __init__(self, column_srid=None):
+        super().__init__()
+        self.column_srid = column_srid
+
     def process_bind_param(self, value, dialect):
         if value is None:
             return None
-        return as_wkb_hex(value, strip_srid=False)
+        return as_ewkb_hex(value, column_srid=self.column_srid)
 
 
 def _coerce_ewkb_clause_to_hex(wkb_clause, *, literal=False, column_srid=None):
@@ -427,7 +431,10 @@ def _coerce_ewkb_clause_to_hex(wkb_clause, *, literal=False, column_srid=None):
                 unique=True,
             )
         return compile_bin_literal(wkb_clause)
-    return expression.type_coerce(wkb_clause, _SpatialiteEWKBHexBindType())
+    return expression.type_coerce(
+        wkb_clause,
+        _SpatialiteEWKBHexBindType(column_srid=column_srid),
+    )
 
 
 def _compile_GeomFromWKB_SQLite(

--- a/geoalchemy2/admin/dialects/sqlite.py
+++ b/geoalchemy2/admin/dialects/sqlite.py
@@ -17,10 +17,12 @@ from geoalchemy2.admin.dialects.common import _format_select_args
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
 from geoalchemy2.types import _DummyGeometry
+from geoalchemy2.types.dialects.common import as_binary_ewkb
 from geoalchemy2.types.dialects.common import as_wkb_hex
 from geoalchemy2.utils import authorized_values_in_docstring
 
@@ -416,8 +418,14 @@ class _SpatialiteEWKBHexBindType(TypeDecorator):
         return as_wkb_hex(value, strip_srid=False)
 
 
-def _coerce_ewkb_clause_to_hex(wkb_clause, *, literal=False):
+def _coerce_ewkb_clause_to_hex(wkb_clause, *, literal=False, column_srid=None):
     if literal:
+        if hasattr(wkb_clause, "value") and wkb_clause.value is not None:
+            wkb_clause = expression.bindparam(
+                key=wkb_clause.key,
+                value=as_binary_ewkb(wkb_clause.value, column_srid=column_srid),
+                unique=True,
+            )
         return compile_bin_literal(wkb_clause)
     return expression.type_coerce(wkb_clause, _SpatialiteEWKBHexBindType())
 
@@ -429,15 +437,21 @@ def _compile_GeomFromWKB_SQLite(
 
     # Store the SRID
     clauses = list(element.clauses)
+    literal_binds = kw.get("literal_binds", False)
+    if literal_binds:
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
     try:
         srid = clauses[1].value
         element.type.srid = srid
     except (IndexError, TypeError, ValueError):
         srid = element.type.srid
 
-    literal_binds = kw.get("literal_binds", False)
     if coerce_ewkb:
-        wkb_clause = _coerce_ewkb_clause_to_hex(clauses[0], literal=literal_binds)
+        wkb_clause = _coerce_ewkb_clause_to_hex(
+            clauses[0],
+            literal=literal_binds,
+            column_srid=srid,
+        )
         prefix = ""
         suffix = ""
     elif literal_binds:

--- a/geoalchemy2/admin/dialects/sqlite.py
+++ b/geoalchemy2/admin/dialects/sqlite.py
@@ -5,8 +5,11 @@ import os
 from sqlalchemy import text
 from sqlalchemy.dialects.sqlite.base import ischema_names as _sqlite_ischema_names
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import expression
 from sqlalchemy.sql import func
 from sqlalchemy.sql import select
+from sqlalchemy.types import String
+from sqlalchemy.types import TypeDecorator
 
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
@@ -18,6 +21,7 @@ from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
 from geoalchemy2.types import _DummyGeometry
+from geoalchemy2.types.dialects.common import as_wkb_hex
 from geoalchemy2.utils import authorized_values_in_docstring
 
 # Register Geometry, Geography and Raster to SQLAlchemy's reflection subsystems.
@@ -400,7 +404,27 @@ def register_sqlite_mapping(mapping):
 register_sqlite_mapping(_SQLITE_FUNCTIONS)
 
 
-def _compile_GeomFromWKB_SQLite(element, compiler, *, identifier, include_srid=True, **kw):
+class _SpatialiteEWKBHexBindType(TypeDecorator):
+    """Bind EWKB as HEXEWKB text for SpatiaLite's GeomFromEWKB."""
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return as_wkb_hex(value, strip_srid=False)
+
+
+def _coerce_ewkb_clause_to_hex(wkb_clause, *, literal=False):
+    if literal:
+        return compile_bin_literal(wkb_clause)
+    return expression.type_coerce(wkb_clause, _SpatialiteEWKBHexBindType())
+
+
+def _compile_GeomFromWKB_SQLite(
+    element, compiler, *, identifier, include_srid=True, coerce_ewkb=False, **kw
+):
     element.identifier = identifier
 
     # Store the SRID
@@ -411,7 +435,12 @@ def _compile_GeomFromWKB_SQLite(element, compiler, *, identifier, include_srid=T
     except (IndexError, TypeError, ValueError):
         srid = element.type.srid
 
-    if kw.get("literal_binds", False):
+    literal_binds = kw.get("literal_binds", False)
+    if coerce_ewkb:
+        wkb_clause = _coerce_ewkb_clause_to_hex(clauses[0], literal=literal_binds)
+        prefix = ""
+        suffix = ""
+    elif literal_binds:
         wkb_clause = compile_bin_literal(clauses[0])
         prefix = "unhex("
         suffix = ")"
@@ -436,5 +465,10 @@ def _SQLite_ST_GeomFromWKB(element, compiler, **kw):
 @compiles(functions.ST_GeomFromEWKB, "sqlite")  # type: ignore
 def _SQLite_ST_GeomFromEWKB(element, compiler, **kw):
     return _compile_GeomFromWKB_SQLite(
-        element, compiler, identifier="GeomFromEWKB", include_srid=False, **kw
+        element,
+        compiler,
+        identifier="GeomFromEWKB",
+        include_srid=False,
+        coerce_ewkb=True,
+        **kw,
     )

--- a/geoalchemy2/alembic_helpers.py
+++ b/geoalchemy2/alembic_helpers.py
@@ -25,6 +25,8 @@ from sqlalchemy.dialects.sqlite.base import SQLiteDialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import DropTable
 from sqlalchemy.sql import func
+from sqlalchemy.types import Integer
+from sqlalchemy.types import String
 from sqlalchemy.types import TypeDecorator
 
 from geoalchemy2 import Geography
@@ -210,8 +212,31 @@ def render_item(obj_type, obj, autogen_context):
         import_name = obj.__class__.__name__
         autogen_context.imports.add(f"from geoalchemy2 import {import_name}")
         return f"{obj!r}"
+    if obj_type == "type":
+        rendered_sqlalchemy_type = _render_simple_sqlalchemy_type(obj, autogen_context)
+        if rendered_sqlalchemy_type is not False:
+            return rendered_sqlalchemy_type
 
     # Default rendering for other objects
+    return False
+
+
+def _render_simple_sqlalchemy_type(obj, autogen_context):
+    """Render simple SQLAlchemy types without relying on their generic repr."""
+    prefix = autogen_context.opts.get("sqlalchemy_module_prefix", "sa.")
+    prefix = prefix or ""
+
+    if type(obj) is Integer:
+        return f"{prefix}Integer()"
+
+    if type(obj) is String:
+        arguments = []
+        if obj.length is not None:
+            arguments.append(repr(obj.length))
+        if obj.collation is not None:
+            arguments.append(f"collation={obj.collation!r}")
+        return f"{prefix}String({', '.join(arguments)})"
+
     return False
 
 

--- a/geoalchemy2/alembic_helpers.py
+++ b/geoalchemy2/alembic_helpers.py
@@ -1,5 +1,9 @@
 """Some helpers to use with Alembic migration tool."""
 
+import inspect
+import platform
+
+import sqlalchemy
 from alembic.autogenerate import renderers
 from alembic.autogenerate import rewriter
 from alembic.autogenerate.render import _add_column
@@ -26,6 +30,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import DropTable
 from sqlalchemy.sql import func
 from sqlalchemy.types import TypeDecorator
+from sqlalchemy.util import compat as sqlalchemy_compat
 
 from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
@@ -38,6 +43,27 @@ writer = rewriter.Rewriter()
 """Rewriter object for Alembic."""
 
 _SPATIAL_TABLES: set[str] = set()
+
+
+def _monkey_patch_sqlalchemy_pypy_builtin_method_repr():
+    """Avoid SQLAlchemy 1.4 repr recursion on PyPy bound built-in methods."""
+    if platform.python_implementation() != "PyPy" or not sqlalchemy.__version__.startswith("1.4."):
+        return
+
+    normal_behavior = sqlalchemy_compat.inspect_getfullargspec
+    if getattr(normal_behavior, "_geoalchemy2_pypy_builtin_method_patch", False):
+        return
+
+    def inspect_getfullargspec(func):
+        if not inspect.ismethod(func) and inspect.isbuiltin(func) and hasattr(func, "__func__"):
+            raise TypeError("not a Python function")
+        return normal_behavior(func)
+
+    inspect_getfullargspec._geoalchemy2_pypy_builtin_method_patch = True
+    sqlalchemy_compat.inspect_getfullargspec = inspect_getfullargspec
+
+
+_monkey_patch_sqlalchemy_pypy_builtin_method_repr()
 
 
 class GeoPackageImpl(SQLiteImpl):

--- a/geoalchemy2/alembic_helpers.py
+++ b/geoalchemy2/alembic_helpers.py
@@ -1,8 +1,5 @@
 """Some helpers to use with Alembic migration tool."""
 
-import sys
-from functools import wraps
-
 from alembic.autogenerate import renderers
 from alembic.autogenerate import rewriter
 from alembic.autogenerate.render import _add_column
@@ -29,7 +26,6 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import DropTable
 from sqlalchemy.sql import func
 from sqlalchemy.types import TypeDecorator
-from sqlalchemy.util import compat
 
 from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
@@ -214,32 +210,9 @@ def render_item(obj_type, obj, autogen_context):
         import_name = obj.__class__.__name__
         autogen_context.imports.add(f"from geoalchemy2 import {import_name}")
         return f"{obj!r}"
-    if obj_type == "type":
-        _ensure_pypy_type_repr_compat()
 
     # Default rendering for other objects
     return False
-
-
-def _ensure_pypy_type_repr_compat(_force=False):
-    """Avoid PyPy recursion in SQLAlchemy's generic type repr fallback."""
-    if not _force and sys.implementation.name != "pypy":
-        return
-
-    inspect_getfullargspec = compat.inspect_getfullargspec
-    if getattr(inspect_getfullargspec, "_geoalchemy2_pypy_type_repr_compat", False):
-        return
-
-    @wraps(inspect_getfullargspec)
-    def inspect_getfullargspec_compat(func):
-        try:
-            return inspect_getfullargspec(func)
-        except RecursionError as exc:
-            raise TypeError("Could not inspect function signature without recursive repr") from exc
-
-    inspect_getfullargspec_compat._geoalchemy2_pypy_type_repr_compat = True
-    inspect_getfullargspec_compat._geoalchemy2_original = inspect_getfullargspec
-    compat.inspect_getfullargspec = inspect_getfullargspec_compat
 
 
 def include_object(obj, name, obj_type, reflected, compare_to):

--- a/geoalchemy2/alembic_helpers.py
+++ b/geoalchemy2/alembic_helpers.py
@@ -1,5 +1,8 @@
 """Some helpers to use with Alembic migration tool."""
 
+import sys
+from functools import wraps
+
 from alembic.autogenerate import renderers
 from alembic.autogenerate import rewriter
 from alembic.autogenerate.render import _add_column
@@ -25,9 +28,8 @@ from sqlalchemy.dialects.sqlite.base import SQLiteDialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import DropTable
 from sqlalchemy.sql import func
-from sqlalchemy.types import Integer
-from sqlalchemy.types import String
 from sqlalchemy.types import TypeDecorator
+from sqlalchemy.util import compat
 
 from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
@@ -213,31 +215,31 @@ def render_item(obj_type, obj, autogen_context):
         autogen_context.imports.add(f"from geoalchemy2 import {import_name}")
         return f"{obj!r}"
     if obj_type == "type":
-        rendered_sqlalchemy_type = _render_simple_sqlalchemy_type(obj, autogen_context)
-        if rendered_sqlalchemy_type is not False:
-            return rendered_sqlalchemy_type
+        _ensure_pypy_type_repr_compat()
 
     # Default rendering for other objects
     return False
 
 
-def _render_simple_sqlalchemy_type(obj, autogen_context):
-    """Render simple SQLAlchemy types without relying on their generic repr."""
-    prefix = autogen_context.opts.get("sqlalchemy_module_prefix", "sa.")
-    prefix = prefix or ""
+def _ensure_pypy_type_repr_compat(_force=False):
+    """Avoid PyPy recursion in SQLAlchemy's generic type repr fallback."""
+    if not _force and sys.implementation.name != "pypy":
+        return
 
-    if type(obj) is Integer:
-        return f"{prefix}Integer()"
+    inspect_getfullargspec = compat.inspect_getfullargspec
+    if getattr(inspect_getfullargspec, "_geoalchemy2_pypy_type_repr_compat", False):
+        return
 
-    if type(obj) is String:
-        arguments = []
-        if obj.length is not None:
-            arguments.append(repr(obj.length))
-        if obj.collation is not None:
-            arguments.append(f"collation={obj.collation!r}")
-        return f"{prefix}String({', '.join(arguments)})"
+    @wraps(inspect_getfullargspec)
+    def inspect_getfullargspec_compat(func):
+        try:
+            return inspect_getfullargspec(func)
+        except RecursionError as exc:
+            raise TypeError("Could not inspect function signature without recursive repr") from exc
 
-    return False
+    inspect_getfullargspec_compat._geoalchemy2_pypy_type_repr_compat = True
+    inspect_getfullargspec_compat._geoalchemy2_original = inspect_getfullargspec
+    compat.inspect_getfullargspec = inspect_getfullargspec_compat
 
 
 def include_object(obj, name, obj_type, reflected, compare_to):

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -9,9 +9,8 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import functions
 from sqlalchemy.sql.functions import FunctionElement
 from sqlalchemy.types import to_instance
-from wkb_wkt_converter import text_to_wkb
-from wkb_wkt_converter import text_to_wkt
-from wkb_wkt_converter import wkb_to_wkt_split_srid
+from wkb_wkt_converter import to_wkb
+from wkb_wkt_converter import to_wkt
 
 from geoalchemy2.exc import ArgumentError
 
@@ -166,19 +165,23 @@ class WKTElement(_SpatialElement):
             return WKTElement(data, extended=True)
         return WKTElement(self.data, self.srid, self.extended)
 
-    def as_wkb(self, extended: bool = False) -> WKBElement:
-        """Return this element as a :class:`WKBElement`.
+    def as_wkb(self) -> WKBElement:
+        """Return this element as a plain :class:`WKBElement` (no SRID embedded).
 
-        Args:
-            extended: If ``True`` and the element has a valid SRID, the result
-                uses EWKB format (SRID embedded in the binary data).
-                If ``False`` (default), plain WKB is returned and the SRID is
-                stored as a Python attribute only.
+        The SRID is preserved as a Python attribute on the returned element.
         """
-        if extended and self.srid != -1:
-            wkb_bytes = text_to_wkb(self.data, srid=self.srid)
+        wkb_bytes = to_wkb(self.data, srid=False)
+        return WKBElement(wkb_bytes, srid=self.srid, extended=False)
+
+    def as_ewkb(self) -> WKBElement:
+        """Return this element as an extended :class:`WKBElement` (SRID embedded).
+
+        If the element has no valid SRID, the result is equivalent to :meth:`as_wkb`.
+        """
+        srid_arg: int | bool = self.srid if self.srid != -1 else False
+        wkb_bytes = to_wkb(self.data, srid=srid_arg)
+        if self.srid != -1:
             return WKBElement(wkb_bytes, extended=True)
-        wkb_bytes = text_to_wkb(self.data, srid=False)
         return WKBElement(wkb_bytes, srid=self.srid, extended=False)
 
 
@@ -340,29 +343,22 @@ class WKBElement(_SpatialElement):
             return WKBElement(data, self.srid, extended=True)
         return WKBElement(self.data, self.srid)
 
-    def as_wkt(self, extended: bool = False) -> WKTElement:
-        """Return this element as a :class:`WKTElement`.
+    def as_wkt(self) -> WKTElement:
+        """Return this element as a plain :class:`WKTElement` (no SRID prefix).
 
-        Args:
-            extended: If ``True`` and the element has a valid SRID, the result
-                uses EWKT format (``SRID=N;WKT`` string).
-                If ``False`` (default), plain WKT is returned and the SRID is
-                stored as a Python attribute only.
+        The SRID is preserved as a Python attribute on the returned element.
         """
-        data = self.data
-        if isinstance(data, str):
-            srid_arg: int | bool = self.srid if (extended and self.srid != -1) else False
-            wkt = text_to_wkt(data, srid=srid_arg)
-        else:
-            if isinstance(data, memoryview):
-                data = bytes(data)
-            plain_wkt, _ = wkb_to_wkt_split_srid(data)
-            if extended and self.srid != -1:  # noqa: SIM108
-                wkt = f"SRID={self.srid};{plain_wkt}"
-            else:
-                wkt = plain_wkt
+        wkt = to_wkt(self.data, srid=False)
+        return WKTElement(wkt, srid=self.srid, extended=False)
 
-        if extended and self.srid != -1:
+    def as_ewkt(self) -> WKTElement:
+        """Return this element as an extended :class:`WKTElement` (``SRID=N;WKT``).
+
+        If the element has no valid SRID, the result is equivalent to :meth:`as_wkt`.
+        """
+        srid_arg: int | bool = self.srid if self.srid != -1 else False
+        wkt = to_wkt(self.data, srid=srid_arg)
+        if self.srid != -1:
             return WKTElement(wkt, extended=True)
         return WKTElement(wkt, srid=self.srid, extended=False)
 

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -9,6 +9,9 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import functions
 from sqlalchemy.sql.functions import FunctionElement
 from sqlalchemy.types import to_instance
+from wkb_wkt_converter import text_to_wkb
+from wkb_wkt_converter import text_to_wkt
+from wkb_wkt_converter import wkb_to_wkt_split_srid
 
 from geoalchemy2.exc import ArgumentError
 
@@ -162,6 +165,21 @@ class WKTElement(_SpatialElement):
             data = f"SRID={self.srid};" + self.data
             return WKTElement(data, extended=True)
         return WKTElement(self.data, self.srid, self.extended)
+
+    def as_wkb(self, extended: bool = False) -> WKBElement:
+        """Return this element as a :class:`WKBElement`.
+
+        Args:
+            extended: If ``True`` and the element has a valid SRID, the result
+                uses EWKB format (SRID embedded in the binary data).
+                If ``False`` (default), plain WKB is returned and the SRID is
+                stored as a Python attribute only.
+        """
+        if extended and self.srid != -1:
+            wkb_bytes = text_to_wkb(self.data, srid=self.srid)
+            return WKBElement(wkb_bytes, extended=True)
+        wkb_bytes = text_to_wkb(self.data, srid=False)
+        return WKBElement(wkb_bytes, srid=self.srid, extended=False)
 
 
 class DynamicWKTElement(WKTElement):
@@ -321,6 +339,32 @@ class WKBElement(_SpatialElement):
 
             return WKBElement(data, self.srid, extended=True)
         return WKBElement(self.data, self.srid)
+
+    def as_wkt(self, extended: bool = False) -> WKTElement:
+        """Return this element as a :class:`WKTElement`.
+
+        Args:
+            extended: If ``True`` and the element has a valid SRID, the result
+                uses EWKT format (``SRID=N;WKT`` string).
+                If ``False`` (default), plain WKT is returned and the SRID is
+                stored as a Python attribute only.
+        """
+        data = self.data
+        if isinstance(data, str):
+            srid_arg: int | bool = self.srid if (extended and self.srid != -1) else False
+            wkt = text_to_wkt(data, srid=srid_arg)
+        else:
+            if isinstance(data, memoryview):
+                data = bytes(data)
+            plain_wkt, _ = wkb_to_wkt_split_srid(data)
+            if extended and self.srid != -1:  # noqa: SIM108
+                wkt = f"SRID={self.srid};{plain_wkt}"
+            else:
+                wkt = plain_wkt
+
+        if extended and self.srid != -1:
+            return WKTElement(wkt, extended=True)
+        return WKTElement(wkt, srid=self.srid, extended=False)
 
 
 class DynamicWKBElement(WKBElement):

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -219,33 +219,16 @@ class WKBElement(_SpatialElement):
         self, data: str | bytes | memoryview, srid: int = -1, extended: bool | None = None
     ) -> None:
         if srid == -1 or extended is None or extended:
-            # read srid from the EWKB
-            #
-            # WKB struct {
-            #    byte    byteOrder;
-            #    uint32  wkbType;
-            #    uint32  SRID;
-            #    struct  geometry;
-            # }
-            # byteOrder enum {
-            #     WKB_XDR = 0,  // Most Significant Byte First
-            #     WKB_NDR = 1,  // Least Significant Byte First
-            # }
-            # See https://trac.osgeo.org/postgis/browser/branches/3.0/doc/ZMSgeoms.txt
-            # for more details about WKB/EWKB specifications.
-
-            # SpatiaLite case: assume that the string is an hex value
-            header = binascii.unhexlify(data[:18]) if isinstance(data, str) else data[:9]
-            byte_order, wkb_type, wkb_srid = header[0], header[1:5], header[5:]
-            byte_order_marker = "<I" if byte_order else ">I"
-            wkb_type_int = (
-                int(struct.unpack(byte_order_marker, wkb_type)[0]) if len(wkb_type) == 4 else 0
-            )
+            wkb_srid = None
+            if (extended is True and srid == -1) or (extended is None and len(data) >= 5):
+                try:
+                    wkb_srid = _wkb_wkt.wkb_srid(data)
+                except ValueError:
+                    if extended is True:
+                        raise
             if extended is None:
-                # Check SRID bit
-                extended = False if not wkb_type_int else extended or bool(wkb_type_int & 536870912)
+                extended = wkb_srid is not None
             if extended and srid == -1:
-                wkb_srid = struct.unpack(byte_order_marker, wkb_srid)[0]
                 srid = int(wkb_srid)
         _SpatialElement.__init__(self, data, srid, extended)
 
@@ -275,14 +258,9 @@ class WKBElement(_SpatialElement):
 
     def as_ewkb(self) -> WKBElement:
         if self.srid > 0:
-            if self.extended:
-                if _wkb_wkt.can_header_rewrite(self.data):
-                    embedded_srid = _wkb_wkt.wkb_srid(self.data)
-                else:
-                    _, embedded_srid = _wkb_wkt.split_wkb_srid(self.data)
-                if embedded_srid == self.srid:
-                    return WKBElement(self.data, self.srid, extended=True)
             data = _wkb_wkt.to_ewkb_header(self.data, self.srid)
+            if self.extended and _wkb_wkt.wkb_srid(self.data) == self.srid:
+                return WKBElement(self.data, self.srid, extended=True)
             return WKBElement(data, self.srid, extended=True)
         return self.as_wkb()
 

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -153,13 +153,20 @@ class WKTElement(_SpatialElement):
 
     def as_wkt(self) -> WKTElement:
         if self.extended:
-            return WKTElement(_wkb_wkt.to_wkt_no_srid(self.data), self.srid, extended=False)
+            match = self._REMOVE_SRID.match(self.data)
+            assert match is not None
+            return WKTElement(match.group(3), self.srid, extended=False)
         return WKTElement(self.data, self.srid, self.extended)
 
     def as_ewkt(self) -> WKTElement:
         if self.srid > 0:
-            data = _wkb_wkt.to_wkt(self.data, srid=self.srid)
-            return WKTElement(data, extended=True)
+            if self.extended:
+                match = self._REMOVE_SRID.match(self.data)
+                assert match is not None
+                data = match.group(3)
+            else:
+                data = self.data
+            return WKTElement(f"SRID={self.srid};{data}", extended=True)
         return self.as_wkt()
 
     def as_wkb(self) -> WKBElement:
@@ -256,11 +263,29 @@ class WKBElement(_SpatialElement):
             return WKBElement(data, self.srid, extended=False)
         return WKBElement(self.data, self.srid, extended=False)
 
+    @staticmethod
+    def _has_simple_ewkb_header(data: str | bytes | memoryview) -> bool:
+        if isinstance(data, str):  # noqa: SIM108
+            header = binascii.unhexlify(data[:10])
+        else:
+            header = bytes(data[:5])
+        byte_order = header[0]
+        wkb_type = struct.unpack("<I" if byte_order else ">I", header[1:5])[0]
+        return wkb_type & 0xFF in {1, 2, 3}
+
     def as_ewkb(self) -> WKBElement:
         if self.srid > 0:
+            if self.extended:
+                try:
+                    has_matching_srid = _wkb_wkt.wkb_srid(self.data) == self.srid
+                except ValueError:
+                    has_matching_srid = False
+                if has_matching_srid:
+                    if self._has_simple_ewkb_header(self.data):
+                        return WKBElement(self.data, self.srid, extended=True)
+                    _wkb_wkt.to_ewkb_header(self.data, self.srid)
+                    return WKBElement(self.data, self.srid, extended=True)
             data = _wkb_wkt.to_ewkb_header(self.data, self.srid)
-            if self.extended and _wkb_wkt.wkb_srid(self.data) == self.srid:
-                return WKBElement(self.data, self.srid, extended=True)
             return WKBElement(data, self.srid, extended=True)
         return self.as_wkb()
 

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -9,9 +9,8 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import functions
 from sqlalchemy.sql.functions import FunctionElement
 from sqlalchemy.types import to_instance
-from wkb_wkt_converter import to_wkb
-from wkb_wkt_converter import to_wkt
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.exc import ArgumentError
 
 BinasciiError = binascii.Error
@@ -154,23 +153,21 @@ class WKTElement(_SpatialElement):
 
     def as_wkt(self) -> WKTElement:
         if self.extended:
-            srid_match = self._REMOVE_SRID.match(self.data)
-            assert srid_match is not None
-            return WKTElement(srid_match.group(3), self.srid, extended=False)
+            return WKTElement(_wkb_wkt.to_wkt_no_srid(self.data), self.srid, extended=False)
         return WKTElement(self.data, self.srid, self.extended)
 
     def as_ewkt(self) -> WKTElement:
-        if not self.extended and self.srid != -1:
-            data = f"SRID={self.srid};" + self.data
+        if self.srid > 0:
+            data = _wkb_wkt.to_wkt(self.data, srid=self.srid)
             return WKTElement(data, extended=True)
-        return WKTElement(self.data, self.srid, self.extended)
+        return self.as_wkt()
 
     def as_wkb(self) -> WKBElement:
         """Return this element as a plain :class:`WKBElement` (no SRID embedded).
 
         The SRID is preserved as a Python attribute on the returned element.
         """
-        wkb_bytes = to_wkb(self.data, srid=False)
+        wkb_bytes = _wkb_wkt.to_wkb_no_srid(self.data)
         return WKBElement(wkb_bytes, srid=self.srid, extended=False)
 
     def as_ewkb(self) -> WKBElement:
@@ -178,11 +175,10 @@ class WKTElement(_SpatialElement):
 
         If the element has no valid SRID, the result is equivalent to :meth:`as_wkb`.
         """
-        srid_arg: int | bool = self.srid if self.srid != -1 else False
-        wkb_bytes = to_wkb(self.data, srid=srid_arg)
-        if self.srid != -1:
+        if self.srid > 0:
+            wkb_bytes = _wkb_wkt.to_wkb(self.data, srid=self.srid)
             return WKBElement(wkb_bytes, extended=True)
-        return WKBElement(wkb_bytes, srid=self.srid, extended=False)
+        return self.as_wkb()
 
 
 class DynamicWKTElement(WKTElement):
@@ -273,82 +269,26 @@ class WKBElement(_SpatialElement):
 
     def as_wkb(self) -> WKBElement:
         if self.extended:
-            if isinstance(self.data, str):
-                # SpatiaLite case
-                # assume that the string is an hex value
-                is_hex = True
-                header = binascii.unhexlify(self.data[:10])
-                byte_order, wkb_type = header[0], header[1:5]
-            else:
-                is_hex = False
-                byte_order, wkb_type = self.data[0], self.data[1:5]
-
-            byte_order_marker = "<I" if byte_order else ">I"
-            wkb_type_int = (
-                int(struct.unpack(byte_order_marker, wkb_type)[0]) if len(wkb_type) == 4 else 0
-            )
-            wkb_type_int &= 3758096383  # Set SRID bit to 0 and keep all other bits
-
-            if is_hex:
-                wkb_type_hex = binascii.hexlify(
-                    wkb_type_int.to_bytes(4, "little" if byte_order else "big")
-                )
-                data = self.data[:2] + wkb_type_hex.decode("ascii") + self.data[18:]
-            else:
-                buffer = bytearray()
-                buffer.extend(self.data[:1])
-                buffer.extend(struct.pack(byte_order_marker, wkb_type_int))
-                buffer.extend(self.data[9:])
-                data = memoryview(buffer)
+            data = _wkb_wkt.to_wkb_no_srid(self.data)
             return WKBElement(data, self.srid, extended=False)
         return WKBElement(self.data, self.srid)
 
     def as_ewkb(self) -> WKBElement:
-        if not self.extended and self.srid != -1:
-            if isinstance(self.data, str):
-                # SpatiaLite case
-                # assume that the string is an hex value
-                header = binascii.unhexlify(self.data[:10])
-                byte_order, wkb_type = header[0], header[1:5]
-            else:
-                byte_order, wkb_type = self.data[0], self.data[1:5]
-            byte_order_marker = "<I" if byte_order else ">I"
-            wkb_type_int = int(
-                struct.unpack(byte_order_marker, wkb_type)[0] if len(wkb_type) == 4 else 0
-            )
-            wkb_type_int |= 536870912  # Set SRID bit to 1 and keep all other bits
-
-            data: str | memoryview
-            if isinstance(self.data, str):
-                wkb_type_hex = binascii.hexlify(
-                    wkb_type_int.to_bytes(4, "little" if byte_order else "big")
-                )
-                wkb_srid_hex = binascii.hexlify(
-                    self.srid.to_bytes(4, "little" if byte_order else "big")
-                )
-                data = (
-                    self.data[:2]
-                    + wkb_type_hex.decode("ascii")
-                    + wkb_srid_hex.decode("ascii")
-                    + self.data[10:]
-                )
-            else:
-                buffer = bytearray()
-                buffer.extend(self.data[:1])
-                buffer.extend(struct.pack(byte_order_marker, wkb_type_int))
-                buffer.extend(struct.pack(byte_order_marker, self.srid))
-                buffer.extend(self.data[5:])
-                data = memoryview(buffer)
-
+        if self.srid > 0:
+            if self.extended:
+                _, embedded_srid = _wkb_wkt.split_wkb_srid(self.data)
+                if embedded_srid == self.srid:
+                    return WKBElement(self.data, self.srid, extended=True)
+            data = _wkb_wkt.to_wkb(self.data, srid=self.srid)
             return WKBElement(data, self.srid, extended=True)
-        return WKBElement(self.data, self.srid)
+        return self.as_wkb()
 
     def as_wkt(self) -> WKTElement:
         """Return this element as a plain :class:`WKTElement` (no SRID prefix).
 
         The SRID is preserved as a Python attribute on the returned element.
         """
-        wkt = to_wkt(self.data, srid=False)
+        wkt = _wkb_wkt.to_wkt_no_srid(self.data)
         return WKTElement(wkt, srid=self.srid, extended=False)
 
     def as_ewkt(self) -> WKTElement:
@@ -356,10 +296,10 @@ class WKBElement(_SpatialElement):
 
         If the element has no valid SRID, the result is equivalent to :meth:`as_wkt`.
         """
-        srid_arg: int | bool = self.srid if self.srid != -1 else False
-        wkt = to_wkt(self.data, srid=srid_arg)
-        if self.srid != -1:
+        if self.srid > 0:
+            wkt = _wkb_wkt.to_wkt(self.data, srid=self.srid)
             return WKTElement(wkt, extended=True)
+        wkt = _wkb_wkt.to_wkt_no_srid(self.data)
         return WKTElement(wkt, srid=self.srid, extended=False)
 
 

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -228,8 +228,8 @@ class WKBElement(_SpatialElement):
                         raise
             if extended is None:
                 extended = wkb_srid is not None
-            if extended and srid == -1:
-                srid = int(wkb_srid)
+            if extended and srid == -1 and wkb_srid is not None:
+                srid = wkb_srid
         _SpatialElement.__init__(self, data, srid, extended)
 
     @staticmethod

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -269,17 +269,20 @@ class WKBElement(_SpatialElement):
 
     def as_wkb(self) -> WKBElement:
         if self.extended:
-            data = _wkb_wkt.to_wkb_no_srid(self.data)
+            data = _wkb_wkt.to_wkb_no_srid_header(self.data)
             return WKBElement(data, self.srid, extended=False)
-        return WKBElement(self.data, self.srid)
+        return WKBElement(self.data, self.srid, extended=False)
 
     def as_ewkb(self) -> WKBElement:
         if self.srid > 0:
             if self.extended:
-                _, embedded_srid = _wkb_wkt.split_wkb_srid(self.data)
+                if _wkb_wkt.can_header_rewrite(self.data):
+                    embedded_srid = _wkb_wkt.wkb_srid(self.data)
+                else:
+                    _, embedded_srid = _wkb_wkt.split_wkb_srid(self.data)
                 if embedded_srid == self.srid:
                     return WKBElement(self.data, self.srid, extended=True)
-            data = _wkb_wkt.to_wkb(self.data, srid=self.srid)
+            data = _wkb_wkt.to_ewkb_header(self.data, self.srid)
             return WKBElement(data, self.srid, extended=True)
         return self.as_wkb()
 

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -219,7 +219,10 @@ class WKBElement(_SpatialElement):
     geom_from_extended_version: str = "ST_GeomFromEWKB"
 
     def __init__(
-        self, data: str | bytes | memoryview, srid: int = -1, extended: bool | None = None
+        self,
+        data: str | bytes | bytearray | memoryview,
+        srid: int = -1,
+        extended: bool | None = None,
     ) -> None:
         if srid == -1 or extended is None or extended:
             wkb_srid = None
@@ -236,7 +239,7 @@ class WKBElement(_SpatialElement):
         _SpatialElement.__init__(self, data, srid, extended)
 
     @staticmethod
-    def _wkb_to_hex(data: str | bytes | memoryview) -> str:
+    def _wkb_to_hex(data: str | bytes | bytearray | memoryview) -> str:
         """Convert WKB to hex string."""
         if isinstance(data, str):
             # SpatiaLite case
@@ -259,16 +262,6 @@ class WKBElement(_SpatialElement):
             return WKBElement(data, self.srid, extended=False)
         return WKBElement(self.data, self.srid, extended=False)
 
-    @staticmethod
-    def _has_simple_ewkb_header(data: str | bytes | memoryview) -> bool:
-        if isinstance(data, str):  # noqa: SIM108
-            header = binascii.unhexlify(data[:10])
-        else:
-            header = bytes(data[:5])
-        byte_order = header[0]
-        wkb_type = struct.unpack("<I" if byte_order else ">I", header[1:5])[0]
-        return wkb_type & 0xFF in {1, 2, 3}
-
     def as_ewkb(self) -> WKBElement:
         if self.srid > 0:
             if self.extended:
@@ -277,9 +270,6 @@ class WKBElement(_SpatialElement):
                 except ValueError:
                     has_matching_srid = False
                 if has_matching_srid:
-                    if self._has_simple_ewkb_header(self.data):
-                        return WKBElement(self.data, self.srid, extended=True)
-                    _wkb_wkt.to_ewkb_header(self.data, self.srid)
                     return WKBElement(self.data, self.srid, extended=True)
             data = _wkb_wkt.to_ewkb_header(self.data, self.srid)
             return WKBElement(data, self.srid, extended=True)

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -153,20 +153,16 @@ class WKTElement(_SpatialElement):
 
     def as_wkt(self) -> WKTElement:
         if self.extended:
-            match = self._REMOVE_SRID.match(self.data)
-            assert match is not None
-            return WKTElement(match.group(3), self.srid, extended=False)
+            wkt = _wkb_wkt.to_wkt_no_srid(self.data)
+            return WKTElement(wkt, self.srid, extended=False)
         return WKTElement(self.data, self.srid, self.extended)
 
     def as_ewkt(self) -> WKTElement:
         if self.srid > 0:
             if self.extended:
-                match = self._REMOVE_SRID.match(self.data)
-                assert match is not None
-                data = match.group(3)
-            else:
-                data = self.data
-            return WKTElement(f"SRID={self.srid};{data}", extended=True)
+                wkt = _wkb_wkt.to_wkt(self.data, srid=self.srid)
+                return WKTElement(wkt, extended=True)
+            return WKTElement(f"SRID={self.srid};{self.data}", extended=True)
         return self.as_wkt()
 
     def as_wkb(self) -> WKBElement:

--- a/geoalchemy2/types/__init__.py
+++ b/geoalchemy2/types/__init__.py
@@ -219,6 +219,45 @@ class _GISType(UserDefinedType):
 
         return geometry_type, srid, dimension
 
+    def _repr_kwarg_defaults(self) -> dict[str, Any]:
+        return {
+            "geometry_type": "GEOMETRY",
+            "srid": -1,
+            "dimension": None,
+            "spatial_index": True,
+            "use_N_D_index": False,
+            "use_typmod": None,
+            "from_text": type(self).from_text,
+            "name": type(self).name,
+            "nullable": True,
+        }
+
+    def __repr__(self) -> str:
+        defaults = self._repr_kwarg_defaults()
+        values = (
+            ("geometry_type", self.geometry_type),
+            ("srid", self.srid),
+            ("dimension", self.dimension),
+            ("spatial_index", self.spatial_index),
+            ("use_N_D_index", self.use_N_D_index),
+            ("use_typmod", self.use_typmod),
+            ("from_text", self.from_text),
+            ("name", self.name),
+            ("nullable", self.nullable),
+        )
+
+        parts = []
+        for key, value in values:
+            if key == "dimension" and self.geometry_type is not None:
+                continue
+            if value != defaults[key]:
+                parts.append(f"{key}={value!r}")
+
+        arguments = ", ".join(parts)
+        if not arguments:
+            return f"{self.__class__.__name__}()"
+        return f"{self.__class__.__name__}({arguments})"
+
 
 @compiles(_GISType, "mysql")
 @compiles(_GISType, "mariadb")
@@ -416,6 +455,11 @@ class Raster(_GISType):
     def check_ctor_args(*args, **kwargs):
         return None, -1, None
 
+    def _repr_kwarg_defaults(self) -> dict[str, Any]:
+        defaults = super()._repr_kwarg_defaults()
+        defaults.update({"geometry_type": None, "use_typmod": False})
+        return defaults
+
 
 class _DummyGeometry(Geometry):
     """A dummy type only used with SQLite."""
@@ -438,13 +482,17 @@ class CompositeType(UserDefinedType):
     """ Dictionary used for defining the content types and their
         corresponding keys. Set in subclasses. """
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
     class comparator_factory(UserDefinedType.Comparator):
         def __getattr__(self, key):
             try:
                 type_ = self.type.typemap[key]
             except KeyError:
+                type_name = type(self.type).__name__
                 raise AttributeError(
-                    f"Type '{self.type}' doesn't have an attribute: '{key}'"
+                    f"Type '{type_name}' doesn't have an attribute: '{key}'"
                 ) from None
 
             return CompositeElement(self.expr, key, type_)

--- a/geoalchemy2/types/__init__.py
+++ b/geoalchemy2/types/__init__.py
@@ -219,45 +219,6 @@ class _GISType(UserDefinedType):
 
         return geometry_type, srid, dimension
 
-    def _repr_kwarg_defaults(self) -> dict[str, Any]:
-        return {
-            "geometry_type": "GEOMETRY",
-            "srid": -1,
-            "dimension": None,
-            "spatial_index": True,
-            "use_N_D_index": False,
-            "use_typmod": None,
-            "from_text": type(self).from_text,
-            "name": type(self).name,
-            "nullable": True,
-        }
-
-    def __repr__(self) -> str:
-        defaults = self._repr_kwarg_defaults()
-        values = (
-            ("geometry_type", self.geometry_type),
-            ("srid", self.srid),
-            ("dimension", self.dimension),
-            ("spatial_index", self.spatial_index),
-            ("use_N_D_index", self.use_N_D_index),
-            ("use_typmod", self.use_typmod),
-            ("from_text", self.from_text),
-            ("name", self.name),
-            ("nullable", self.nullable),
-        )
-
-        parts = []
-        for key, value in values:
-            if key == "dimension" and self.geometry_type is not None:
-                continue
-            if value != defaults[key]:
-                parts.append(f"{key}={value!r}")
-
-        arguments = ", ".join(parts)
-        if not arguments:
-            return f"{self.__class__.__name__}()"
-        return f"{self.__class__.__name__}({arguments})"
-
 
 @compiles(_GISType, "mysql")
 @compiles(_GISType, "mariadb")
@@ -455,11 +416,6 @@ class Raster(_GISType):
     def check_ctor_args(*args, **kwargs):
         return None, -1, None
 
-    def _repr_kwarg_defaults(self) -> dict[str, Any]:
-        defaults = super()._repr_kwarg_defaults()
-        defaults.update({"geometry_type": None, "use_typmod": False})
-        return defaults
-
 
 class _DummyGeometry(Geometry):
     """A dummy type only used with SQLite."""
@@ -481,9 +437,6 @@ class CompositeType(UserDefinedType):
     typemap: dict[str, _TypeEngineArgument] = {}
     """ Dictionary used for defining the content types and their
         corresponding keys. Set in subclasses. """
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
 
     class comparator_factory(UserDefinedType.Comparator):
         def __getattr__(self, key):

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -1,17 +1,11 @@
 """This module defines functions used by several dialects."""
 
-from wkb_wkt_converter import text_to_wkt
-from wkb_wkt_converter import wkb_to_wkt_split_srid
+from wkb_wkt_converter import to_wkt
 
 
 def _wkbelement_to_wkt(bindvalue):
     """Convert a WKBElement to a plain WKT string (no SRID prefix)."""
-    data = bindvalue.data
-    if isinstance(data, str):
-        return text_to_wkt(data, srid=False)
-    data = data.tobytes() if isinstance(data, memoryview) else bytes(data)
-    wkt, _ = wkb_to_wkt_split_srid(data)
-    return wkt
+    return to_wkt(bindvalue.data, srid=False)
 
 
 def bind_processor_process(spatial_type, bindvalue):

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -8,6 +8,10 @@ def is_wkb_constructor(spatial_type):
     return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
 
 
+def is_ewkb_constructor(spatial_type):
+    return "ewkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
 def as_binary_wkb(bindvalue, *, strip_srid=False):
     if strip_srid:
         wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -1,12 +1,5 @@
 """This module defines functions used by several dialects."""
 
-from wkb_wkt_converter import to_wkt
-
-
-def _wkbelement_to_wkt(bindvalue):
-    """Convert a WKBElement to a plain WKT string (no SRID prefix)."""
-    return to_wkt(bindvalue.data, srid=False)
-
 
 def bind_processor_process(spatial_type, bindvalue):
     return bindvalue  # pragma: no cover

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -1,5 +1,46 @@
 """This module defines functions used by several dialects."""
 
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.exc import ArgumentError
+
+
+def is_wkb_constructor(spatial_type):
+    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def as_binary_wkb(bindvalue, *, strip_srid=False):
+    if strip_srid:
+        wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
+        bindvalue = wkb_element.as_wkb().data
+    elif isinstance(bindvalue, WKBElement):
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, memoryview):
+        return bindvalue.tobytes()
+    if isinstance(bindvalue, str):
+        return WKBElement._data_from_desc(bindvalue)
+    return bytes(bindvalue)
+
+
+def as_wkb_hex(bindvalue, *, strip_srid=True):
+    if strip_srid:
+        wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
+        return wkb_element.as_wkb().desc
+    if isinstance(bindvalue, WKBElement):
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, memoryview):
+        bindvalue = bindvalue.tobytes()
+    if isinstance(bindvalue, (bytes, bytearray)):
+        return bytes(bindvalue).hex()
+    return bindvalue.lower()
+
+
+def validate_wkb_srid(column_srid, srid, *, has_fixed_srid=True):
+    if has_fixed_srid and srid is not None and srid != column_srid:
+        raise ArgumentError(
+            f"The SRID ({srid}) of the supplied value is different "
+            f"from the one of the column ({column_srid})"
+        )
+
 
 def bind_processor_process(spatial_type, bindvalue):
     return bindvalue  # pragma: no cover

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -39,7 +39,14 @@ def as_wkb_hex(bindvalue, *, strip_srid=True):
 
 
 def validate_wkb_srid(column_srid, srid, *, has_fixed_srid=True):
-    if has_fixed_srid and srid is not None and srid != column_srid:
+    if (
+        has_fixed_srid
+        and column_srid is not None
+        and column_srid > 0
+        and srid is not None
+        and srid > 0
+        and srid != column_srid
+    ):
         raise ArgumentError(
             f"The SRID ({srid}) of the supplied value is different "
             f"from the one of the column ({column_srid})"

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -1,5 +1,18 @@
 """This module defines functions used by several dialects."""
 
+from wkb_wkt_converter import text_to_wkt
+from wkb_wkt_converter import wkb_to_wkt_split_srid
+
+
+def _wkbelement_to_wkt(bindvalue):
+    """Convert a WKBElement to a plain WKT string (no SRID prefix)."""
+    data = bindvalue.data
+    if isinstance(data, str):
+        return text_to_wkt(data, srid=False)
+    data = data.tobytes() if isinstance(data, memoryview) else bytes(data)
+    wkt, _ = wkb_to_wkt_split_srid(data)
+    return wkt
+
 
 def bind_processor_process(spatial_type, bindvalue):
     return bindvalue  # pragma: no cover

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -1,5 +1,6 @@
 """This module defines functions used by several dialects."""
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.exc import ArgumentError
 
@@ -12,10 +13,36 @@ def is_ewkb_constructor(spatial_type):
     return "ewkb" in (getattr(spatial_type, "from_text", "") or "").lower()
 
 
-def as_binary_wkb(bindvalue, *, strip_srid=False):
+def _validate_wkb_bindvalue_srid(bindvalue, column_srid):
+    if column_srid is None or column_srid <= 0:
+        return
+
+    if isinstance(bindvalue, bytearray):
+        bindvalue = bytes(bindvalue)
+
+    srids = []
+    if isinstance(bindvalue, WKBElement):
+        if bindvalue.srid > 0:
+            srids.append(bindvalue.srid)
+        bindvalue = bindvalue.data
+
+    if isinstance(bindvalue, (bytes, bytearray, memoryview, str)):
+        srid = _wkb_wkt.wkb_srid(bindvalue)
+        if srid is not None and srid > 0:
+            srids.append(srid)
+
+    for srid in srids:
+        validate_wkb_srid(column_srid, srid)
+
+
+def as_binary_wkb(bindvalue, *, strip_srid=False, column_srid=None):
     if strip_srid:
-        wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
-        bindvalue = wkb_element.as_wkb().data
+        _validate_wkb_bindvalue_srid(bindvalue, column_srid)
+        if isinstance(bindvalue, WKBElement):
+            bindvalue = bindvalue.data
+        if isinstance(bindvalue, bytearray):
+            bindvalue = bytes(bindvalue)
+        return _wkb_wkt.to_wkb_no_srid(bindvalue)
     elif isinstance(bindvalue, WKBElement):
         bindvalue = bindvalue.data
     if isinstance(bindvalue, memoryview):
@@ -25,10 +52,14 @@ def as_binary_wkb(bindvalue, *, strip_srid=False):
     return bytes(bindvalue)
 
 
-def as_wkb_hex(bindvalue, *, strip_srid=True):
+def as_wkb_hex(bindvalue, *, strip_srid=True, column_srid=None):
     if strip_srid:
-        wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
-        return wkb_element.as_wkb().desc
+        _validate_wkb_bindvalue_srid(bindvalue, column_srid)
+        if isinstance(bindvalue, WKBElement):
+            bindvalue = bindvalue.data
+        if isinstance(bindvalue, bytearray):
+            bindvalue = bytes(bindvalue)
+        return _wkb_wkt.to_hex_wkb_no_srid(bindvalue).lower()
     if isinstance(bindvalue, WKBElement):
         bindvalue = bindvalue.data
     if isinstance(bindvalue, memoryview):

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -53,6 +53,34 @@ def as_binary_wkb(bindvalue, *, strip_srid=False, column_srid=None):
     return bytes(bindvalue)
 
 
+def as_binary_ewkb(bindvalue, *, column_srid=None):
+    if bindvalue is None:
+        return None
+
+    _validate_wkb_bindvalue_srid(bindvalue, column_srid)
+
+    element_srid = None
+    if isinstance(bindvalue, WKBElement):
+        if is_known_srid(bindvalue.srid):
+            element_srid = bindvalue.srid
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, bytearray):
+        bindvalue = bytes(bindvalue)
+
+    embedded_srid = None
+    if isinstance(bindvalue, (bytes, bytearray, memoryview, str)):
+        embedded_srid = _wkb_wkt.wkb_srid(bindvalue)
+
+    if is_known_srid(embedded_srid):
+        return as_binary_wkb(bindvalue)
+
+    srid = element_srid if is_known_srid(element_srid) else column_srid
+    if is_known_srid(srid):
+        return _wkb_wkt.to_ewkb_header(bindvalue, srid)
+
+    return as_binary_wkb(bindvalue)
+
+
 def as_wkb_hex(bindvalue, *, strip_srid=True, column_srid=None):
     if strip_srid:
         _validate_wkb_bindvalue_srid(bindvalue, column_srid)

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -57,8 +57,6 @@ def as_binary_ewkb(bindvalue, *, column_srid=None):
     if bindvalue is None:
         return None
 
-    _validate_wkb_bindvalue_srid(bindvalue, column_srid)
-
     element_srid = None
     if isinstance(bindvalue, WKBElement):
         if is_known_srid(bindvalue.srid):
@@ -70,32 +68,40 @@ def as_binary_ewkb(bindvalue, *, column_srid=None):
     embedded_srid = None
     if isinstance(bindvalue, (bytes, bytearray, memoryview, str)):
         embedded_srid = _wkb_wkt.wkb_srid(bindvalue)
+    if isinstance(bindvalue, str):
+        bindvalue = WKBElement._data_from_desc(bindvalue)
+
+    if is_known_srid(element_srid):
+        validate_wkb_srid(column_srid, element_srid)
+    elif is_known_srid(embedded_srid):
+        validate_wkb_srid(column_srid, embedded_srid)
+
+    if is_known_srid(element_srid):
+        return _wkb_wkt.to_ewkb_header(bindvalue, element_srid)
 
     if is_known_srid(embedded_srid):
         return as_binary_wkb(bindvalue)
 
-    srid = element_srid if is_known_srid(element_srid) else column_srid
-    if is_known_srid(srid):
-        return _wkb_wkt.to_ewkb_header(bindvalue, srid)
+    if is_known_srid(column_srid):
+        return _wkb_wkt.to_ewkb_header(bindvalue, column_srid)
 
     return as_binary_wkb(bindvalue)
 
 
-def as_wkb_hex(bindvalue, *, strip_srid=True, column_srid=None):
-    if strip_srid:
-        _validate_wkb_bindvalue_srid(bindvalue, column_srid)
-        if isinstance(bindvalue, WKBElement):
-            bindvalue = bindvalue.data
-        if isinstance(bindvalue, bytearray):
-            bindvalue = bytes(bindvalue)
-        return _wkb_wkt.to_hex_wkb_no_srid(bindvalue).lower()
+def as_ewkb_hex(bindvalue, *, column_srid=None):
+    ewkb = as_binary_ewkb(bindvalue, column_srid=column_srid)
+    if ewkb is None:
+        return None
+    return ewkb.hex()
+
+
+def as_wkb_hex(bindvalue, *, column_srid=None):
+    _validate_wkb_bindvalue_srid(bindvalue, column_srid)
     if isinstance(bindvalue, WKBElement):
-        return bindvalue.as_ewkb().desc
-    if isinstance(bindvalue, memoryview):
-        bindvalue = bindvalue.tobytes()
-    if isinstance(bindvalue, (bytes, bytearray)):
-        return bytes(bindvalue).hex()
-    return bindvalue.lower()
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, bytearray):
+        bindvalue = bytes(bindvalue)
+    return _wkb_wkt.to_hex_wkb_no_srid(bindvalue).lower()
 
 
 def validate_wkb_srid(column_srid, srid, *, has_fixed_srid=True):

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -1,6 +1,7 @@
 """This module defines functions used by several dialects."""
 
 from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.exc import ArgumentError
 
@@ -14,7 +15,7 @@ def is_ewkb_constructor(spatial_type):
 
 
 def _validate_wkb_bindvalue_srid(bindvalue, column_srid):
-    if column_srid is None or column_srid <= 0:
+    if not is_known_srid(column_srid):
         return
 
     if isinstance(bindvalue, bytearray):
@@ -22,13 +23,13 @@ def _validate_wkb_bindvalue_srid(bindvalue, column_srid):
 
     srids = []
     if isinstance(bindvalue, WKBElement):
-        if bindvalue.srid > 0:
+        if is_known_srid(bindvalue.srid):
             srids.append(bindvalue.srid)
         bindvalue = bindvalue.data
 
     if isinstance(bindvalue, (bytes, bytearray, memoryview, str)):
         srid = _wkb_wkt.wkb_srid(bindvalue)
-        if srid is not None and srid > 0:
+        if is_known_srid(srid):
             srids.append(srid)
 
     for srid in srids:
@@ -61,7 +62,7 @@ def as_wkb_hex(bindvalue, *, strip_srid=True, column_srid=None):
             bindvalue = bytes(bindvalue)
         return _wkb_wkt.to_hex_wkb_no_srid(bindvalue).lower()
     if isinstance(bindvalue, WKBElement):
-        bindvalue = bindvalue.data
+        return bindvalue.as_ewkb().desc
     if isinstance(bindvalue, memoryview):
         bindvalue = bindvalue.tobytes()
     if isinstance(bindvalue, (bytes, bytearray)):
@@ -73,9 +74,8 @@ def validate_wkb_srid(column_srid, srid, *, has_fixed_srid=True):
     if (
         has_fixed_srid
         and column_srid is not None
-        and column_srid > 0
-        and srid is not None
-        and srid > 0
+        and is_known_srid(column_srid)
+        and is_known_srid(srid)
         and srid != column_srid
     ):
         raise ArgumentError(

--- a/geoalchemy2/types/dialects/geopackage.py
+++ b/geoalchemy2/types/dialects/geopackage.py
@@ -1,3 +1,30 @@
 """This module defines specific functions for GeoPackage dialect."""
 
-from geoalchemy2.types.dialects.sqlite import bind_processor_process  # noqa
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.types.dialects.sqlite import (
+    bind_processor_process as sqlite_bind_processor_process,
+)
+
+__all__ = ["bind_processor_process"]
+
+
+def _is_wkb_constructor(spatial_type):
+    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def _as_binary_wkb(bindvalue):
+    if isinstance(bindvalue, WKBElement):
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, memoryview):
+        return bindvalue.tobytes()
+    if isinstance(bindvalue, str):
+        return WKBElement._data_from_desc(bindvalue)
+    return bytes(bindvalue)
+
+
+def bind_processor_process(spatial_type, bindvalue):
+    if _is_wkb_constructor(spatial_type) and isinstance(
+        bindvalue, (WKBElement, bytes, memoryview, str)
+    ):
+        return _as_binary_wkb(bindvalue)
+    return sqlite_bind_processor_process(spatial_type, bindvalue)

--- a/geoalchemy2/types/dialects/geopackage.py
+++ b/geoalchemy2/types/dialects/geopackage.py
@@ -1,6 +1,8 @@
 """This module defines specific functions for GeoPackage dialect."""
 
 from geoalchemy2.elements import WKBElement
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import is_wkb_constructor
 from geoalchemy2.types.dialects.sqlite import (
     bind_processor_process as sqlite_bind_processor_process,
 )
@@ -8,23 +10,9 @@ from geoalchemy2.types.dialects.sqlite import (
 __all__ = ["bind_processor_process"]
 
 
-def _is_wkb_constructor(spatial_type):
-    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
-
-
-def _as_binary_wkb(bindvalue):
-    if isinstance(bindvalue, WKBElement):
-        bindvalue = bindvalue.data
-    if isinstance(bindvalue, memoryview):
-        return bindvalue.tobytes()
-    if isinstance(bindvalue, str):
-        return WKBElement._data_from_desc(bindvalue)
-    return bytes(bindvalue)
-
-
 def bind_processor_process(spatial_type, bindvalue):
-    if _is_wkb_constructor(spatial_type) and isinstance(
+    if is_wkb_constructor(spatial_type) and isinstance(
         bindvalue, (WKBElement, bytes, memoryview, str)
     ):
-        return _as_binary_wkb(bindvalue)
+        return as_binary_wkb(bindvalue)
     return sqlite_bind_processor_process(spatial_type, bindvalue)

--- a/geoalchemy2/types/dialects/geopackage.py
+++ b/geoalchemy2/types/dialects/geopackage.py
@@ -2,7 +2,7 @@
 
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.types.dialects.common import as_binary_wkb
-from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import as_ewkb_hex
 from geoalchemy2.types.dialects.common import is_ewkb_constructor
 from geoalchemy2.types.dialects.common import is_wkb_constructor
 from geoalchemy2.types.dialects.sqlite import (
@@ -17,6 +17,6 @@ def bind_processor_process(spatial_type, bindvalue):
         bindvalue, (WKBElement, bytes, bytearray, memoryview, str)
     ):
         if is_ewkb_constructor(spatial_type):
-            return as_wkb_hex(bindvalue, strip_srid=False)
+            return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
         return as_binary_wkb(bindvalue)
     return sqlite_bind_processor_process(spatial_type, bindvalue)

--- a/geoalchemy2/types/dialects/geopackage.py
+++ b/geoalchemy2/types/dialects/geopackage.py
@@ -2,6 +2,8 @@
 
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import is_ewkb_constructor
 from geoalchemy2.types.dialects.common import is_wkb_constructor
 from geoalchemy2.types.dialects.sqlite import (
     bind_processor_process as sqlite_bind_processor_process,
@@ -12,7 +14,9 @@ __all__ = ["bind_processor_process"]
 
 def bind_processor_process(spatial_type, bindvalue):
     if is_wkb_constructor(spatial_type) and isinstance(
-        bindvalue, (WKBElement, bytes, memoryview, str)
+        bindvalue, (WKBElement, bytes, bytearray, memoryview, str)
     ):
+        if is_ewkb_constructor(spatial_type):
+            return as_wkb_hex(bindvalue, strip_srid=False)
         return as_binary_wkb(bindvalue)
     return sqlite_bind_processor_process(spatial_type, bindvalue)

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -7,6 +7,15 @@ from geoalchemy2.exc import ArgumentError
 from geoalchemy2.shape import to_shape
 
 
+def _is_wkb_constructor(spatial_type):
+    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def _as_wkb_hex(bindvalue):
+    wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
+    return wkb_element.as_wkb().desc
+
+
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
@@ -42,7 +51,7 @@ def bind_processor_process(spatial_type, bindvalue):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
-        if "wkb" not in spatial_type.from_text.lower():
+        if not _is_wkb_constructor(spatial_type):
             # With MariaDB we use Shapely to convert the WKBElement to an EWKT string
             wkt = to_shape(bindvalue).wkt
             if "multipoint" in wkt[:20].lower():
@@ -56,7 +65,7 @@ def bind_processor_process(spatial_type, bindvalue):
                 )
             return wkt
         # MariaDB does not support raw binary data so we use the hex representation
-        return bindvalue.desc
-    elif isinstance(bindvalue, memoryview):
-        return bindvalue.tobytes().hex()
+        return _as_wkb_hex(bindvalue)
+    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
+        return _as_wkb_hex(bindvalue)
     return bindvalue

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -1,10 +1,11 @@
 """This module defines specific functions for MySQL dialect."""
 
+from wkb_wkt_converter import to_wkt
+
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -52,7 +53,7 @@ def bind_processor_process(spatial_type, bindvalue):
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
         if not _is_wkb_constructor(spatial_type):
-            wkt = _wkbelement_to_wkt(bindvalue)
+            wkt = to_wkt(bindvalue.data, srid=False)
             if "multipoint" in wkt[:20].lower():
                 # MariaDB does not support ISO WKT with parentheses around each sub-point
                 first_idx = wkt.find("(")

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -4,7 +4,7 @@ from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -52,10 +52,9 @@ def bind_processor_process(spatial_type, bindvalue):
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
         if not _is_wkb_constructor(spatial_type):
-            # With MariaDB we use Shapely to convert the WKBElement to an EWKT string
-            wkt = to_shape(bindvalue).wkt
+            wkt = _wkbelement_to_wkt(bindvalue)
             if "multipoint" in wkt[:20].lower():
-                # Shapely>=2.1 adds parentheses around each sub-point which is not supported
+                # MariaDB does not support ISO WKT with parentheses around each sub-point
                 first_idx = wkt.find("(")
                 last_idx = wkt.rfind(")")
                 wkt = (

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -1,6 +1,7 @@
 """This module defines specific functions for MySQL dialect."""
 
 from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
@@ -40,26 +41,15 @@ def bind_processor_process(spatial_type, bindvalue):
                 f"The SRID ({srid}) of the supplied value can not be casted to integer"
             ) from None
 
-        if srid is not None and srid != spatial_type.srid:
-            raise ArgumentError(
-                f"The SRID ({srid}) of the supplied value is different "
-                f"from the one of the column ({spatial_type.srid})"
-            )
+        validate_wkb_srid(spatial_type.srid, srid)
         return wkt_match.group(3)
 
-    if (
-        isinstance(bindvalue, _SpatialElement)
-        and bindvalue.srid > 0
-        and bindvalue.srid != spatial_type.srid
-    ):
-        raise ArgumentError(
-            f"The SRID ({bindvalue.srid}) of the supplied value is different "
-            f"from the one of the column ({spatial_type.srid})"
-        )
+    if isinstance(bindvalue, _SpatialElement):
+        validate_wkb_srid(spatial_type.srid, bindvalue.srid)
 
     if isinstance(bindvalue, WKTElement):
         bindvalue = bindvalue.as_wkt()
-        if bindvalue.srid <= 0:
+        if not is_known_srid(bindvalue.srid):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -5,23 +5,9 @@ from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-
-
-def _is_wkb_constructor(spatial_type):
-    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
-
-
-def _as_wkb_hex(bindvalue):
-    wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
-    return wkb_element.as_wkb().desc
-
-
-def _validate_wkb_srid(spatial_type, srid):
-    if srid is not None and srid != spatial_type.srid:
-        raise ArgumentError(
-            f"The SRID ({srid}) of the supplied value is different "
-            f"from the one of the column ({spatial_type.srid})"
-        )
+from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import is_wkb_constructor
+from geoalchemy2.types.dialects.common import validate_wkb_srid
 
 
 def _normalize_mariadb_wkt(wkt):
@@ -74,14 +60,14 @@ def bind_processor_process(spatial_type, bindvalue):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
-        if not _is_wkb_constructor(spatial_type):
+        if not is_wkb_constructor(spatial_type):
             return _normalize_mariadb_wkt(_wkb_wkt.to_wkt_no_srid(bindvalue.data))
         # MariaDB does not support raw binary data so we use the hex representation
-        return _as_wkb_hex(bindvalue)
+        return as_wkb_hex(bindvalue)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
-        if _is_wkb_constructor(spatial_type):
-            return _as_wkb_hex(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_wkb_hex(bindvalue)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
-        _validate_wkb_srid(spatial_type, srid)
+        validate_wkb_srid(spatial_type.srid, srid)
         return _normalize_mariadb_wkt(wkt)
     return bindvalue

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -16,8 +16,7 @@ def _as_wkb_hex(bindvalue):
     return wkb_element.as_wkb().desc
 
 
-def _validate_raw_wkb_srid(spatial_type, bindvalue):
-    _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+def _validate_wkb_srid(spatial_type, srid):
     if srid is not None and srid != spatial_type.srid:
         raise ArgumentError(
             f"The SRID ({srid}) of the supplied value is different "
@@ -82,6 +81,7 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if _is_wkb_constructor(spatial_type):
             return _as_wkb_hex(bindvalue)
-        _validate_raw_wkb_srid(spatial_type, bindvalue)
-        return _normalize_mariadb_wkt(_wkb_wkt.to_wkt_no_srid(bindvalue))
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        _validate_wkb_srid(spatial_type, srid)
+        return _normalize_mariadb_wkt(wkt)
     return bindvalue

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -28,7 +28,7 @@ def _normalize_mariadb_wkt(wkt):
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
         if is_wkb_constructor(spatial_type):
-            return as_wkb_hex(bindvalue)
+            return as_wkb_hex(bindvalue, column_srid=spatial_type.srid)
 
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
         srid = wkt_match.group(2)
@@ -49,7 +49,7 @@ def bind_processor_process(spatial_type, bindvalue):
 
     if (
         isinstance(bindvalue, _SpatialElement)
-        and bindvalue.srid != -1
+        and bindvalue.srid > 0
         and bindvalue.srid != spatial_type.srid
     ):
         raise ArgumentError(
@@ -66,10 +66,10 @@ def bind_processor_process(spatial_type, bindvalue):
         if not is_wkb_constructor(spatial_type):
             return _normalize_mariadb_wkt(_wkb_wkt.to_wkt_no_srid(bindvalue.data))
         # MariaDB does not support raw binary data so we use the hex representation
-        return as_wkb_hex(bindvalue)
+        return as_wkb_hex(bindvalue, column_srid=spatial_type.srid)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if is_wkb_constructor(spatial_type):
-            return as_wkb_hex(bindvalue)
+            return as_wkb_hex(bindvalue, column_srid=spatial_type.srid)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
         validate_wkb_srid(spatial_type.srid, srid)
         return _normalize_mariadb_wkt(wkt)

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -27,6 +27,9 @@ def _normalize_mariadb_wkt(wkt):
 
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
+        if is_wkb_constructor(spatial_type):
+            return as_wkb_hex(bindvalue)
+
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
         srid = wkt_match.group(2)
         try:

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -1,7 +1,6 @@
 """This module defines specific functions for MySQL dialect."""
 
-from wkb_wkt_converter import to_wkt
-
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
@@ -15,6 +14,30 @@ def _is_wkb_constructor(spatial_type):
 def _as_wkb_hex(bindvalue):
     wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
     return wkb_element.as_wkb().desc
+
+
+def _validate_raw_wkb_srid(spatial_type, bindvalue):
+    _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+    if srid is not None and srid != spatial_type.srid:
+        raise ArgumentError(
+            f"The SRID ({srid}) of the supplied value is different "
+            f"from the one of the column ({spatial_type.srid})"
+        )
+
+
+def _normalize_mariadb_wkt(wkt):
+    if "multipoint" in wkt[:20].lower() and "empty" not in wkt[:30].lower():
+        # MariaDB does not support ISO WKT with parentheses around each sub-point.
+        first_idx = wkt.find("(")
+        last_idx = wkt.rfind(")")
+        if first_idx == -1 or last_idx == -1:
+            return wkt
+        wkt = (
+            wkt[: first_idx + 1]
+            + wkt[first_idx:last_idx].replace("(", "").replace(")", "")
+            + wkt[last_idx:]
+        )
+    return wkt
 
 
 def bind_processor_process(spatial_type, bindvalue):
@@ -53,19 +76,12 @@ def bind_processor_process(spatial_type, bindvalue):
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
         if not _is_wkb_constructor(spatial_type):
-            wkt = to_wkt(bindvalue.data, srid=False)
-            if "multipoint" in wkt[:20].lower():
-                # MariaDB does not support ISO WKT with parentheses around each sub-point
-                first_idx = wkt.find("(")
-                last_idx = wkt.rfind(")")
-                wkt = (
-                    wkt[: first_idx + 1]
-                    + wkt[first_idx:last_idx].replace("(", "").replace(")", "")
-                    + wkt[last_idx:]
-                )
-            return wkt
+            return _normalize_mariadb_wkt(_wkb_wkt.to_wkt_no_srid(bindvalue.data))
         # MariaDB does not support raw binary data so we use the hex representation
         return _as_wkb_hex(bindvalue)
-    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
-        return _as_wkb_hex(bindvalue)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if _is_wkb_constructor(spatial_type):
+            return _as_wkb_hex(bindvalue)
+        _validate_raw_wkb_srid(spatial_type, bindvalue)
+        return _normalize_mariadb_wkt(_wkb_wkt.to_wkt_no_srid(bindvalue))
     return bindvalue

--- a/geoalchemy2/types/dialects/mssql.py
+++ b/geoalchemy2/types/dialects/mssql.py
@@ -1,35 +1,24 @@
 """This module defines specific functions for MSSQL dialect."""
 
-import binascii
-import math
 import re
-import struct
 
 from sqlalchemy.types import TypeDecorator
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.shape import to_shape
 
 _WKT_DIMENSION_SUFFIX = re.compile(
-    r"^([A-Z]+?)\s*(ZM|Z|M)(\s*\(.*)$",
+    r"\b(POINT|LINESTRING|POLYGON|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON|"
+    r"GEOMETRYCOLLECTION)\s*(ZM|Z|M)(?=\s*(?:\(|EMPTY))",
     re.IGNORECASE | re.DOTALL,
 )
-_WKB_TYPE_NAMES = {
-    1: "POINT",
-    2: "LINESTRING",
-    3: "POLYGON",
-    4: "MULTIPOINT",
-    5: "MULTILINESTRING",
-    6: "MULTIPOLYGON",
-    7: "GEOMETRYCOLLECTION",
-}
 
 
 def _normalize_wkt_for_mssql(wkt):
-    return _WKT_DIMENSION_SUFFIX.sub(r"\1\3", wkt)
+    return _WKT_DIMENSION_SUFFIX.sub(r"\1", wkt)
 
 
 def _split_mssql_st_point_args(spec):
@@ -96,12 +85,6 @@ def _split_mssql_st_point_args(spec):
     return None
 
 
-def _format_wkb_number(value):
-    if value == 0:
-        value = 0.0
-    return format(value, ".17g")
-
-
 def _coerce_wkb_data(value):
     if isinstance(value, WKBElement):
         value = value.data
@@ -110,119 +93,37 @@ def _coerce_wkb_data(value):
     if isinstance(value, (bytes, bytearray)):
         return bytes(value)
     if isinstance(value, str):
-        return binascii.unhexlify(value)
+        return value
     raise TypeError("Unsupported WKB value type")
-
-
-def _decode_wkb_type(raw_type):
-    has_srid = bool(raw_type & 0x20000000)
-    has_z = bool(raw_type & 0x80000000)
-    has_m = bool(raw_type & 0x40000000)
-    base_type = raw_type & 0x1FFFFFFF
-
-    if base_type not in _WKB_TYPE_NAMES:
-        if base_type >= 3000:
-            base_type -= 3000
-            has_z = True
-            has_m = True
-        elif base_type >= 2000:
-            base_type -= 2000
-            has_m = True
-        elif base_type >= 1000:
-            base_type -= 1000
-            has_z = True
-
-    type_name = _WKB_TYPE_NAMES.get(base_type)
-    if type_name is None:
-        raise ValueError(f"Unsupported WKB geometry type: {raw_type}")
-
-    return type_name, 2 + int(has_z) + int(has_m), has_srid
-
-
-def _read_uint32(data, offset, byte_order):
-    return struct.unpack_from(f"{byte_order}I", data, offset)[0], offset + 4
-
-
-def _read_coord(data, offset, byte_order, dimension):
-    values = struct.unpack_from(f"{byte_order}{'d' * dimension}", data, offset)
-    coord = " ".join(_format_wkb_number(value) for value in values)
-    return coord, values, offset + (8 * dimension)
-
-
-def _read_coords(data, offset, byte_order, dimension, count):
-    coords = []
-    for _ in range(count):
-        coord, _, offset = _read_coord(data, offset, byte_order, dimension)
-        coords.append(coord)
-    return coords, offset
-
-
-def _parse_wkb_geometry(data, offset=0):
-    byte_order_marker = data[offset]
-    if byte_order_marker not in (0, 1):
-        raise ValueError(f"Invalid WKB byte order marker: {byte_order_marker}")
-    byte_order = "<" if byte_order_marker == 1 else ">"
-    offset += 1
-
-    raw_type, offset = _read_uint32(data, offset, byte_order)
-    type_name, dimension, has_srid = _decode_wkb_type(raw_type)
-
-    if has_srid:
-        _, offset = _read_uint32(data, offset, byte_order)
-
-    if type_name == "POINT":
-        coord, values, offset = _read_coord(data, offset, byte_order, dimension)
-        if all(math.isnan(value) for value in values):
-            return type_name, " EMPTY", offset
-        return type_name, f" ({coord})", offset
-
-    if type_name == "LINESTRING":
-        point_count, offset = _read_uint32(data, offset, byte_order)
-        if point_count == 0:
-            return type_name, " EMPTY", offset
-        coords, offset = _read_coords(data, offset, byte_order, dimension, point_count)
-        return type_name, f" ({', '.join(coords)})", offset
-
-    if type_name == "POLYGON":
-        ring_count, offset = _read_uint32(data, offset, byte_order)
-        if ring_count == 0:
-            return type_name, " EMPTY", offset
-        rings = []
-        for _ in range(ring_count):
-            point_count, offset = _read_uint32(data, offset, byte_order)
-            coords, offset = _read_coords(data, offset, byte_order, dimension, point_count)
-            rings.append(f"({', '.join(coords)})")
-        return type_name, f" ({', '.join(rings)})", offset
-
-    if type_name in {"MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON", "GEOMETRYCOLLECTION"}:
-        geometry_count, offset = _read_uint32(data, offset, byte_order)
-        if geometry_count == 0:
-            return type_name, " EMPTY", offset
-        geometries = []
-        for _ in range(geometry_count):
-            child_type, child_text, offset = _parse_wkb_geometry(data, offset)
-            if type_name == "GEOMETRYCOLLECTION":
-                geometries.append(f"{child_type}{child_text}")
-            else:
-                geometries.append(child_text.strip())
-        return type_name, f" ({', '.join(geometries)})", offset
-
-    raise ValueError(f"Unsupported WKB geometry type: {type_name}")
 
 
 def _wkb_to_mssql_wkt(value):
     data = _coerce_wkb_data(value)
-    type_name, body, _ = _parse_wkb_geometry(data)
-    return f"{type_name}{body}"
+    try:
+        return _normalize_wkt_for_mssql(_wkb_wkt.to_wkt_no_srid(data))
+    except ValueError as exc:
+        message = str(exc)
+        message_lower = message.lower()
+        if "unsupported geometry type" in message_lower:
+            raise ValueError(f"Unsupported WKB geometry type: {message}") from None
+        if "invalid byte order marker" in message_lower:
+            raise ValueError(f"Invalid WKB byte order marker: {message}") from None
+        raise
 
 
 def _to_mssql_wkt(value):
-    try:
-        return _wkb_to_mssql_wkt(value)
-    except (TypeError, ValueError, struct.error, binascii.Error, IndexError):
-        if isinstance(value, (bytes, bytearray, memoryview)):
-            value = WKBElement(value)
-        return _normalize_wkt_for_mssql(to_shape(value).wkt)
+    if isinstance(value, WKTElement):
+        return _normalize_wkt_for_mssql(_wkb_wkt.to_wkt_no_srid(value.data))
+    return _wkb_to_mssql_wkt(value)
+
+
+def _validate_raw_wkb_srid(column_srid, has_fixed_srid, bindvalue):
+    _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+    if has_fixed_srid and srid is not None and srid != column_srid:
+        raise ArgumentError(
+            f"The SRID ({srid}) of the supplied value is different "
+            f"from the one of the column ({column_srid})"
+        )
 
 
 def _resolve_mssql_spatial_type(spatial_type, dialect):
@@ -269,6 +170,9 @@ def bind_processor_process(spatial_type, bindvalue, dialect=None):
         if bindvalue.srid <= 0:
             bindvalue.srid = spatial_type.srid
         return _normalize_wkt_for_mssql(bindvalue.data)
-    elif isinstance(bindvalue, (bytes, bytearray, memoryview, WKBElement)):
+    elif isinstance(bindvalue, WKBElement):
+        return _to_mssql_wkt(bindvalue)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        _validate_raw_wkb_srid(column_srid, has_fixed_srid, bindvalue)
         return _to_mssql_wkt(bindvalue)
     return bindvalue

--- a/geoalchemy2/types/dialects/mssql.py
+++ b/geoalchemy2/types/dialects/mssql.py
@@ -5,6 +5,7 @@ import re
 from sqlalchemy.types import TypeDecorator
 
 from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
@@ -133,7 +134,7 @@ def _to_mssql_wkt(value):
 
 
 def _validate_wkb_srid(column_srid, has_fixed_srid, srid):
-    if has_fixed_srid and srid is not None and srid > 0 and srid != column_srid:
+    if has_fixed_srid and is_known_srid(srid) and srid != column_srid:
         raise ArgumentError(
             f"The SRID ({srid}) of the supplied value is different "
             f"from the one of the column ({column_srid})"
@@ -161,27 +162,15 @@ def bind_processor_process(spatial_type, bindvalue, dialect=None):
                 f"The SRID ({srid}) of the supplied value can not be casted to integer"
             ) from None
 
-        if has_fixed_srid and srid is not None and srid != column_srid:
-            raise ArgumentError(
-                f"The SRID ({srid}) of the supplied value is different "
-                f"from the one of the column ({column_srid})"
-            )
+        _validate_wkb_srid(column_srid, has_fixed_srid, srid)
         return _normalize_wkt_for_mssql(wkt_match.group(3))
 
-    if (
-        isinstance(bindvalue, _SpatialElement)
-        and has_fixed_srid
-        and bindvalue.srid != -1
-        and bindvalue.srid != column_srid
-    ):
-        raise ArgumentError(
-            f"The SRID ({bindvalue.srid}) of the supplied value is different "
-            f"from the one of the column ({column_srid})"
-        )
+    if isinstance(bindvalue, _SpatialElement):
+        _validate_wkb_srid(column_srid, has_fixed_srid, bindvalue.srid)
 
     if isinstance(bindvalue, WKTElement):
         bindvalue = bindvalue.as_wkt()
-        if bindvalue.srid <= 0:
+        if not is_known_srid(bindvalue.srid):
             bindvalue.srid = spatial_type.srid
         return _normalize_wkt_for_mssql(bindvalue.data)
     elif isinstance(bindvalue, WKBElement):

--- a/geoalchemy2/types/dialects/mssql.py
+++ b/geoalchemy2/types/dialects/mssql.py
@@ -133,7 +133,7 @@ def _to_mssql_wkt(value):
 
 
 def _validate_wkb_srid(column_srid, has_fixed_srid, srid):
-    if has_fixed_srid and srid is not None and srid != column_srid:
+    if has_fixed_srid and srid is not None and srid > 0 and srid != column_srid:
         raise ArgumentError(
             f"The SRID ({srid}) of the supplied value is different "
             f"from the one of the column ({column_srid})"

--- a/geoalchemy2/types/dialects/mssql.py
+++ b/geoalchemy2/types/dialects/mssql.py
@@ -111,14 +111,28 @@ def _wkb_to_mssql_wkt(value):
         raise
 
 
+def _split_wkb_to_mssql_wkt(value):
+    data = _coerce_wkb_data(value)
+    try:
+        wkt, srid = _wkb_wkt.split_wkb_srid(data)
+    except ValueError as exc:
+        message = str(exc)
+        message_lower = message.lower()
+        if "unsupported geometry type" in message_lower:
+            raise ValueError(f"Unsupported WKB geometry type: {message}") from None
+        if "invalid byte order marker" in message_lower:
+            raise ValueError(f"Invalid WKB byte order marker: {message}") from None
+        raise
+    return _normalize_wkt_for_mssql(wkt), srid
+
+
 def _to_mssql_wkt(value):
     if isinstance(value, WKTElement):
         return _normalize_wkt_for_mssql(_wkb_wkt.to_wkt_no_srid(value.data))
     return _wkb_to_mssql_wkt(value)
 
 
-def _validate_raw_wkb_srid(column_srid, has_fixed_srid, bindvalue):
-    _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+def _validate_wkb_srid(column_srid, has_fixed_srid, srid):
     if has_fixed_srid and srid is not None and srid != column_srid:
         raise ArgumentError(
             f"The SRID ({srid}) of the supplied value is different "
@@ -173,6 +187,7 @@ def bind_processor_process(spatial_type, bindvalue, dialect=None):
     elif isinstance(bindvalue, WKBElement):
         return _to_mssql_wkt(bindvalue)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
-        _validate_raw_wkb_srid(column_srid, has_fixed_srid, bindvalue)
-        return _to_mssql_wkt(bindvalue)
+        wkt, srid = _split_wkb_to_mssql_wkt(bindvalue)
+        _validate_wkb_srid(column_srid, has_fixed_srid, srid)
+        return wkt
     return bindvalue

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -7,6 +7,20 @@ from geoalchemy2.exc import ArgumentError
 from geoalchemy2.shape import to_shape
 
 
+def _is_wkb_constructor(spatial_type):
+    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def _as_binary_wkb(bindvalue):
+    wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
+    bindvalue = wkb_element.as_wkb().data
+    if isinstance(bindvalue, memoryview):
+        return bindvalue.tobytes()
+    if isinstance(bindvalue, str):
+        return WKBElement._data_from_desc(bindvalue)
+    return bytes(bindvalue)
+
+
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
@@ -42,7 +56,11 @@ def bind_processor_process(spatial_type, bindvalue):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
-        if "wkb" not in spatial_type.from_text.lower():
+        if _is_wkb_constructor(spatial_type):
+            return _as_binary_wkb(bindvalue)
+        else:
             # With MySQL we use Shapely to convert the WKBElement to an EWKT string
             return to_shape(bindvalue).wkt
+    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
+        return _as_binary_wkb(bindvalue)
     return bindvalue

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -1,10 +1,11 @@
 """This module defines specific functions for MySQL dialect."""
 
+from wkb_wkt_converter import to_wkt
+
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -59,7 +60,7 @@ def bind_processor_process(spatial_type, bindvalue):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         else:
-            return _wkbelement_to_wkt(bindvalue)
+            return to_wkt(bindvalue.data, srid=False)
     elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
         return _as_binary_wkb(bindvalue)
     return bindvalue

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -13,7 +13,7 @@ from geoalchemy2.types.dialects.common import validate_wkb_srid
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
         if is_wkb_constructor(spatial_type):
-            return as_binary_wkb(bindvalue, strip_srid=True)
+            return as_binary_wkb(bindvalue, strip_srid=True, column_srid=spatial_type.srid)
 
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
         srid = wkt_match.group(2)
@@ -34,7 +34,7 @@ def bind_processor_process(spatial_type, bindvalue):
 
     if (
         isinstance(bindvalue, _SpatialElement)
-        and bindvalue.srid != -1
+        and bindvalue.srid > 0
         and bindvalue.srid != spatial_type.srid
     ):
         raise ArgumentError(
@@ -49,12 +49,12 @@ def bind_processor_process(spatial_type, bindvalue):
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
         if is_wkb_constructor(spatial_type):
-            return as_binary_wkb(bindvalue, strip_srid=True)
+            return as_binary_wkb(bindvalue, strip_srid=True, column_srid=spatial_type.srid)
         else:
             return _wkb_wkt.to_wkt_no_srid(bindvalue.data)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if is_wkb_constructor(spatial_type):
-            return as_binary_wkb(bindvalue, strip_srid=True)
+            return as_binary_wkb(bindvalue, strip_srid=True, column_srid=spatial_type.srid)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
         validate_wkb_srid(spatial_type.srid, srid)
         return wkt

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -1,7 +1,6 @@
 """This module defines specific functions for MySQL dialect."""
 
-from wkb_wkt_converter import to_wkt
-
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
@@ -20,6 +19,15 @@ def _as_binary_wkb(bindvalue):
     if isinstance(bindvalue, str):
         return WKBElement._data_from_desc(bindvalue)
     return bytes(bindvalue)
+
+
+def _validate_raw_wkb_srid(spatial_type, bindvalue):
+    _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+    if srid is not None and srid != spatial_type.srid:
+        raise ArgumentError(
+            f"The SRID ({srid}) of the supplied value is different "
+            f"from the one of the column ({spatial_type.srid})"
+        )
 
 
 def bind_processor_process(spatial_type, bindvalue):
@@ -60,7 +68,10 @@ def bind_processor_process(spatial_type, bindvalue):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         else:
-            return to_wkt(bindvalue.data, srid=False)
-    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
-        return _as_binary_wkb(bindvalue)
+            return _wkb_wkt.to_wkt_no_srid(bindvalue.data)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if _is_wkb_constructor(spatial_type):
+            return _as_binary_wkb(bindvalue)
+        _validate_raw_wkb_srid(spatial_type, bindvalue)
+        return _wkb_wkt.to_wkt_no_srid(bindvalue)
     return bindvalue

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -21,8 +21,7 @@ def _as_binary_wkb(bindvalue):
     return bytes(bindvalue)
 
 
-def _validate_raw_wkb_srid(spatial_type, bindvalue):
-    _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+def _validate_wkb_srid(spatial_type, srid):
     if srid is not None and srid != spatial_type.srid:
         raise ArgumentError(
             f"The SRID ({srid}) of the supplied value is different "
@@ -72,6 +71,7 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
-        _validate_raw_wkb_srid(spatial_type, bindvalue)
-        return _wkb_wkt.to_wkt_no_srid(bindvalue)
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        _validate_wkb_srid(spatial_type, srid)
+        return wkt
     return bindvalue

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -5,28 +5,9 @@ from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-
-
-def _is_wkb_constructor(spatial_type):
-    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
-
-
-def _as_binary_wkb(bindvalue):
-    wkb_element = bindvalue if isinstance(bindvalue, WKBElement) else WKBElement(bindvalue)
-    bindvalue = wkb_element.as_wkb().data
-    if isinstance(bindvalue, memoryview):
-        return bindvalue.tobytes()
-    if isinstance(bindvalue, str):
-        return WKBElement._data_from_desc(bindvalue)
-    return bytes(bindvalue)
-
-
-def _validate_wkb_srid(spatial_type, srid):
-    if srid is not None and srid != spatial_type.srid:
-        raise ArgumentError(
-            f"The SRID ({srid}) of the supplied value is different "
-            f"from the one of the column ({spatial_type.srid})"
-        )
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import is_wkb_constructor
+from geoalchemy2.types.dialects.common import validate_wkb_srid
 
 
 def bind_processor_process(spatial_type, bindvalue):
@@ -64,14 +45,14 @@ def bind_processor_process(spatial_type, bindvalue):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
-        if _is_wkb_constructor(spatial_type):
-            return _as_binary_wkb(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue, strip_srid=True)
         else:
             return _wkb_wkt.to_wkt_no_srid(bindvalue.data)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
-        if _is_wkb_constructor(spatial_type):
-            return _as_binary_wkb(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue, strip_srid=True)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
-        _validate_wkb_srid(spatial_type, srid)
+        validate_wkb_srid(spatial_type.srid, srid)
         return wkt
     return bindvalue

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -1,6 +1,7 @@
 """This module defines specific functions for MySQL dialect."""
 
 from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
@@ -25,26 +26,15 @@ def bind_processor_process(spatial_type, bindvalue):
                 f"The SRID ({srid}) of the supplied value can not be casted to integer"
             ) from None
 
-        if srid is not None and srid != spatial_type.srid:
-            raise ArgumentError(
-                f"The SRID ({srid}) of the supplied value is different "
-                f"from the one of the column ({spatial_type.srid})"
-            )
+        validate_wkb_srid(spatial_type.srid, srid)
         return wkt_match.group(3)
 
-    if (
-        isinstance(bindvalue, _SpatialElement)
-        and bindvalue.srid > 0
-        and bindvalue.srid != spatial_type.srid
-    ):
-        raise ArgumentError(
-            f"The SRID ({bindvalue.srid}) of the supplied value is different "
-            f"from the one of the column ({spatial_type.srid})"
-        )
+    if isinstance(bindvalue, _SpatialElement):
+        validate_wkb_srid(spatial_type.srid, bindvalue.srid)
 
     if isinstance(bindvalue, WKTElement):
         bindvalue = bindvalue.as_wkt()
-        if bindvalue.srid <= 0:
+        if not is_known_srid(bindvalue.srid):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -4,7 +4,7 @@ from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -59,8 +59,7 @@ def bind_processor_process(spatial_type, bindvalue):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         else:
-            # With MySQL we use Shapely to convert the WKBElement to an EWKT string
-            return to_shape(bindvalue).wkt
+            return _wkbelement_to_wkt(bindvalue)
     elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
         return _as_binary_wkb(bindvalue)
     return bindvalue

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -12,6 +12,9 @@ from geoalchemy2.types.dialects.common import validate_wkb_srid
 
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue, strip_srid=True)
+
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
         srid = wkt_match.group(2)
         try:

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -6,6 +6,20 @@ from geoalchemy2.elements import WKTElement
 from geoalchemy2.shape import to_shape
 
 
+def _is_wkb_constructor(spatial_type):
+    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def _as_binary_wkb(bindvalue):
+    if isinstance(bindvalue, WKBElement):
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, memoryview):
+        return bindvalue.tobytes()
+    if isinstance(bindvalue, str):
+        return WKBElement._data_from_desc(bindvalue)
+    return bytes(bindvalue)
+
+
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, WKTElement):
         if bindvalue.extended:
@@ -13,7 +27,9 @@ def bind_processor_process(spatial_type, bindvalue):
         else:
             return f"SRID={bindvalue.srid};{bindvalue.data}"
     elif isinstance(bindvalue, WKBElement):
-        if not bindvalue.extended:
+        if _is_wkb_constructor(spatial_type):
+            return _as_binary_wkb(bindvalue)
+        elif not bindvalue.extended:
             # When the WKBElement includes a WKB value rather
             # than a EWKB value we use Shapely to convert the WKBElement to an
             # EWKT string
@@ -25,5 +41,7 @@ def bind_processor_process(spatial_type, bindvalue):
             return bindvalue.desc
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
+    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
+        return _as_binary_wkb(bindvalue)
     else:
         return bindvalue

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -5,7 +5,9 @@ from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.exc import ArgumentError
+from geoalchemy2.types.dialects.common import as_binary_ewkb
 from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import is_ewkb_constructor
 from geoalchemy2.types.dialects.common import is_wkb_constructor
 
 
@@ -16,7 +18,9 @@ def bind_processor_process(spatial_type, bindvalue):
         else:
             return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
     elif isinstance(bindvalue, WKBElement):
-        if is_wkb_constructor(spatial_type):
+        if is_ewkb_constructor(spatial_type):
+            return as_binary_ewkb(bindvalue, column_srid=spatial_type.srid)
+        elif is_wkb_constructor(spatial_type):
             return as_binary_wkb(bindvalue)
         elif not bindvalue.extended:
             return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
@@ -27,7 +31,9 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
-        if is_wkb_constructor(spatial_type):
+        if is_ewkb_constructor(spatial_type):
+            return as_binary_ewkb(bindvalue, column_srid=spatial_type.srid)
+        elif is_wkb_constructor(spatial_type):
             return as_binary_wkb(bindvalue)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
         column_srid = spatial_type.srid

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -4,6 +4,7 @@ from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
+from geoalchemy2.exc import ArgumentError
 from geoalchemy2.types.dialects.common import as_binary_wkb
 from geoalchemy2.types.dialects.common import is_wkb_constructor
 
@@ -28,6 +29,15 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if is_wkb_constructor(spatial_type):
             return as_binary_wkb(bindvalue)
-        return _wkb_wkt.to_wkt_for_column(bindvalue, srid=spatial_type.srid)
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        column_srid = spatial_type.srid
+        if srid is not None and srid > 0:
+            if column_srid > 0 and srid != column_srid:
+                raise ArgumentError(
+                    f"The SRID ({srid}) of the supplied value is different "
+                    f"from the one of the column ({column_srid})"
+                )
+            return _wkb_wkt.to_wkt(wkt, srid=srid)
+        return _wkb_wkt.to_wkt(wkt, srid=column_srid)
     else:
         return bindvalue

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -1,9 +1,10 @@
 """This module defines specific functions for Postgresql dialect."""
 
+from wkb_wkt_converter import to_wkt
+
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -23,14 +24,14 @@ def _as_binary_wkb(bindvalue):
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, WKTElement):
         if bindvalue.extended:
-            return f"{bindvalue.data}"
+            return bindvalue.data
         else:
-            return f"SRID={bindvalue.srid};{bindvalue.data}"
+            return to_wkt(bindvalue.data, srid=bindvalue.srid)
     elif isinstance(bindvalue, WKBElement):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         elif not bindvalue.extended:
-            return f"SRID={bindvalue.srid};{_wkbelement_to_wkt(bindvalue)}"
+            return to_wkt(bindvalue.data, srid=bindvalue.srid)
         else:
             # PostGIS ST_GeomFromEWKT works with EWKT strings as well
             # as EWKB hex strings

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -3,7 +3,7 @@
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -30,11 +30,7 @@ def bind_processor_process(spatial_type, bindvalue):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         elif not bindvalue.extended:
-            # When the WKBElement includes a WKB value rather
-            # than a EWKB value we use Shapely to convert the WKBElement to an
-            # EWKT string
-            shape = to_shape(bindvalue)
-            return f"SRID={bindvalue.srid};{shape.wkt}"
+            return f"SRID={bindvalue.srid};{_wkbelement_to_wkt(bindvalue)}"
         else:
             # PostGIS ST_GeomFromEWKT works with EWKT strings as well
             # as EWKB hex strings

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -1,7 +1,6 @@
 """This module defines specific functions for Postgresql dialect."""
 
-from wkb_wkt_converter import to_wkt
-
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
@@ -26,19 +25,21 @@ def bind_processor_process(spatial_type, bindvalue):
         if bindvalue.extended:
             return bindvalue.data
         else:
-            return to_wkt(bindvalue.data, srid=bindvalue.srid)
+            return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
     elif isinstance(bindvalue, WKBElement):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         elif not bindvalue.extended:
-            return to_wkt(bindvalue.data, srid=bindvalue.srid)
+            return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
         else:
             # PostGIS ST_GeomFromEWKT works with EWKT strings as well
             # as EWKB hex strings
             return bindvalue.desc
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
-    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
-        return _as_binary_wkb(bindvalue)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if _is_wkb_constructor(spatial_type):
+            return _as_binary_wkb(bindvalue)
+        return _wkb_wkt.to_wkt_for_column(bindvalue, srid=spatial_type.srid)
     else:
         return bindvalue

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -4,20 +4,8 @@ from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-
-
-def _is_wkb_constructor(spatial_type):
-    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
-
-
-def _as_binary_wkb(bindvalue):
-    if isinstance(bindvalue, WKBElement):
-        bindvalue = bindvalue.data
-    if isinstance(bindvalue, memoryview):
-        return bindvalue.tobytes()
-    if isinstance(bindvalue, str):
-        return WKBElement._data_from_desc(bindvalue)
-    return bytes(bindvalue)
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import is_wkb_constructor
 
 
 def bind_processor_process(spatial_type, bindvalue):
@@ -27,8 +15,8 @@ def bind_processor_process(spatial_type, bindvalue):
         else:
             return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
     elif isinstance(bindvalue, WKBElement):
-        if _is_wkb_constructor(spatial_type):
-            return _as_binary_wkb(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
         elif not bindvalue.extended:
             return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
         else:
@@ -38,8 +26,8 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
-        if _is_wkb_constructor(spatial_type):
-            return _as_binary_wkb(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
         return _wkb_wkt.to_wkt_for_column(bindvalue, srid=spatial_type.srid)
     else:
         return bindvalue

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -9,6 +9,20 @@ from geoalchemy2.elements import WKTElement
 from geoalchemy2.shape import to_shape
 
 
+def _is_wkb_constructor(spatial_type):
+    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def _as_binary_wkb(bindvalue):
+    if isinstance(bindvalue, WKBElement):
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, memoryview):
+        return bindvalue.tobytes()
+    if isinstance(bindvalue, str):
+        return WKBElement._data_from_desc(bindvalue)
+    return bytes(bindvalue)
+
+
 def format_geom_type(wkt, default_srid=None):
     """Format the Geometry type for SQLite."""
     match = re.match(WKTElement.SPLIT_WKT_PATTERN, wkt)
@@ -40,6 +54,8 @@ def bind_processor_process(spatial_type, bindvalue):
             default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
         )
     elif isinstance(bindvalue, WKBElement):
+        if _is_wkb_constructor(spatial_type):
+            return _as_binary_wkb(bindvalue)
         # With SpatiaLite we use Shapely to convert the WKBElement to an EWKT string
         shape = to_shape(bindvalue)
         # shapely.wkb.loads returns geom_type with a 'Z', for example, 'LINESTRING Z'
@@ -51,6 +67,10 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
     elif isinstance(bindvalue, str):
+        if _is_wkb_constructor(spatial_type):
+            return _as_binary_wkb(bindvalue)
         return format_geom_type(bindvalue, default_srid=spatial_type.srid)
+    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
+        return _as_binary_wkb(bindvalue)
     else:
         return bindvalue

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -6,7 +6,7 @@ import warnings
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -56,12 +56,9 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, WKBElement):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
-        # With SpatiaLite we use Shapely to convert the WKBElement to an EWKT string
-        shape = to_shape(bindvalue)
-        # shapely.wkb.loads returns geom_type with a 'Z', for example, 'LINESTRING Z'
-        # which is a limitation with SpatiaLite. Hence, a temporary fix.
         res = format_geom_type(
-            shape.wkt, default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid
+            _wkbelement_to_wkt(bindvalue),
+            default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
         )
         return res
     elif isinstance(bindvalue, RasterElement):

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -8,6 +8,8 @@ from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import is_ewkb_constructor
 from geoalchemy2.types.dialects.common import is_wkb_constructor
 
 
@@ -36,6 +38,7 @@ def format_geom_type(wkt, default_srid=None):
 
 
 def bind_processor_process(spatial_type, bindvalue):
+    use_ewkb_constructor = is_ewkb_constructor(spatial_type)
     if isinstance(bindvalue, WKTElement):
         return format_geom_type(
             bindvalue.data,
@@ -43,6 +46,8 @@ def bind_processor_process(spatial_type, bindvalue):
         )
     elif isinstance(bindvalue, WKBElement):
         if is_wkb_constructor(spatial_type):
+            if use_ewkb_constructor:
+                return as_wkb_hex(bindvalue, strip_srid=False)
             return as_binary_wkb(bindvalue)
         res = format_geom_type(
             _wkb_wkt.to_wkt_no_srid(bindvalue.data),
@@ -53,10 +58,14 @@ def bind_processor_process(spatial_type, bindvalue):
         return f"{bindvalue.data}"
     elif isinstance(bindvalue, str):
         if is_wkb_constructor(spatial_type):
+            if use_ewkb_constructor:
+                return as_wkb_hex(bindvalue, strip_srid=False)
             return as_binary_wkb(bindvalue)
         return format_geom_type(bindvalue, default_srid=spatial_type.srid)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if is_wkb_constructor(spatial_type):
+            if use_ewkb_constructor:
+                return as_wkb_hex(bindvalue, strip_srid=False)
             return as_binary_wkb(bindvalue)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
         return format_geom_type(

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -70,9 +70,9 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
-        _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
         return format_geom_type(
-            _wkb_wkt.to_wkt_no_srid(bindvalue),
+            wkt,
             default_srid=srid if srid is not None and srid >= 0 else spatial_type.srid,
         )
     else:

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -3,8 +3,7 @@
 import re
 import warnings
 
-from wkb_wkt_converter import to_wkt
-
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
@@ -58,7 +57,7 @@ def bind_processor_process(spatial_type, bindvalue):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         res = format_geom_type(
-            to_wkt(bindvalue.data, srid=False),
+            _wkb_wkt.to_wkt_no_srid(bindvalue.data),
             default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
         )
         return res
@@ -68,7 +67,13 @@ def bind_processor_process(spatial_type, bindvalue):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         return format_geom_type(bindvalue, default_srid=spatial_type.srid)
-    elif isinstance(bindvalue, (bytes, memoryview)) and _is_wkb_constructor(spatial_type):
-        return _as_binary_wkb(bindvalue)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if _is_wkb_constructor(spatial_type):
+            return _as_binary_wkb(bindvalue)
+        _, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        return format_geom_type(
+            _wkb_wkt.to_wkt_no_srid(bindvalue),
+            default_srid=srid if srid is not None and srid >= 0 else spatial_type.srid,
+        )
     else:
         return bindvalue

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -7,20 +7,8 @@ from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-
-
-def _is_wkb_constructor(spatial_type):
-    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
-
-
-def _as_binary_wkb(bindvalue):
-    if isinstance(bindvalue, WKBElement):
-        bindvalue = bindvalue.data
-    if isinstance(bindvalue, memoryview):
-        return bindvalue.tobytes()
-    if isinstance(bindvalue, str):
-        return WKBElement._data_from_desc(bindvalue)
-    return bytes(bindvalue)
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import is_wkb_constructor
 
 
 def format_geom_type(wkt, default_srid=None):
@@ -54,8 +42,8 @@ def bind_processor_process(spatial_type, bindvalue):
             default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
         )
     elif isinstance(bindvalue, WKBElement):
-        if _is_wkb_constructor(spatial_type):
-            return _as_binary_wkb(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
         res = format_geom_type(
             _wkb_wkt.to_wkt_no_srid(bindvalue.data),
             default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
@@ -64,12 +52,12 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
     elif isinstance(bindvalue, str):
-        if _is_wkb_constructor(spatial_type):
-            return _as_binary_wkb(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
         return format_geom_type(bindvalue, default_srid=spatial_type.srid)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
-        if _is_wkb_constructor(spatial_type):
-            return _as_binary_wkb(bindvalue)
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
         return format_geom_type(
             wkt,

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -3,10 +3,11 @@
 import re
 import warnings
 
+from wkb_wkt_converter import to_wkt
+
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-from geoalchemy2.types.dialects.common import _wkbelement_to_wkt
 
 
 def _is_wkb_constructor(spatial_type):
@@ -57,7 +58,7 @@ def bind_processor_process(spatial_type, bindvalue):
         if _is_wkb_constructor(spatial_type):
             return _as_binary_wkb(bindvalue)
         res = format_geom_type(
-            _wkbelement_to_wkt(bindvalue),
+            to_wkt(bindvalue.data, srid=False),
             default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
         )
         return res

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -8,7 +8,7 @@ from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.types.dialects.common import as_binary_wkb
-from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import as_ewkb_hex
 from geoalchemy2.types.dialects.common import is_ewkb_constructor
 from geoalchemy2.types.dialects.common import is_wkb_constructor
 
@@ -47,7 +47,7 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, WKBElement):
         if is_wkb_constructor(spatial_type):
             if use_ewkb_constructor:
-                return as_wkb_hex(bindvalue, strip_srid=False)
+                return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
             return as_binary_wkb(bindvalue)
         res = format_geom_type(
             _wkb_wkt.to_wkt_no_srid(bindvalue.data),
@@ -59,13 +59,13 @@ def bind_processor_process(spatial_type, bindvalue):
     elif isinstance(bindvalue, str):
         if is_wkb_constructor(spatial_type):
             if use_ewkb_constructor:
-                return as_wkb_hex(bindvalue, strip_srid=False)
+                return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
             return as_binary_wkb(bindvalue)
         return format_geom_type(bindvalue, default_srid=spatial_type.srid)
     elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
         if is_wkb_constructor(spatial_type):
             if use_ewkb_constructor:
-                return as_wkb_hex(bindvalue, strip_srid=False)
+                return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
             return as_binary_wkb(bindvalue)
         wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
         return format_geom_type(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "SQLAlchemy>=1.4",
     "packaging",
-    "wkb-wkt-converter",
+    "wkb-wkt-converter>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 dependencies = [
     "SQLAlchemy>=1.4",
     "packaging",
+    "wkb-wkt-converter",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "SQLAlchemy>=1.4",
     "packaging",
-    "wkb-wkt-converter>=0.5.0",
+    "wkb-wkt-converter>=0.6.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "SQLAlchemy>=1.4",
     "packaging",
-    "wkb-wkt-converter>=0.4.0",
+    "wkb-wkt-converter>=0.5.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pytest
 pytest-cov
 pytest-benchmark
 pytest-html
-pytest-mypy
+pytest-mypy;implementation_name!='pypy'
 rasterio;implementation_name!='pypy'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-benchmark
 pytest-html
 pytest-mypy;implementation_name!='pypy'
 rasterio;implementation_name!='pypy'
+wkb-wkt-converter>=0.6.1

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -3,6 +3,30 @@ FROM ubuntu:24.04
 COPY ./helpers/install_requirements.sh /
 RUN /install_requirements.sh
 
+ARG PYPY_VERSION=7.3.22
+ARG PYPY_DIST=pypy3.11-v7.3.22-linux64
+ARG PYPY_SHA256=c0c239a6b0d381338bcccf852d0690b9daca632e0216389a3796f8817fd66e0e
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y bzip2; \
+    curl -fsSLo "/tmp/${PYPY_DIST}.tar.bz2" \
+        "https://downloads.python.org/pypy/${PYPY_DIST}.tar.bz2"; \
+    echo "${PYPY_SHA256}  /tmp/${PYPY_DIST}.tar.bz2" | sha256sum -c -; \
+    tar -xjf "/tmp/${PYPY_DIST}.tar.bz2" -C /opt; \
+    for binary in pypy pypy3 pypy3.11 pypy3-config pypy3.11-config; do \
+        if [ -x "/opt/${PYPY_DIST}/bin/${binary}" ]; then \
+            ln -sf "/opt/${PYPY_DIST}/bin/${binary}" "/usr/local/bin/${binary}"; \
+        fi; \
+    done; \
+    if [ ! -x /usr/local/bin/pypy3 ]; then \
+        ln -sf "/opt/${PYPY_DIST}/bin/pypy3.11" /usr/local/bin/pypy3; \
+    fi; \
+    test "$(command -v pypy3)" = "/usr/local/bin/pypy3"; \
+    pypy3 -c "import sys; assert sys.pypy_version_info[:3] == tuple(map(int, '${PYPY_VERSION}'.split('.')))"; \
+    rm "/tmp/${PYPY_DIST}.tar.bz2"; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
 ENV SPATIALITE_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/mod_spatialite.so"
 
 # Install MSSQL tools and drivers

--- a/test_container/helpers/entrypoint.sh
+++ b/test_container/helpers/entrypoint.sh
@@ -55,6 +55,7 @@ echo "GeoAlchemy2 Test Container"
 echo ""
 echo 'run tests with `tox --workdir /output -v run`'
 echo 'run only a specific job, e.g. `py310-sqlalatest`, with `tox --workdir /output -v run -e py310-sqlalatest`'
+echo 'run the PyPy job with `tox --workdir /output -v run -e pypy3-sqlalatest`'
 echo "MSSQL defaults: server=${MSSQL_HOST} db=${MSSQL_TEST_DB} user=${MSSQL_TEST_LOGIN} password=${MSSQL_TEST_PASSWORD}"
 echo "CockroachDB defaults: server=${COCKROACH_HOST}:${COCKROACH_PORT} db=${COCKROACH_DATABASE} user=${COCKROACH_USER}"
 echo "###############################"

--- a/test_container/run.sh
+++ b/test_container/run.sh
@@ -5,12 +5,34 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 mkdir -p "${SCRIPT_DIR}/output"
 
-cleanup() {
-    docker compose down >/dev/null 2>&1 || true
+SERVICES=(postgres mysql mariadb mssql cockroachdb)
+
+is_healthy() {
+    local service="$1"
+    local container_id
+    local health_status
+
+    container_id=$(docker compose ps -q "${service}" 2>/dev/null || true)
+    if [ -z "${container_id}" ]; then
+        return 1
+    fi
+
+    health_status=$(docker inspect --format '{{ if .State.Health }}{{ .State.Health.Status }}{{ end }}' "${container_id}" 2>/dev/null || true)
+    [ "${health_status}" = "healthy" ]
 }
 
-trap cleanup EXIT
-
 cd "${SCRIPT_DIR}"
-docker compose up -d postgres mysql mariadb mssql cockroachdb
-docker compose run --rm runner "$@"
+
+missing_services=()
+for service in "${SERVICES[@]}"; do
+    if ! is_healthy "${service}"; then
+        missing_services+=("${service}")
+    fi
+done
+
+if [ "${#missing_services[@]}" -gt 0 ]; then
+    echo "Starting test services: ${missing_services[*]}"
+    "${SCRIPT_DIR}/start.sh"
+fi
+
+docker compose run --rm --no-deps runner "$@"

--- a/test_container/start.sh
+++ b/test_container/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd "${SCRIPT_DIR}"
+docker compose up --wait --wait-timeout 300 postgres mysql mariadb mssql cockroachdb

--- a/test_container/stop.sh
+++ b/test_container/stop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd "${SCRIPT_DIR}"
+docker compose stop postgres mysql mariadb mssql cockroachdb

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -14,6 +14,9 @@ from .. import select
 
 ROUNDS = 5
 
+# SQL Server allows at most 1000 row value expressions per INSERT statement.
+_MSSQL_INSERT_CHUNK_SIZE = 1000
+
 
 class SuccessfulTest(BaseException):
     """A custom exception used to mark the successful test."""
@@ -129,15 +132,14 @@ def GeomTable(
 
 def insert_all_points(conn, table, points):
     """Insert all points into the database."""
-    query = table.insert().values(
-        [
-            {
-                "geom": point,
-            }
-            for point in points
-        ]
-    )
-    return conn.execute(query)
+    rows = [{"geom": point} for point in points]
+    if conn.dialect.name != "mssql":
+        return conn.execute(table.insert().values(rows))
+
+    result = None
+    for start in range(0, len(rows), _MSSQL_INSERT_CHUNK_SIZE):
+        result = conn.execute(table.insert().values(rows[start : start + _MSSQL_INSERT_CHUNK_SIZE]))
+    return result
 
 
 def select_all_points(conn, table):

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -94,11 +94,11 @@ def GeomTable(
     print("output_representation:", output_representation)
     print("is_default_geom_type:", is_default_geom_type)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-    if input_representation == "WKB":
+    if input_representation == "WKB input":
         from_text_func = "ST_GeomFromEWKB" if is_extended_input else "ST_GeomFromWKB"
     else:
         from_text_func = "ST_GeomFromEWKT" if is_extended_input else "ST_GeomFromText"
-    if output_representation == "WKB":
+    if output_representation == "WKB output":
         to_text_func = "ST_AsEWKB" if is_extended_output else "ST_AsBinary"
         ElementType_cls = WKBElement
     else:
@@ -284,7 +284,7 @@ def test_insert(
     _insert_fail_or_success_type,
 ):
     """Benchmark the insert operation."""
-    convert_wkb = input_representation == "WKB"
+    convert_wkb = input_representation == "WKB input"
 
     try:
         _benchmark_insert(
@@ -363,6 +363,8 @@ def _insert_select_fail_or_success_type(
         and not is_extended_output
     ):
         return AssertionError
+    if is_default_geom_type and output_representation == "WKT output":
+        return AssertionError
     if dialect_name in ["mysql", "sqlite", "geopackage"] and is_extended_output:
         return AssertionError
     if dialect_name in ["mariadb"] and is_extended_output:
@@ -386,7 +388,7 @@ def _actual_test_insert_select(
     is_default_geom_type,
 ):
     """Actual test for insert and select operations."""
-    convert_wkb = input_representation == "WKB"
+    convert_wkb = input_representation == "WKB input"
     all_points = _benchmark_insert_select(
         conn,
         GeomTable,
@@ -414,9 +416,9 @@ def _actual_test_insert_select(
     if conn.dialect.name == "mssql" and is_default_geom_type:
         expected_extended_output = True
     assert res[0].extended == expected_extended_output
-    if output_representation == "WKB":
+    if output_representation == "WKB output":
         assert isinstance(res[0], WKBElement)
-    elif output_representation == "WKT":
+    elif output_representation == "WKT output":
         assert isinstance(res[0], WKTElement)
     assert res[0].srid == 4326
 

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql import func
 
 from geoalchemy2 import Geometry
@@ -234,6 +235,25 @@ def _insert_fail_or_success_type(
 ):
     """Fixture to determine if the current test should fail or succeed."""
     if (
+        dialect_name in ["mysql", "mariadb", "postgresql", "sqlite"]
+        and input_representation == "WKB input"
+        and is_raw_input
+        and is_default_geom_type
+    ):
+        return (SQLAlchemyError, AssertionError)
+    if (
+        dialect_name == "sqlite"
+        and input_representation == "WKB input"
+        and is_extended_input
+        and not is_default_geom_type
+    ):
+        return (OperationalError, AssertionError)
+    if dialect_name == "geopackage" and input_representation == "WKB input":
+        if is_raw_input and (is_extended_input or is_default_geom_type):
+            return AssertionError
+        if is_extended_input and not is_default_geom_type:
+            return AssertionError
+    if (
         dialect_name in ["sqlite", "geopackage"]
         and not is_default_geom_type
         and not is_extended_input
@@ -305,13 +325,36 @@ def _insert_select_fail_or_success_type(
     is_default_geom_type,
 ):
     """Fixture to determine if the current test should fail or succeed."""
-    if dialect_name in ["mysql"] and not is_default_geom_type and is_extended_output:
+    if dialect_name in ["mysql", "mariadb"] and not is_default_geom_type and is_extended_output:
+        if output_representation == "WKB output":
+            return AssertionError
         return OperationalError
+    if (
+        dialect_name in ["mysql", "mariadb", "postgresql", "sqlite"]
+        and input_representation == "WKB input"
+        and is_raw_input
+        and is_default_geom_type
+    ):
+        return (SQLAlchemyError, AssertionError)
+    if (
+        dialect_name == "sqlite"
+        and input_representation == "WKB input"
+        and is_extended_input
+        and not is_default_geom_type
+    ):
+        return (OperationalError, AssertionError)
+    if (
+        dialect_name == "geopackage"
+        and not is_default_geom_type
+        and is_extended_output
+        and output_representation == "WKB output"
+    ):
+        return AssertionError
     if dialect_name in ["sqlite", "geopackage"] and not is_default_geom_type:
         if not is_extended_output:
             return AssertionError
         else:
-            return OperationalError
+            return (OperationalError, AssertionError)
     if (
         dialect_name in ["postgresql", "sqlite", "geopackage"]
         and is_default_geom_type
@@ -321,10 +364,7 @@ def _insert_select_fail_or_success_type(
     if dialect_name in ["mysql", "sqlite", "geopackage"] and is_extended_output:
         return AssertionError
     if dialect_name in ["mariadb"] and is_extended_output:
-        if is_default_geom_type:
-            return AssertionError
-        else:
-            return OperationalError
+        return AssertionError
     if not is_default_geom_type and is_extended_output:
         return AssertionError
     return SuccessfulTest

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -237,23 +237,14 @@ def _insert_fail_or_success_type(
 ):
     """Fixture to determine if the current test should fail or succeed."""
     if (
-        dialect_name in ["mysql", "mariadb", "postgresql", "sqlite"]
-        and input_representation == "WKB input"
-        and is_raw_input
-        and is_default_geom_type
-    ):
-        return (SQLAlchemyError, AssertionError)
-    if (
         dialect_name == "sqlite"
         and input_representation == "WKB input"
         and is_extended_input
         and not is_default_geom_type
     ):
         return (OperationalError, AssertionError)
-    if dialect_name == "geopackage" and input_representation == "WKB input":
-        if is_raw_input and (is_extended_input or is_default_geom_type):
-            return AssertionError
-        if is_extended_input and not is_default_geom_type:
+    if dialect_name == "geopackage" and input_representation == "WKB input":  # noqa: SIM102
+        if is_extended_input and not is_default_geom_type:  # noqa: SIM102
             return AssertionError
     if (
         dialect_name in ["sqlite", "geopackage"]

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -12,8 +12,6 @@ from geoalchemy2.elements import WKTElement
 from .. import create_points
 from .. import select
 
-ROUNDS = 5
-
 # SQL Server allows at most 1000 row value expressions per INSERT statement.
 _MSSQL_INSERT_CHUNK_SIZE = 1000
 
@@ -264,6 +262,7 @@ def _insert_fail_or_success_type(
     ],
 )
 def test_insert(
+    insert_select_rounds,
     benchmark,
     GeomTable,
     conn,
@@ -287,7 +286,7 @@ def test_insert(
             raw_input=is_raw_input,
             extended_input=is_extended_input,
             N=N,
-            rounds=ROUNDS,
+            rounds=insert_select_rounds,
         )
 
         assert (
@@ -296,7 +295,7 @@ def test_insert(
                 .select_from(GeomTable.__table__)
                 .where(GeomTable.__table__.c.geom.is_not(None))
             ).scalar()
-            == N * N * ROUNDS
+            == N * N * insert_select_rounds
         )
 
     except SuccessfulTest:
@@ -377,6 +376,7 @@ def _actual_test_insert_select(
     output_representation,
     is_extended_output,
     is_default_geom_type,
+    insert_select_rounds,
 ):
     """Actual test for insert and select operations."""
     convert_wkb = input_representation == "WKB input"
@@ -389,7 +389,7 @@ def _actual_test_insert_select(
         raw_input=is_raw_input,
         extended_input=is_extended_input,
         N=N,
-        rounds=ROUNDS,
+        rounds=insert_select_rounds,
     )
 
     assert (
@@ -398,9 +398,9 @@ def _actual_test_insert_select(
                 GeomTable.__table__.select().where(GeomTable.__table__.c.geom.is_not(None))
             ).fetchall()
         )
-        == N * N * ROUNDS
+        == N * N * insert_select_rounds
     )
-    assert len(all_points) == N * N * ROUNDS
+    assert len(all_points) == N * N * insert_select_rounds
 
     res = conn.execute(select([GeomTable.__table__.c.geom])).fetchone()
     expected_extended_output = is_extended_output
@@ -423,6 +423,7 @@ def _actual_test_insert_select(
     ],
 )
 def test_insert_select(
+    insert_select_rounds,
     benchmark,
     GeomTable,
     conn,
@@ -450,6 +451,7 @@ def test_insert_select(
             output_representation,
             is_extended_output,
             is_default_geom_type,
+            insert_select_rounds,
         )
     except SuccessfulTest:
         # Handle the successful test case

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def pytest_addoption(parser):
         "--insert-select-rounds",
         action="store",
         type=int,
-        default=200,
+        default=5,
         help="Number of benchmark rounds for insert/select benchmarks.",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,22 @@ def pytest_addoption(parser):
         default=False,
         help="If set to True, tests marked as long benchmarks will be run.",
     )
+    parser.addoption(
+        "--insert-select-rounds",
+        action="store",
+        type=int,
+        default=200,
+        help="Number of benchmark rounds for insert/select benchmarks.",
+    )
+
+
+@pytest.fixture
+def insert_select_rounds(request):
+    """Number of rounds used by insert/select benchmarks."""
+    rounds = request.config.getoption("--insert-select-rounds")
+    if rounds <= 0:
+        raise pytest.UsageError("--insert-select-rounds must be a positive integer.")
+    return rounds
 
 
 def pytest_configure(config):

--- a/tests/gallery/test_orm_mapped_v2.py
+++ b/tests/gallery/test_orm_mapped_v2.py
@@ -52,10 +52,11 @@ def test_ORM_mapping(session, conn, schema) -> None:
     # Insert point
     session.add(p)
     session.flush()
+    point_id = p.id
     session.expire(p)
 
     # Query the point and check the result
     pt = session.query(Lake).one()
-    assert pt.id == 1
+    assert pt.id == point_id
     assert pt.mapped_geom.srid == 4326
     check_wkb(pt.mapped_geom, 5, 45)

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -7,6 +7,8 @@ import sqlalchemy as sa  # noqa (This import is only used in the migration scrip
 from alembic import command
 from alembic import script
 from alembic.autogenerate import compare_metadata
+from alembic.autogenerate import render as alembic_render
+from alembic.autogenerate.api import AutogenContext
 from alembic.config import Config
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -18,6 +20,7 @@ from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import text
 from sqlalchemy.dialects import mssql
+from sqlalchemy.sql import type_api
 
 from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
@@ -35,25 +38,68 @@ def filter_tables(name, type_, parent_names):
 
 class TestAutogenerate:
     @pytest.mark.parametrize(
-        ("type_", "expected_import"),
+        ("type_", "expected_rendered", "expected_import"),
         [
-            (Geometry(geometry_type="POINT", srid=4326), "from geoalchemy2 import Geometry"),
-            (Geography(geometry_type="POINT", srid=4326), "from geoalchemy2 import Geography"),
-            (Raster(), "from geoalchemy2 import Raster"),
-            (sa.Integer(), None),
+            (
+                Geometry(geometry_type="POINT", srid=4326),
+                "Geometry(geometry_type='POINT', srid=4326)",
+                "from geoalchemy2 import Geometry",
+            ),
+            (
+                Geography(geometry_type="POINT", srid=4326),
+                "Geography(geometry_type='POINT', srid=4326)",
+                "from geoalchemy2 import Geography",
+            ),
+            (Raster(), "Raster()", "from geoalchemy2 import Raster"),
+            (sa.Integer(), "sa.Integer()", None),
         ],
     )
-    def test_render_item_uses_explicit_spatial_repr(self, type_, expected_import):
-        context = SimpleNamespace(imports=set())
+    def test_render_item_uses_explicit_type_repr(self, type_, expected_rendered, expected_import):
+        context = SimpleNamespace(imports=set(), opts={"sqlalchemy_module_prefix": "sa."})
 
         rendered = alembic_helpers.render_item("type", type_, context)
 
         if expected_import is None:
-            assert rendered is False
             assert context.imports == set()
         else:
-            assert rendered == repr(type_)
             assert context.imports == {expected_import}
+        assert rendered == expected_rendered
+
+    def test_render_table_does_not_require_sqlalchemy_type_repr(self, monkeypatch):
+        def fail_repr(self):
+            raise RecursionError("simulated PyPy repr recursion")
+
+        monkeypatch.setattr(type_api.TypeEngine, "__repr__", fail_repr)
+
+        metadata = MetaData()
+        table = Table(
+            "new_spatial_table",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("name", sa.String),
+            Column("geom", Geometry(geometry_type="LINESTRING", srid=4326)),
+        )
+        engine = sa.create_engine("sqlite://")
+        with engine.connect() as conn:
+            migration_context = MigrationContext.configure(
+                conn,
+                opts={
+                    "alembic_module_prefix": "op.",
+                    "render_item": alembic_helpers.render_item,
+                    "sqlalchemy_module_prefix": "sa.",
+                    "user_module_prefix": None,
+                },
+            )
+            autogen_context = AutogenContext(migration_context)
+
+            rendered = alembic_render._add_table(
+                autogen_context,
+                ops.CreateTableOp.from_table(table),
+            )
+
+        assert "sa.Integer()" in rendered
+        assert "sa.String()" in rendered
+        assert "Geometry(geometry_type='LINESTRING', srid=4326)" in rendered
 
     def test_no_diff(self, conn, Lake, setup_tables, use_alembic_monkeypatch, dialect_name):
         """Check that the autogeneration detects spatial types properly."""

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -20,7 +20,7 @@ from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import text
 from sqlalchemy.dialects import mssql
-from sqlalchemy.sql import type_api
+from sqlalchemy.util import compat
 
 from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
@@ -51,7 +51,6 @@ class TestAutogenerate:
                 "from geoalchemy2 import Geography",
             ),
             (Raster(), "Raster()", "from geoalchemy2 import Raster"),
-            (sa.Integer(), "sa.Integer()", None),
         ],
     )
     def test_render_item_uses_explicit_type_repr(self, type_, expected_rendered, expected_import):
@@ -65,18 +64,51 @@ class TestAutogenerate:
             assert context.imports == {expected_import}
         assert rendered == expected_rendered
 
-    def test_render_table_does_not_require_sqlalchemy_type_repr(self, monkeypatch):
-        def fail_repr(self):
-            raise RecursionError("simulated PyPy repr recursion")
+    def test_render_item_leaves_sqlalchemy_types_to_alembic(self):
+        context = SimpleNamespace(imports=set(), opts={"sqlalchemy_module_prefix": "sa."})
 
-        monkeypatch.setattr(type_api.TypeEngine, "__repr__", fail_repr)
+        rendered = alembic_helpers.render_item("type", sa.Integer(), context)
+
+        assert rendered is False
+        assert context.imports == set()
+
+    def test_pypy_type_repr_compat_is_idempotent(self, monkeypatch):
+        original = compat.inspect_getfullargspec
+        previous = getattr(original, "_geoalchemy2_original", original)
+        monkeypatch.setattr(compat, "inspect_getfullargspec", previous)
+
+        alembic_helpers._ensure_pypy_type_repr_compat(_force=True)
+        first_wrapper = compat.inspect_getfullargspec
+        alembic_helpers._ensure_pypy_type_repr_compat(_force=True)
+
+        assert compat.inspect_getfullargspec is first_wrapper
+        assert first_wrapper is not previous
+        assert first_wrapper._geoalchemy2_original is previous
+
+    def test_render_table_handles_pypy_type_repr_recursion(self, monkeypatch):
+        original = compat.inspect_getfullargspec
+        original = getattr(original, "_geoalchemy2_original", original)
+
+        def inspect_getfullargspec_with_pypy_recursion(func):
+            try:
+                return original(func)
+            except TypeError as exc:
+                raise RecursionError("simulated PyPy repr recursion") from exc
+
+        monkeypatch.setattr(
+            compat,
+            "inspect_getfullargspec",
+            inspect_getfullargspec_with_pypy_recursion,
+        )
+        alembic_helpers._ensure_pypy_type_repr_compat(_force=True)
 
         metadata = MetaData()
         table = Table(
             "new_spatial_table",
             metadata,
             Column("id", Integer, primary_key=True),
-            Column("name", sa.String),
+            Column("created", sa.Date),
+            Column("name", sa.String(30)),
             Column("geom", Geometry(geometry_type="LINESTRING", srid=4326)),
         )
         engine = sa.create_engine("sqlite://")
@@ -98,7 +130,8 @@ class TestAutogenerate:
             )
 
         assert "sa.Integer()" in rendered
-        assert "sa.String()" in rendered
+        assert "sa.Date()" in rendered
+        assert "sa.String(length=30)" in rendered
         assert "Geometry(geometry_type='LINESTRING', srid=4326)" in rendered
 
     def test_no_diff(self, conn, Lake, setup_tables, use_alembic_monkeypatch, dialect_name):

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -1,5 +1,7 @@
 """Test alembic migrations of spatial columns."""
 
+from types import SimpleNamespace
+
 import pytest
 import sqlalchemy as sa  # noqa (This import is only used in the migration scripts)
 from alembic import command
@@ -17,7 +19,9 @@ from sqlalchemy import Table
 from sqlalchemy import text
 from sqlalchemy.dialects import mssql
 
+from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
+from geoalchemy2 import Raster
 from geoalchemy2 import alembic_helpers
 
 from . import check_indexes
@@ -30,6 +34,27 @@ def filter_tables(name, type_, parent_names):
 
 
 class TestAutogenerate:
+    @pytest.mark.parametrize(
+        ("type_", "expected_import"),
+        [
+            (Geometry(geometry_type="POINT", srid=4326), "from geoalchemy2 import Geometry"),
+            (Geography(geometry_type="POINT", srid=4326), "from geoalchemy2 import Geography"),
+            (Raster(), "from geoalchemy2 import Raster"),
+            (sa.Integer(), None),
+        ],
+    )
+    def test_render_item_uses_explicit_spatial_repr(self, type_, expected_import):
+        context = SimpleNamespace(imports=set())
+
+        rendered = alembic_helpers.render_item("type", type_, context)
+
+        if expected_import is None:
+            assert rendered is False
+            assert context.imports == set()
+        else:
+            assert rendered == repr(type_)
+            assert context.imports == {expected_import}
+
     def test_no_diff(self, conn, Lake, setup_tables, use_alembic_monkeypatch, dialect_name):
         """Check that the autogeneration detects spatial types properly."""
         metadata = MetaData()

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -29,6 +29,10 @@ def filter_tables(name, type_, parent_names):
     return type_ != "table" or name in ["lake", "alembic_table"]
 
 
+def test_sqlalchemy_integer_repr_is_safe_after_alembic_helper_import():
+    assert repr(Integer()) == "Integer()"
+
+
 class TestAutogenerate:
     def test_no_diff(self, conn, Lake, setup_tables, use_alembic_monkeypatch, dialect_name):
         """Check that the autogeneration detects spatial types properly."""

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -1,14 +1,10 @@
 """Test alembic migrations of spatial columns."""
 
-from types import SimpleNamespace
-
 import pytest
 import sqlalchemy as sa  # noqa (This import is only used in the migration scripts)
 from alembic import command
 from alembic import script
 from alembic.autogenerate import compare_metadata
-from alembic.autogenerate import render as alembic_render
-from alembic.autogenerate.api import AutogenContext
 from alembic.config import Config
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -20,11 +16,8 @@ from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import text
 from sqlalchemy.dialects import mssql
-from sqlalchemy.util import compat
 
-from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
-from geoalchemy2 import Raster
 from geoalchemy2 import alembic_helpers
 
 from . import check_indexes
@@ -37,103 +30,6 @@ def filter_tables(name, type_, parent_names):
 
 
 class TestAutogenerate:
-    @pytest.mark.parametrize(
-        ("type_", "expected_rendered", "expected_import"),
-        [
-            (
-                Geometry(geometry_type="POINT", srid=4326),
-                "Geometry(geometry_type='POINT', srid=4326)",
-                "from geoalchemy2 import Geometry",
-            ),
-            (
-                Geography(geometry_type="POINT", srid=4326),
-                "Geography(geometry_type='POINT', srid=4326)",
-                "from geoalchemy2 import Geography",
-            ),
-            (Raster(), "Raster()", "from geoalchemy2 import Raster"),
-        ],
-    )
-    def test_render_item_uses_explicit_type_repr(self, type_, expected_rendered, expected_import):
-        context = SimpleNamespace(imports=set(), opts={"sqlalchemy_module_prefix": "sa."})
-
-        rendered = alembic_helpers.render_item("type", type_, context)
-
-        if expected_import is None:
-            assert context.imports == set()
-        else:
-            assert context.imports == {expected_import}
-        assert rendered == expected_rendered
-
-    def test_render_item_leaves_sqlalchemy_types_to_alembic(self):
-        context = SimpleNamespace(imports=set(), opts={"sqlalchemy_module_prefix": "sa."})
-
-        rendered = alembic_helpers.render_item("type", sa.Integer(), context)
-
-        assert rendered is False
-        assert context.imports == set()
-
-    def test_pypy_type_repr_compat_is_idempotent(self, monkeypatch):
-        original = compat.inspect_getfullargspec
-        previous = getattr(original, "_geoalchemy2_original", original)
-        monkeypatch.setattr(compat, "inspect_getfullargspec", previous)
-
-        alembic_helpers._ensure_pypy_type_repr_compat(_force=True)
-        first_wrapper = compat.inspect_getfullargspec
-        alembic_helpers._ensure_pypy_type_repr_compat(_force=True)
-
-        assert compat.inspect_getfullargspec is first_wrapper
-        assert first_wrapper is not previous
-        assert first_wrapper._geoalchemy2_original is previous
-
-    def test_render_table_handles_pypy_type_repr_recursion(self, monkeypatch):
-        original = compat.inspect_getfullargspec
-        original = getattr(original, "_geoalchemy2_original", original)
-
-        def inspect_getfullargspec_with_pypy_recursion(func):
-            try:
-                return original(func)
-            except TypeError as exc:
-                raise RecursionError("simulated PyPy repr recursion") from exc
-
-        monkeypatch.setattr(
-            compat,
-            "inspect_getfullargspec",
-            inspect_getfullargspec_with_pypy_recursion,
-        )
-        alembic_helpers._ensure_pypy_type_repr_compat(_force=True)
-
-        metadata = MetaData()
-        table = Table(
-            "new_spatial_table",
-            metadata,
-            Column("id", Integer, primary_key=True),
-            Column("created", sa.Date),
-            Column("name", sa.String(30)),
-            Column("geom", Geometry(geometry_type="LINESTRING", srid=4326)),
-        )
-        engine = sa.create_engine("sqlite://")
-        with engine.connect() as conn:
-            migration_context = MigrationContext.configure(
-                conn,
-                opts={
-                    "alembic_module_prefix": "op.",
-                    "render_item": alembic_helpers.render_item,
-                    "sqlalchemy_module_prefix": "sa.",
-                    "user_module_prefix": None,
-                },
-            )
-            autogen_context = AutogenContext(migration_context)
-
-            rendered = alembic_render._add_table(
-                autogen_context,
-                ops.CreateTableOp.from_table(table),
-            )
-
-        assert "sa.Integer()" in rendered
-        assert "sa.Date()" in rendered
-        assert "sa.String(length=30)" in rendered
-        assert "Geometry(geometry_type='LINESTRING', srid=4326)" in rendered
-
     def test_no_diff(self, conn, Lake, setup_tables, use_alembic_monkeypatch, dialect_name):
         """Check that the autogeneration detects spatial types properly."""
         metadata = MetaData()

--- a/tests/test_compare_benchmarks.py
+++ b/tests/test_compare_benchmarks.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.sax.saxutils import quoteattr
+
+import pytest
+
+from tools import compare_benchmarks
+
+
+def test_filter_run_by_junitxml_keeps_only_passed_benchmarks(tmp_path: Path) -> None:
+    passed = _nodeid("test_insert[passed]")
+    failed = _nodeid("test_insert[failed]")
+    errored = _nodeid("test_insert[errored]")
+    skipped = _nodeid("test_insert[skipped]")
+    missing = _nodeid("test_insert[missing]")
+    run = _run(tmp_path, "branch", [passed, failed, errored, skipped, missing])
+    junitxml = _junitxml(
+        tmp_path,
+        "branch",
+        [
+            ("tests.benchmarks.test_insert_select", "test_insert[passed]", "passed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[failed]", "failed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[errored]", "error"),
+            ("tests.benchmarks.test_insert_select", "test_insert[skipped]", "skipped"),
+        ],
+    )
+
+    filtered = compare_benchmarks.filter_run_by_junitxml(run, junitxml)
+
+    assert set(filtered.benchmarks) == {passed}
+    assert [benchmark["fullname"] for benchmark in filtered.data["benchmarks"]] == [passed]
+    assert filtered.outcome_filter == {
+        "junitxml": str(junitxml),
+        "kept": 1,
+        "excluded": {
+            "failed": 1,
+            "error": 1,
+            "skipped": 1,
+            "missing-outcome": 1,
+        },
+    }
+
+
+def test_filter_run_by_junitxml_maps_class_based_nodeids(tmp_path: Path) -> None:
+    nodeid = "tests/test_elements.py::TestDynamicElements::test_create_elements[WKTElement]"
+    run = _run(tmp_path, "branch", [nodeid])
+    junitxml = _junitxml(
+        tmp_path,
+        "branch",
+        [
+            (
+                "tests.test_elements.TestDynamicElements",
+                "test_create_elements[WKTElement]",
+                "passed",
+            ),
+        ],
+    )
+
+    filtered = compare_benchmarks.filter_run_by_junitxml(run, junitxml)
+
+    assert set(filtered.benchmarks) == {nodeid}
+
+
+def test_main_filters_before_comparison(tmp_path: Path) -> None:
+    passed = _nodeid("test_insert[passed]")
+    failed = _nodeid("test_insert[failed]")
+    base_json = _benchmark_json(tmp_path, "base", {passed: 1.0, failed: 2.0})
+    compare_json = _benchmark_json(tmp_path, "compare", {passed: 1.5, failed: 0.1})
+    base_xml = _junitxml(
+        tmp_path,
+        "base",
+        [
+            ("tests.benchmarks.test_insert_select", "test_insert[passed]", "passed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[failed]", "passed"),
+        ],
+    )
+    compare_xml = _junitxml(
+        tmp_path,
+        "compare",
+        [
+            ("tests.benchmarks.test_insert_select", "test_insert[passed]", "passed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[failed]", "failed"),
+        ],
+    )
+    output = tmp_path / "comparison"
+
+    result = compare_benchmarks.main(
+        [
+            "--base",
+            str(base_json),
+            "--compare",
+            str(compare_json),
+            "--base-junitxml",
+            str(base_xml),
+            "--compare-junitxml",
+            str(compare_xml),
+            "--output",
+            str(output),
+            "--no-charts",
+        ]
+    )
+
+    comparison = json.loads((output / "comparison.json").read_text(encoding="utf-8"))
+    assert result == 0
+    assert [benchmark["name"] for benchmark in comparison["benchmarks"]] == [passed]
+    assert comparison["benchmarks"][0]["status"] == "slower"
+    assert comparison["compare"]["outcome_filter"]["excluded"]["failed"] == 1
+
+
+def test_main_warns_when_outcome_filtering_is_disabled(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    nodeid = _nodeid("test_insert[passed]")
+    base_json = _benchmark_json(tmp_path, "base", {nodeid: 1.0})
+    compare_json = _benchmark_json(tmp_path, "compare", {nodeid: 1.5})
+
+    result = compare_benchmarks.main(
+        [
+            "--base",
+            str(base_json),
+            "--compare",
+            str(compare_json),
+            "--output",
+            str(tmp_path / "comparison"),
+            "--no-charts",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "benchmark outcome filtering is disabled" in captured.err
+
+
+def test_parse_args_requires_both_junitxml_paths(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        compare_benchmarks.parse_args(
+            [
+                "--base",
+                "base",
+                "--compare",
+                "compare",
+                "--base-junitxml",
+                str(tmp_path / "base.xml"),
+                "--output",
+                str(tmp_path / "comparison"),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def _nodeid(name: str) -> str:
+    return f"tests/benchmarks/test_insert_select.py::{name}"
+
+
+def _run(tmp_path: Path, label: str, nodeids: list[str]) -> compare_benchmarks.BenchmarkRun:
+    path = _benchmark_json(tmp_path, label, dict.fromkeys(nodeids, 1.0))
+    return compare_benchmarks.load_run(label, path)
+
+
+def _benchmark_json(tmp_path: Path, label: str, values: dict[str, float]) -> Path:
+    path = tmp_path / f"{label}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "benchmarks": [
+                    {"fullname": nodeid, "stats": {"mean": value}}
+                    for nodeid, value in values.items()
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _junitxml(tmp_path: Path, label: str, cases: list[tuple[str, str, str]]) -> Path:
+    path = tmp_path / f"{label}.xml"
+    testcases = [_testcase_xml(classname, name, outcome) for classname, name, outcome in cases]
+    path.write_text(
+        f"<testsuites><testsuite>{''.join(testcases)}</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _testcase_xml(classname: str, name: str, outcome: str) -> str:
+    children = {
+        "passed": "",
+        "failed": "<failure />",
+        "error": "<error />",
+        "skipped": "<skipped />",
+    }[outcome]
+    return (
+        f"<testcase classname={quoteattr(classname)} name={quoteattr(name)}>{children}</testcase>"
+    )

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,4 +1,5 @@
 import re
+import struct
 from itertools import permutations
 
 import pytest
@@ -157,6 +158,27 @@ class TestWKTElement:
 
         # Roundtrip: WKT → WKB → WKT
         assert r2.as_wkt() == WKTElement(self._wkt, srid=self._srid, extended=False)
+
+    def test_as_ewkt_as_ewkb_treats_zero_srid_as_no_embedded_srid(self):
+        e = WKTElement(f"SRID=0;{self._wkt}", extended=True)
+
+        assert e.srid == 0
+
+        wkt = e.as_wkt()
+        assert wkt.desc == self._wkt
+        assert wkt.srid == 0
+        assert wkt.extended is False
+
+        ewkt = e.as_ewkt()
+        assert ewkt.desc == self._wkt
+        assert ewkt.srid == 0
+        assert ewkt.extended is False
+
+        wkb = e.as_wkb()
+        ewkb = e.as_ewkb()
+        assert ewkb.desc == wkb.desc
+        assert ewkb.srid == 0
+        assert ewkb.extended is False
 
 
 class TestExtendedWKTElement:
@@ -450,6 +472,7 @@ class TestExtendedWKBElement:
         e1 = WKBElement(self._bin_ewkb)
         e2 = WKBElement(self._hex_ewkb)
         e3 = WKBElement(self._hex_wkb)
+        e4 = WKBElement(self._hex_wkb, srid=0)
 
         # Binary EWKB — SRID preserved as attribute
         r1 = e1.as_wkt()
@@ -484,6 +507,21 @@ class TestExtendedWKBElement:
         assert isinstance(r5, WKTElement)
         assert r5.extended is False
         assert r5.srid == -1
+
+        # Plain WKB with SRID 0 keeps SRID as an attribute but does not emit EWKT.
+        r6 = e4.as_ewkt()
+        assert isinstance(r6, WKTElement)
+        assert r6.extended is False
+        assert r6.srid == 0
+        assert r6.desc == self._wkt
+        assert e4.as_ewkb().extended is False
+
+    def test_as_ewkb_preserves_already_extended_big_endian_data(self):
+        data = memoryview(struct.pack(">BII2d", 0, 0x20000001, self._srid, 1.0, 2.0))
+        elem = WKBElement(data, extended=True)
+
+        assert elem.srid == self._srid
+        assert elem.as_ewkb().desc == elem.desc
 
 
 class TestWKBElement:

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -181,7 +181,7 @@ class TestWKTElement:
         assert ewkb.srid == 0
         assert ewkb.extended is False
 
-    def test_as_wkt_as_ewkt_use_wkt_only_fast_paths(self, monkeypatch):
+    def test_plain_as_wkt_as_ewkt_use_wkt_only_fast_paths(self, monkeypatch):
         def fail(*args, **kwargs):
             raise AssertionError("WKT-only conversion should not use the WKB/WKT converter")
 
@@ -189,11 +189,61 @@ class TestWKTElement:
         monkeypatch.setattr(_wkb_wkt, "to_wkt_no_srid", fail)
 
         wkt = WKTElement(self._wkt, srid=self._srid)
+        zero_srid_wkt = WKTElement(self._wkt, srid=0)
+        no_srid_wkt = WKTElement(self._wkt)
+
+        assert wkt.as_wkt() == WKTElement(self._wkt, srid=self._srid, extended=False)
+        assert wkt.as_ewkt() == WKTElement(self._ewkt, extended=True)
+        assert zero_srid_wkt.as_ewkt() == WKTElement(self._wkt, srid=0, extended=False)
+        assert no_srid_wkt.as_ewkt() == WKTElement(self._wkt, srid=-1, extended=False)
+
+    def test_extended_as_wkt_uses_converter(self, monkeypatch):
+        calls = []
+
+        def to_wkt_no_srid(value):
+            calls.append(value)
+            return self._wkt
+
+        def fail_to_wkt(*args, **kwargs):
+            raise AssertionError("as_wkt() should use the no-SRID converter")
+
+        monkeypatch.setattr(_wkb_wkt, "to_wkt_no_srid", to_wkt_no_srid)
+        monkeypatch.setattr(_wkb_wkt, "to_wkt", fail_to_wkt)
+
         ewkt = WKTElement(self._ewkt, extended=True)
+
+        assert ewkt.as_wkt() == WKTElement(self._wkt, srid=self._srid, extended=False)
+        assert calls == [self._ewkt]
+
+    def test_extended_as_ewkt_with_positive_srid_uses_converter(self, monkeypatch):
+        calls = []
+
+        def to_wkt(value, srid=None):
+            calls.append((value, srid))
+            return f"SRID={srid};{self._wkt}"
+
+        def fail_to_wkt_no_srid(*args, **kwargs):
+            raise AssertionError("positive-SRID as_ewkt() should keep the SRID converter")
+
+        monkeypatch.setattr(_wkb_wkt, "to_wkt", to_wkt)
+        monkeypatch.setattr(_wkb_wkt, "to_wkt_no_srid", fail_to_wkt_no_srid)
+
+        ewkt = WKTElement(self._ewkt, srid=4326, extended=True)
+
+        assert ewkt.as_ewkt() == WKTElement(f"SRID=4326;{self._wkt}", extended=True)
+        assert calls == [(self._ewkt, 4326)]
+
+    def test_extended_as_wkt_as_ewkt_semantics(self):
+        ewkt = WKTElement(self._ewkt, extended=True)
+        spaced_ewkt = WKTElement(f"SRID={self._srid}; {self._wkt}", extended=True)
+        forced_srid_ewkt = WKTElement(self._ewkt, srid=4326, extended=True)
         zero_srid_ewkt = WKTElement(f"SRID=0;{self._wkt}", extended=True)
 
-        assert wkt.as_ewkt() == WKTElement(self._ewkt, extended=True)
         assert ewkt.as_wkt() == WKTElement(self._wkt, srid=self._srid, extended=False)
+        assert ewkt.as_ewkt() == WKTElement(self._ewkt, extended=True)
+        assert spaced_ewkt.as_wkt() == WKTElement(self._wkt, srid=self._srid, extended=False)
+        assert spaced_ewkt.as_ewkt() == WKTElement(self._ewkt, extended=True)
+        assert forced_srid_ewkt.as_ewkt() == WKTElement(f"SRID=4326;{self._wkt}", extended=True)
         assert zero_srid_ewkt.as_wkt() == WKTElement(self._wkt, srid=0, extended=False)
         assert zero_srid_ewkt.as_ewkt() == WKTElement(self._wkt, srid=0, extended=False)
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -120,6 +120,44 @@ class TestWKTElement:
         assert e3.as_wkt() == e3.as_wkt().as_wkt() == e1
         assert e4.as_wkt() == e4.as_wkt().as_wkt() == e2
 
+    def test_as_wkb(self):
+        e1 = WKTElement(self._wkt)
+        e2 = WKTElement(self._wkt, srid=self._srid)
+        e3 = WKTElement(self._ewkt, extended=True)
+
+        # No SRID, extended=False (default)
+        r1 = e1.as_wkb()
+        assert isinstance(r1, WKBElement)
+        assert r1.extended is False
+        assert r1.srid == -1
+
+        # With SRID, extended=False — SRID preserved as attribute
+        r2 = e2.as_wkb()
+        assert isinstance(r2, WKBElement)
+        assert r2.extended is False
+        assert r2.srid == self._srid
+
+        # With SRID, extended=True — SRID embedded in binary
+        r3 = e2.as_wkb(extended=True)
+        assert isinstance(r3, WKBElement)
+        assert r3.extended is True
+        assert r3.srid == self._srid
+
+        # EWKT input, extended=True
+        r4 = e3.as_wkb(extended=True)
+        assert isinstance(r4, WKBElement)
+        assert r4.extended is True
+        assert r4.srid == self._srid
+
+        # No SRID, extended=True → falls back to extended=False (no SRID to embed)
+        r5 = e1.as_wkb(extended=True)
+        assert isinstance(r5, WKBElement)
+        assert r5.extended is False
+        assert r5.srid == -1
+
+        # Roundtrip: WKT → WKB → WKT
+        assert r2.as_wkt() == WKTElement(self._wkt, srid=self._srid, extended=False)
+
 
 class TestExtendedWKTElement:
     _srid = 3857  # expected srid
@@ -407,6 +445,45 @@ class TestExtendedWKBElement:
         e8_ewkb = WKBElement(self._hex_ewkb, srid=arbitrary_srid)
         e8_ewkb.data = e8_ewkb.data[:11] + "4" + e8_ewkb.data[12:]
         assert e8.as_ewkb() == e8_ewkb
+
+    def test_as_wkt(self):
+        e1 = WKBElement(self._bin_ewkb)
+        e2 = WKBElement(self._hex_ewkb)
+        e3 = WKBElement(self._hex_wkb)
+
+        # Binary EWKB, extended=False (default) — SRID preserved as attribute
+        r1 = e1.as_wkt()
+        assert isinstance(r1, WKTElement)
+        assert r1.extended is False
+        assert r1.srid == self._srid
+        assert r1.desc == self._wkt
+
+        # Binary EWKB, extended=True — SRID in WKT string
+        r2 = e1.as_wkt(extended=True)
+        assert isinstance(r2, WKTElement)
+        assert r2.extended is True
+        assert r2.srid == self._srid
+        assert r2.desc == f"SRID={self._srid};{self._wkt}"
+
+        # Hex EWKB, extended=False
+        r3 = e2.as_wkt()
+        assert isinstance(r3, WKTElement)
+        assert r3.extended is False
+        assert r3.srid == self._srid
+        assert r3.desc == self._wkt
+
+        # Hex EWKB, extended=True
+        r4 = e2.as_wkt(extended=True)
+        assert isinstance(r4, WKTElement)
+        assert r4.extended is True
+        assert r4.srid == self._srid
+        assert r4.desc == f"SRID={self._srid};{self._wkt}"
+
+        # Plain WKB (no SRID), extended=True → no SRID to embed, falls back to extended=False
+        r5 = e3.as_wkt(extended=True)
+        assert isinstance(r5, WKTElement)
+        assert r5.extended is False
+        assert r5.srid == -1
 
 
 class TestWKBElement:

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,6 +1,8 @@
 import re
 import struct
 from itertools import permutations
+from typing import get_args
+from typing import get_type_hints
 
 import pytest
 from shapely import wkb
@@ -681,15 +683,13 @@ class TestExtendedWKBElement:
         assert result.srid == 4326
         assert result.desc == ("0107000000010000000101000000000000000000f03f0000000000000040")
 
-    def test_as_ewkb_validates_complex_extended_payload_before_returning_original(self):
-        data = struct.pack("<BIII", 1, 0x20000007, 4326, 1)
-        elem = WKBElement(data, srid=4326, extended=True)
-
-        with pytest.raises(ValueError, match="unexpected end of data"):
-            elem.as_ewkb()
-
 
 class TestWKBElement:
+    def test_constructor_data_annotation_includes_runtime_bytearray_support(self):
+        data_annotation = get_type_hints(WKBElement.__init__)["data"]
+
+        assert bytearray in get_args(data_annotation)
+
     def test_desc(self):
         e = WKBElement(b"\x01\x02")
         assert e.desc == "0102"

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -120,37 +120,37 @@ class TestWKTElement:
         assert e3.as_wkt() == e3.as_wkt().as_wkt() == e1
         assert e4.as_wkt() == e4.as_wkt().as_wkt() == e2
 
-    def test_as_wkb(self):
+    def test_as_wkb_as_ewkb(self):
         e1 = WKTElement(self._wkt)
         e2 = WKTElement(self._wkt, srid=self._srid)
         e3 = WKTElement(self._ewkt, extended=True)
 
-        # No SRID, extended=False (default)
+        # No SRID — SRID preserved as attribute
         r1 = e1.as_wkb()
         assert isinstance(r1, WKBElement)
         assert r1.extended is False
         assert r1.srid == -1
 
-        # With SRID, extended=False — SRID preserved as attribute
+        # With SRID — SRID preserved as attribute
         r2 = e2.as_wkb()
         assert isinstance(r2, WKBElement)
         assert r2.extended is False
         assert r2.srid == self._srid
 
-        # With SRID, extended=True — SRID embedded in binary
-        r3 = e2.as_wkb(extended=True)
+        # With SRID — SRID embedded in binary
+        r3 = e2.as_ewkb()
         assert isinstance(r3, WKBElement)
         assert r3.extended is True
         assert r3.srid == self._srid
 
-        # EWKT input, extended=True
-        r4 = e3.as_wkb(extended=True)
+        # EWKT input
+        r4 = e3.as_ewkb()
         assert isinstance(r4, WKBElement)
         assert r4.extended is True
         assert r4.srid == self._srid
 
-        # No SRID, extended=True → falls back to extended=False (no SRID to embed)
-        r5 = e1.as_wkb(extended=True)
+        # No SRID → falls back to plain WKB (no SRID to embed)
+        r5 = e1.as_ewkb()
         assert isinstance(r5, WKBElement)
         assert r5.extended is False
         assert r5.srid == -1
@@ -446,41 +446,41 @@ class TestExtendedWKBElement:
         e8_ewkb.data = e8_ewkb.data[:11] + "4" + e8_ewkb.data[12:]
         assert e8.as_ewkb() == e8_ewkb
 
-    def test_as_wkt(self):
+    def test_as_wkt_as_ewkt_cross(self):
         e1 = WKBElement(self._bin_ewkb)
         e2 = WKBElement(self._hex_ewkb)
         e3 = WKBElement(self._hex_wkb)
 
-        # Binary EWKB, extended=False (default) — SRID preserved as attribute
+        # Binary EWKB — SRID preserved as attribute
         r1 = e1.as_wkt()
         assert isinstance(r1, WKTElement)
         assert r1.extended is False
         assert r1.srid == self._srid
         assert r1.desc == self._wkt
 
-        # Binary EWKB, extended=True — SRID in WKT string
-        r2 = e1.as_wkt(extended=True)
+        # Binary EWKB — SRID in WKT string
+        r2 = e1.as_ewkt()
         assert isinstance(r2, WKTElement)
         assert r2.extended is True
         assert r2.srid == self._srid
         assert r2.desc == f"SRID={self._srid};{self._wkt}"
 
-        # Hex EWKB, extended=False
+        # Hex EWKB plain
         r3 = e2.as_wkt()
         assert isinstance(r3, WKTElement)
         assert r3.extended is False
         assert r3.srid == self._srid
         assert r3.desc == self._wkt
 
-        # Hex EWKB, extended=True
-        r4 = e2.as_wkt(extended=True)
+        # Hex EWKB extended
+        r4 = e2.as_ewkt()
         assert isinstance(r4, WKTElement)
         assert r4.extended is True
         assert r4.srid == self._srid
         assert r4.desc == f"SRID={self._srid};{self._wkt}"
 
-        # Plain WKB (no SRID), extended=True → no SRID to embed, falls back to extended=False
-        r5 = e3.as_wkt(extended=True)
+        # Plain WKB (no SRID) → falls back to plain WKT
+        r5 = e3.as_ewkt()
         assert isinstance(r5, WKTElement)
         assert r5.extended is False
         assert r5.srid == -1

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -181,6 +181,22 @@ class TestWKTElement:
         assert ewkb.srid == 0
         assert ewkb.extended is False
 
+    def test_as_wkt_as_ewkt_use_wkt_only_fast_paths(self, monkeypatch):
+        def fail(*args, **kwargs):
+            raise AssertionError("WKT-only conversion should not use the WKB/WKT converter")
+
+        monkeypatch.setattr(_wkb_wkt, "to_wkt", fail)
+        monkeypatch.setattr(_wkb_wkt, "to_wkt_no_srid", fail)
+
+        wkt = WKTElement(self._wkt, srid=self._srid)
+        ewkt = WKTElement(self._ewkt, extended=True)
+        zero_srid_ewkt = WKTElement(f"SRID=0;{self._wkt}", extended=True)
+
+        assert wkt.as_ewkt() == WKTElement(self._ewkt, extended=True)
+        assert ewkt.as_wkt() == WKTElement(self._wkt, srid=self._srid, extended=False)
+        assert zero_srid_ewkt.as_wkt() == WKTElement(self._wkt, srid=0, extended=False)
+        assert zero_srid_ewkt.as_ewkt() == WKTElement(self._wkt, srid=0, extended=False)
+
 
 class TestExtendedWKTElement:
     _srid = 3857  # expected srid
@@ -581,9 +597,13 @@ class TestExtendedWKBElement:
         data = struct.pack("<BII", 1, 0x20000001, self._srid)
         elem = WKBElement(data, srid=self._srid, extended=True)
 
+        def to_ewkb_header(value, srid):
+            raise AssertionError("simple no-op should not rewrite the EWKB header")
+
         def split_wkb_srid(value):
             raise AssertionError("simple no-op should not full-parse WKB")
 
+        monkeypatch.setattr(_wkb_wkt, "to_ewkb_header", to_ewkb_header)
         monkeypatch.setattr(_wkb_wkt, "split_wkb_srid", split_wkb_srid)
 
         result = elem.as_ewkb()

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -10,6 +10,7 @@ from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import func
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import CompositeElement
 from geoalchemy2.elements import DynamicWKBElement
 from geoalchemy2.elements import DynamicWKTElement
@@ -522,6 +523,100 @@ class TestExtendedWKBElement:
 
         assert elem.srid == self._srid
         assert elem.as_ewkb().desc == elem.desc
+
+    def test_as_ewkb_overrides_already_extended_binary_srid(self):
+        arbitrary_srid = self._srid + 1
+        elem = WKBElement(self._bin_ewkb, srid=arbitrary_srid, extended=True)
+        result = elem.as_ewkb()
+
+        assert result.extended is True
+        assert result.srid == arbitrary_srid
+        assert result.desc == "010100002004000000000000000000f03f0000000000000040"
+
+    def test_as_ewkb_overrides_already_extended_hex_srid(self):
+        arbitrary_srid = self._srid + 1
+        elem = WKBElement(self._hex_ewkb, srid=arbitrary_srid, extended=True)
+        result = elem.as_ewkb()
+
+        assert result.extended is True
+        assert result.srid == arbitrary_srid
+        assert result.desc == "010100002004000000000000000000f03f0000000000000040"
+
+    def test_as_ewkb_overrides_already_extended_big_endian_srid(self):
+        arbitrary_srid = self._srid + 1
+        data = memoryview(struct.pack(">BII2d", 0, 0x20000001, self._srid, 1.0, 2.0))
+        elem = WKBElement(data, srid=arbitrary_srid, extended=True)
+        result = elem.as_ewkb()
+
+        assert result.extended is True
+        assert result.srid == arbitrary_srid
+        assert result.desc == "0020000001000000043ff00000000000004000000000000000"
+
+    def test_as_wkb_uses_explicit_plain_wkb_state_for_plain_values(self):
+        elem = WKBElement(self._bin_wkb, srid=self._srid, extended=False)
+        result = elem.as_wkb()
+
+        assert result.data is self._bin_wkb
+        assert result.extended is False
+        assert result.srid == self._srid
+
+    def test_as_wkb_and_as_ewkb_support_memoryview_bytearray_and_hex(self):
+        binary_elem = WKBElement(memoryview(bytearray(self._bin_ewkb)), extended=True)
+        plain_binary = binary_elem.as_wkb()
+        assert plain_binary.desc == self._hex_wkb
+        assert plain_binary.as_ewkb().desc == self._hex_ewkb
+
+        hex_elem = WKBElement(self._hex_ewkb, extended=True)
+        plain_hex = hex_elem.as_wkb()
+        assert plain_hex.desc == self._hex_wkb
+        assert plain_hex.as_ewkb().desc == self._hex_ewkb
+
+    def test_as_wkb_short_header_preserves_current_failure_behavior(self):
+        elem = WKBElement(b"\x01", srid=self._srid, extended=True)
+
+        with pytest.raises(ValueError, match="too short"):
+            elem.as_wkb()
+
+    def test_as_ewkb_matching_simple_header_uses_header_only_noop(self, monkeypatch):
+        data = struct.pack("<BII", 1, 0x20000001, self._srid)
+        elem = WKBElement(data, srid=self._srid, extended=True)
+
+        def split_wkb_srid(value):
+            raise AssertionError("simple no-op should not full-parse WKB")
+
+        monkeypatch.setattr(_wkb_wkt, "split_wkb_srid", split_wkb_srid)
+
+        result = elem.as_ewkb()
+
+        assert result.extended is True
+        assert result.srid == self._srid
+        assert result.desc == data.hex()
+
+    def test_as_ewkb_falls_back_for_iso_dimensional_wkb(self):
+        data = struct.pack("<BI3d", 1, 1001, 1.0, 2.0, 3.0)
+        elem = WKBElement(data, srid=4326, extended=False)
+        result = elem.as_ewkb()
+
+        assert result.extended is True
+        assert result.srid == 4326
+        assert result.desc == ("01010000a0e6100000000000000000f03f00000000000000400000000000000840")
+
+    def test_as_wkb_falls_back_for_nested_collection_headers(self):
+        child = struct.pack("<BIIdd", 1, 0x20000001, 3857, 1.0, 2.0)
+        data = struct.pack("<BIII", 1, 0x20000007, 4326, 1) + child
+        elem = WKBElement(data, srid=4326, extended=True)
+        result = elem.as_wkb()
+
+        assert result.extended is False
+        assert result.srid == 4326
+        assert result.desc == ("0107000000010000000101000000000000000000f03f0000000000000040")
+
+    def test_as_ewkb_validates_complex_extended_payload_before_returning_original(self):
+        data = struct.pack("<BIII", 1, 0x20000007, 4326, 1)
+        elem = WKBElement(data, srid=4326, extended=True)
+
+        with pytest.raises(ValueError, match="unexpected end of data"):
+            elem.as_ewkb()
 
 
 class TestWKBElement:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,7 @@ import weakref
 import pytest
 from sqlalchemy import Column
 from sqlalchemy import MetaData
+from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import bindparam
 from sqlalchemy.dialects import mysql
@@ -451,6 +452,51 @@ class TestMySQLWKBConstructors:
 
         assert expanded_params[wkb_key] is ewkb
         assert expanded_params[srid_key] is ewkb
+        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb
+
+    @pytest.mark.parametrize(
+        "statement_factory",
+        [
+            insert,
+            update,
+        ],
+    )
+    def test_before_execute_expands_dml_runtime_ewkb_binds_with_other_fixed_values(
+        self,
+        statement_factory,
+    ):
+        class Conn:
+            dialect = mysql.dialect()
+
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("name", String),
+            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = statement_factory(table).values(name="fixed")
+        source_bind = bindparam("geom")
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+        ewkb = bytes.fromhex(EWKB_HEX)
+
+        clauseelement, _, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {"geom": ewkb},
+            {},
+        )
+
+        assert clauseelement is stmt
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+        compiled = clauseelement.compile(
+            dialect=mysql.dialect(),
+            column_keys=list(expanded_params),
+        )
         assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb
 
     def test_before_execute_expands_multivalue_dml_generated_dynamic_ewkb_binds(self):
@@ -1531,6 +1577,33 @@ class TestGeoPackage:
 
         assert self.normalize_sql(compiled_expr) == "GeomFromEWKB(?)"
         assert compiled_expr._bind_processors["wkb"](bytes.fromhex(self.EWKB_HEX)) == self.EWKB_HEX
+
+    def test_geom_from_ewkb_default_geometry_typed_bindparam_uses_ewkb_processor(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb", type_=Geometry(srid=4326)))
+        compiled_expr = expr.compile(dialect=GeoPackageDialect())
+
+        assert self.normalize_sql(compiled_expr) == "GeomFromEWKB(?)"
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(self.EWKB_HEX)) == self.EWKB_HEX
+
+    def test_geom_from_ewkb_insert_bindparam_uses_geometry_bind_processor(self, monkeypatch):
+        def fail_type_coerce(*args, **kwargs):
+            raise AssertionError("GeoPackage EWKB binds should not use compiler type coercion")
+
+        monkeypatch.setattr(_sqlite_admin.expression, "type_coerce", fail_type_coerce)
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=4326, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = insert(table).values(geom=bindparam("geom"))
+
+        compiled_expr = stmt.compile(dialect=GeoPackageDialect())
+
+        assert self.normalize_sql(compiled_expr) == (
+            "INSERT INTO lake (geom) VALUES (GeomFromEWKB(?))"
+        )
+        assert isinstance(compiled_expr.binds["geom"].type, Geometry)
+        assert compiled_expr._bind_processors["geom"](bytes.fromhex(self.EWKB_HEX)) == self.EWKB_HEX
 
     @pytest.mark.parametrize(
         "bindvalue",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1271,9 +1271,29 @@ class TestSQLiteWKBConstructors:
     def test_geom_from_ewkb_compile_omits_srid_parameter(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
 
-        compiled = self.normalize_sql(expr.compile(dialect=sqlite.dialect()))
+        compiled_expr = expr.compile(dialect=sqlite.dialect())
+        compiled = self.normalize_sql(compiled_expr)
 
         assert compiled == "GeomFromEWKB(?)"
+        param_key = next(iter(compiled_expr.params))
+        assert compiled_expr.params == {param_key: bytes.fromhex(EWKB_HEX)}
+        assert compiled_expr._bind_processors[param_key](bytes.fromhex(EWKB_HEX)) == EWKB_HEX
+
+    def test_geom_from_ewkb_literal_compile_uses_hex_text(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"GeomFromEWKB('{EWKB_HEX}')"
+
+    def test_geom_from_ewkb_bindparam_converts_runtime_value_to_hex_text(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"))
+        compiled_expr = expr.compile(dialect=sqlite.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "GeomFromEWKB(?)"
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == EWKB_HEX
 
     def test_bind_processor_preserves_wkbelement_for_wkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
@@ -1324,6 +1344,21 @@ class TestSQLiteWKBConstructors:
             "SRID=4326;POINT(1 2)"
         )
 
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(EWKB_HEX),
+            memoryview(bytes.fromhex(EWKB_HEX)),
+            EWKB_HEX,
+            WKBElement(bytes.fromhex(EWKB_HEX), extended=True),
+            WKBElement(EWKB_HEX, extended=True),
+        ],
+    )
+    def test_bind_processor_converts_ewkb_to_hex_for_ewkb_constructor(self, bindvalue):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert sqlite_type.bind_processor_process(spatial_type, bindvalue) == EWKB_HEX
+
 
 class TestGeoPackage:
     WKB_HEX = WKB_HEX
@@ -1342,7 +1377,7 @@ class TestGeoPackage:
 
         assert compiled == f"GeomFromWKB(unhex('{self.WKB_HEX}'), 4326)"
 
-    def test_geom_from_ewkb_literal_compile_omits_srid(self):
+    def test_geom_from_ewkb_literal_compile_uses_hex_text(self):
         ewkb = bytes.fromhex(self.EWKB_HEX)
         expr = func.ST_GeomFromEWKB(ewkb, type_=Geometry(srid=4326))
 
@@ -1350,15 +1385,28 @@ class TestGeoPackage:
             expr.compile(dialect=GeoPackageDialect(), compile_kwargs={"literal_binds": True})
         )
 
-        assert compiled == f"GeomFromEWKB(unhex('{self.EWKB_HEX}'))"
+        assert compiled == f"GeomFromEWKB('{self.EWKB_HEX}')"
 
     def test_geom_from_ewkb_compile_omits_srid_parameter(self):
         ewkb = bytes.fromhex(self.EWKB_HEX)
         expr = func.ST_GeomFromEWKB(ewkb, type_=Geometry(srid=4326))
 
-        compiled = self.normalize_sql(expr.compile(dialect=GeoPackageDialect()))
+        compiled_expr = expr.compile(dialect=GeoPackageDialect())
+        compiled = self.normalize_sql(compiled_expr)
 
         assert compiled == "GeomFromEWKB(?)"
+        param_key = next(iter(compiled_expr.params))
+        assert compiled_expr.params == {param_key: bytes.fromhex(self.EWKB_HEX)}
+        assert (
+            compiled_expr._bind_processors[param_key](bytes.fromhex(self.EWKB_HEX)) == self.EWKB_HEX
+        )
+
+    def test_geom_from_ewkb_bindparam_converts_runtime_value_to_hex_text(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"))
+        compiled_expr = expr.compile(dialect=GeoPackageDialect())
+
+        assert self.normalize_sql(compiled_expr) == "GeomFromEWKB(?)"
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(self.EWKB_HEX)) == self.EWKB_HEX
 
     @pytest.mark.parametrize(
         "bindvalue",
@@ -1389,11 +1437,10 @@ class TestGeoPackage:
             WKBElement(EWKB_HEX, extended=True),
         ],
     )
-    def test_bind_processor_preserves_ewkb_for_ewkb_constructor(self, bindvalue):
-        ewkb = bytes.fromhex(self.EWKB_HEX)
+    def test_bind_processor_converts_ewkb_to_hex_for_ewkb_constructor(self, bindvalue):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
 
-        assert geopackage_type.bind_processor_process(spatial_type, bindvalue) == ewkb
+        assert geopackage_type.bind_processor_process(spatial_type, bindvalue) == self.EWKB_HEX
 
 
 class TestRaster:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -261,6 +261,27 @@ class TestMySQLWKBConstructors:
 
         assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
 
+    def test_geom_from_wkb_omits_unknown_srid(self):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), -1)
+
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        compiled_literal = expr.compile(
+            dialect=mysql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s)"
+        assert self.normalize_sql(compiled_literal) == f"ST_GeomFromWKB(unhex('{WKB_HEX}'))"
+
+    def test_wkbelement_literal_compile_omits_unknown_srid(self):
+        query = select([func.ST_AsText(WKBElement(bytes.fromhex(WKB_HEX)))])
+
+        compiled = self.normalize_sql(
+            query.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert f"ST_GeomFromWKB(unhex('{WKB_HEX}'))" in compiled
+        assert ", -1" not in compiled
+
     def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
 
@@ -314,6 +335,30 @@ class TestMariaDBWKBConstructors:
         )
 
         assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    def test_geom_from_wkb_omits_unknown_srid(self):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), -1)
+
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+        compiled_literal = expr.compile(
+            dialect=mariadb_dialect.MariaDBDialect(), compile_kwargs={"literal_binds": True}
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s))"
+        assert self.normalize_sql(compiled_literal) == f"ST_GeomFromWKB(unhex('{WKB_HEX}'))"
+
+    def test_wkbelement_literal_compile_omits_unknown_srid(self):
+        query = select([func.ST_AsText(WKBElement(bytes.fromhex(WKB_HEX)))])
+
+        compiled = self.normalize_sql(
+            query.compile(
+                dialect=mariadb_dialect.MariaDBDialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+        assert f"ST_GeomFromWKB(unhex('{WKB_HEX}'))" in compiled
+        assert ", -1" not in compiled
 
     def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,9 +1,11 @@
 import re
+import weakref
 
 import pytest
 from sqlalchemy import Column
 from sqlalchemy import MetaData
 from sqlalchemy import Table
+from sqlalchemy import bindparam
 from sqlalchemy.dialects import mysql
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects import sqlite
@@ -11,6 +13,7 @@ from sqlalchemy.dialects.mysql import mariadb as mariadb_dialect
 from sqlalchemy.sql import func
 from sqlalchemy.sql import insert
 from sqlalchemy.sql import text
+from sqlalchemy.sql import update
 
 from geoalchemy2.admin.dialects import mariadb as _mariadb_admin  # noqa: F401
 from geoalchemy2.admin.dialects import mysql as _mysql_admin  # noqa: F401
@@ -296,6 +299,447 @@ class TestMySQLWKBConstructors:
 
         assert compiled == "ST_GeomFromWKB(%s, 4326)"
 
+    @pytest.mark.parametrize(
+        ("runtime_value", "expected_wkb", "expected_srid"),
+        [
+            (bytes.fromhex(EWKB_HEX), bytes.fromhex(WKB_HEX), 4326),
+            (memoryview(bytes.fromhex(EWKB_HEX)), bytes.fromhex(WKB_HEX), 4326),
+            (EWKB_HEX, bytes.fromhex(WKB_HEX), 4326),
+            (WKBElement(bytes.fromhex(EWKB_HEX), extended=True), bytes.fromhex(WKB_HEX), 4326),
+            (WKBElement(bytes.fromhex(WKB_HEX), srid=3857), bytes.fromhex(WKB_HEX), 3857),
+            (bytes.fromhex(WKB_HEX), bytes.fromhex(WKB_HEX), 0),
+            (None, None, 0),
+        ],
+    )
+    def test_geom_from_ewkb_dynamic_bindparam_processes_runtime_values(
+        self,
+        runtime_value,
+        expected_wkb,
+        expected_srid,
+    ):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(source_bind)
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        compiled = self.normalize_sql(compiled_expr)
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+
+        assert compiled == "ST_GeomFromWKB(%s, %s)"
+        assert set(compiled_expr.params) == {wkb_key, srid_key}
+        wkb_processor = compiled_expr._bind_processors[wkb_key]
+        srid_processor = compiled_expr._bind_processors[srid_key]
+
+        processed_wkb = wkb_processor(runtime_value)
+        assert processed_wkb == expected_wkb
+        assert srid_processor(runtime_value) == expected_srid
+
+    def test_geom_from_ewkb_dynamic_bindparam_uses_type_srid_for_plain_wkb(self):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
+            WKB_HEX
+        )
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(WKB_HEX)) == 3857
+
+    def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_literal(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), 3857)
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 3857)"
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == bytes.fromhex(
+            WKB_HEX
+        )
+
+    def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_bindparam(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), bindparam("srid"))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert set(compiled_expr.params) == {"wkb", "srid"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == bytes.fromhex(
+            WKB_HEX
+        )
+
+    @pytest.mark.parametrize("srid", [0, 3857])
+    def test_geom_from_ewkb_dynamic_bindparam_with_defaulted_srid_bindparam(self, srid):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), bindparam("srid", srid))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert set(compiled_expr.params) == {"wkb", "srid"}
+        assert compiled_expr.params["srid"] == srid
+        assert (
+            compiled_expr.construct_params(params={"wkb": bytes.fromhex(EWKB_HEX), "srid": 4326})[
+                "srid"
+            ]
+            == 4326
+        )
+
+    @pytest.mark.parametrize(
+        ("statement_factory", "param_key"),
+        [
+            (lambda table: insert(table), "geom"),
+            (lambda table: insert(table).values(geom=bindparam("wkb")), "wkb"),
+            (lambda table: update(table).values(geom=bindparam("wkb")), "wkb"),
+            (
+                lambda table: update(table).ordered_values((table.c.geom, bindparam("wkb"))),
+                "wkb",
+            ),
+        ],
+    )
+    def test_before_execute_expands_dml_generated_dynamic_ewkb_binds(
+        self,
+        statement_factory,
+        param_key,
+    ):
+        class Conn:
+            dialect = mysql.dialect()
+
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = statement_factory(table)
+        source_bind = bindparam(param_key)
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+        ewkb = bytes.fromhex(EWKB_HEX)
+
+        _, _, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {param_key: ewkb},
+            {},
+        )
+        compiled = stmt.compile(dialect=mysql.dialect())
+
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb
+
+    def test_before_execute_expands_multivalue_dml_generated_dynamic_ewkb_binds(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = insert(table).values(
+            [
+                {"geom": bindparam("wkb1")},
+                {"geom": bindparam("wkb2")},
+            ]
+        )
+        ewkb1 = bytes.fromhex(EWKB_HEX)
+        ewkb2 = memoryview(bytes.fromhex(EWKB_HEX))
+        params = {"wkb1": ewkb1, "wkb2": ewkb2}
+
+        clauseelement, _, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            params,
+            {},
+        )
+        compiled = clauseelement.compile(dialect=mysql.dialect())
+
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            bindparam("wkb1"),
+            default_srid=3857,
+        )
+        assert expanded_params[wkb_key] is ewkb1
+        assert expanded_params[srid_key] is ewkb1
+        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb1
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            bindparam("wkb2"),
+            default_srid=3857,
+        )
+        assert expanded_params[wkb_key] is ewkb2
+        assert expanded_params[srid_key] is ewkb2
+        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb2
+        assert self.normalize_sql(compiled).count("ST_GeomFromWKB") == 2
+
+    def test_before_execute_expands_dynamic_ewkb_params_without_mutating_source(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+        ewkb = bytes.fromhex(EWKB_HEX)
+        params = {"wkb": ewkb}
+
+        _, multiparams, expanded_params = _mysql_admin.before_execute(Conn(), stmt, (), params, {})
+
+        assert multiparams == ()
+        assert params == {"wkb": ewkb}
+        assert expanded_params["wkb"] is ewkb
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+
+    def test_before_execute_skips_non_wkb_runtime_params(self, monkeypatch):
+        class Conn:
+            dialect = mysql.dialect()
+
+        def collect_source_binds(clauseelement):
+            raise AssertionError("non-WKB params should not traverse the statement")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_collect_mysql_dynamic_ewkb_source_binds",
+            collect_source_binds,
+        )
+        stmt = select([bindparam("id")])
+        params = {"id": 1}
+
+        result = _mysql_admin.before_execute(Conn(), stmt, (), params, {})
+
+        assert result == (stmt, (), params)
+
+    def test_before_execute_skips_text_clause(self, monkeypatch):
+        class Conn:
+            dialect = mysql.dialect()
+
+        def collect_source_binds(clauseelement):
+            raise AssertionError("text clauses should not traverse the statement")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_collect_mysql_dynamic_ewkb_source_binds",
+            collect_source_binds,
+        )
+        stmt = text("SELECT :wkb")
+        params = {"wkb": bytes.fromhex(EWKB_HEX)}
+
+        result = _mysql_admin.before_execute(Conn(), stmt, (), params, {})
+
+        assert result == (stmt, (), params)
+
+    def test_before_execute_caches_dynamic_bind_discovery(self, monkeypatch):
+        class Conn:
+            dialect = mysql.dialect()
+
+        calls = []
+
+        def collect_source_binds(clauseelement):
+            calls.append(clauseelement)
+            return ()
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_MYSQL_DYNAMIC_EWKB_SOURCE_BIND_CACHE",
+            weakref.WeakKeyDictionary(),
+        )
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_collect_mysql_dynamic_ewkb_source_binds_uncached",
+            collect_source_binds,
+        )
+        stmt = select([bindparam("blob")])
+        params = {"blob": None}
+
+        _mysql_admin.before_execute(Conn(), stmt, (), params, {})
+        _mysql_admin.before_execute(Conn(), stmt, (), params, {})
+
+        assert calls == [stmt]
+
+    def test_before_execute_avoids_statement_compile_for_named_bindparam(self, monkeypatch):
+        class Conn:
+            dialect = mysql.dialect()
+
+        def compile_bind_name_map(clauseelement, dialect):
+            raise AssertionError("named bindparams should not need a statement compile")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_compile_mysql_statement_bind_name_map",
+            compile_bind_name_map,
+        )
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        ewkb = bytes.fromhex(EWKB_HEX)
+
+        _, _, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {"wkb": ewkb},
+            {},
+        )
+
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+
+    def test_before_execute_wraps_multivalue_dml_without_runtime_params(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = insert(table).values([{"geom": bindparam("wkb", bytes.fromhex(EWKB_HEX))}])
+
+        clauseelement, multiparams, params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {},
+            {},
+        )
+
+        assert multiparams == ()
+        assert params == {}
+        assert "ST_GeomFromWKB" in self.normalize_sql(
+            clauseelement.compile(dialect=mysql.dialect())
+        )
+
+    def test_before_execute_expands_defaulted_user_bindparam_override(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        source_bind = bindparam("wkb", bytes.fromhex(WKB_HEX))
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+        ewkb = bytes.fromhex(EWKB_HEX)
+
+        _, _, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {"wkb": ewkb},
+            {},
+        )
+
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+
+    def test_before_execute_expands_dynamic_ewkb_multiparams(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+        ewkb = bytes.fromhex(EWKB_HEX)
+        wkb = bytes.fromhex(WKB_HEX)
+        multiparams = ({"wkb": ewkb}, {"wkb": wkb})
+
+        _, expanded_multiparams, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            multiparams,
+            {},
+            {},
+        )
+
+        assert expanded_params == {}
+        assert multiparams == ({"wkb": ewkb}, {"wkb": wkb})
+        assert expanded_multiparams[0][wkb_key] is ewkb
+        assert expanded_multiparams[0][srid_key] is ewkb
+        assert expanded_multiparams[1][wkb_key] is wkb
+        assert expanded_multiparams[1][srid_key] is wkb
+
+    def test_before_execute_expands_dynamic_ewkb_unique_compiled_name(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        source_bind = bindparam("wkb", unique=True)
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        bind_name_map = _mysql_admin._compile_mysql_statement_bind_name_map(stmt, Conn.dialect)
+        compiled_name = bind_name_map[_mysql_admin._mysql_dynamic_ewkb_bind_identifier(source_bind)]
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+        ewkb = bytes.fromhex(EWKB_HEX)
+
+        _, _, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {compiled_name: ewkb},
+            {},
+        )
+
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+
+    def test_before_execute_expands_reused_dynamic_ewkb_bind_for_distinct_default_srids(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        source_bind = bindparam("wkb")
+        stmt = select(
+            [
+                func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=4326)),
+                func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857)),
+            ]
+        )
+        wkb_key_4326, srid_key_4326 = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=4326,
+        )
+        wkb_key_3857, srid_key_3857 = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+        ewkb = bytes.fromhex(EWKB_HEX)
+
+        _, _, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {"wkb": ewkb},
+            {},
+        )
+
+        assert expanded_params[wkb_key_4326] is ewkb
+        assert expanded_params[srid_key_4326] is ewkb
+        assert expanded_params[wkb_key_3857] is ewkb
+        assert expanded_params[srid_key_3857] is ewkb
+
+    def test_before_execute_leaves_already_expanded_dynamic_ewkb_params_unchanged(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+        ewkb = bytes.fromhex(EWKB_HEX)
+        params = {"wkb": ewkb, wkb_key: ewkb, srid_key: ewkb}
+
+        _, multiparams, expanded_params = _mysql_admin.before_execute(Conn(), stmt, (), params, {})
+
+        assert multiparams == ()
+        assert expanded_params is params
+
+    def test_before_execute_ignores_auto_constructor_ewkb_bind(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        stmt = select([func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))])
+        params = {}
+
+        _, multiparams, expanded_params = _mysql_admin.before_execute(Conn(), stmt, (), params, {})
+
+        assert multiparams == ()
+        assert expanded_params is params
+
     def test_bind_processor_converts_wkbelement_for_wkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
 
@@ -373,6 +817,197 @@ class TestMariaDBWKBConstructors:
         compiled = self.normalize_sql(expr.compile(dialect=mariadb_dialect.MariaDBDialect()))
 
         assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+
+    @pytest.mark.parametrize(
+        ("runtime_value", "expected_wkb", "expected_srid"),
+        [
+            (bytes.fromhex(EWKB_HEX), WKB_HEX, 4326),
+            (memoryview(bytes.fromhex(EWKB_HEX)), WKB_HEX, 4326),
+            (EWKB_HEX, WKB_HEX, 4326),
+            (WKBElement(bytes.fromhex(EWKB_HEX), extended=True), WKB_HEX, 4326),
+            (WKBElement(bytes.fromhex(WKB_HEX), srid=3857), WKB_HEX, 3857),
+            (bytes.fromhex(WKB_HEX), WKB_HEX, 0),
+            (None, None, 0),
+        ],
+    )
+    def test_geom_from_ewkb_dynamic_bindparam_processes_runtime_values(
+        self,
+        runtime_value,
+        expected_wkb,
+        expected_srid,
+    ):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(source_bind)
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+        compiled = self.normalize_sql(compiled_expr)
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+
+        assert compiled == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert set(compiled_expr.params) == {wkb_key, srid_key}
+        wkb_processor = compiled_expr._bind_processors[wkb_key]
+        srid_processor = compiled_expr._bind_processors[srid_key]
+
+        assert wkb_processor(runtime_value) == expected_wkb
+        assert srid_processor(runtime_value) == expected_srid
+
+    def test_geom_from_ewkb_dynamic_bindparam_uses_type_srid_for_plain_wkb(self):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(WKB_HEX)) == WKB_HEX
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(WKB_HEX)) == 3857
+
+    def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_literal(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), 3857)
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 3857)"
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == WKB_HEX
+
+    def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_bindparam(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), bindparam("srid"))
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert set(compiled_expr.params) == {"wkb", "srid"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == WKB_HEX
+
+    @pytest.mark.parametrize("srid", [0, 3857])
+    def test_geom_from_ewkb_dynamic_bindparam_with_defaulted_srid_bindparam(self, srid):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), bindparam("srid", srid))
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert set(compiled_expr.params) == {"wkb", "srid"}
+        assert compiled_expr.params["srid"] == srid
+        assert (
+            compiled_expr.construct_params(params={"wkb": bytes.fromhex(EWKB_HEX), "srid": 4326})[
+                "srid"
+            ]
+            == 4326
+        )
+
+    @pytest.mark.parametrize(
+        ("statement_factory", "param_key"),
+        [
+            (lambda table: insert(table), "geom"),
+            (lambda table: insert(table).values(geom=bindparam("wkb")), "wkb"),
+            (lambda table: update(table).values(geom=bindparam("wkb")), "wkb"),
+            (
+                lambda table: update(table).ordered_values((table.c.geom, bindparam("wkb"))),
+                "wkb",
+            ),
+        ],
+    )
+    def test_before_execute_expands_dml_generated_dynamic_ewkb_binds(
+        self,
+        statement_factory,
+        param_key,
+    ):
+        class Conn:
+            dialect = mariadb_dialect.MariaDBDialect()
+
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = statement_factory(table)
+        source_bind = bindparam(param_key)
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+        ewkb = bytes.fromhex(EWKB_HEX)
+
+        _, _, expanded_params = _mariadb_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            {param_key: ewkb},
+            {},
+        )
+        compiled = stmt.compile(dialect=mariadb_dialect.MariaDBDialect())
+
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb
+
+    def test_before_execute_expands_multivalue_dml_generated_dynamic_ewkb_binds(self):
+        class Conn:
+            dialect = mariadb_dialect.MariaDBDialect()
+
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = insert(table).values(
+            [
+                {"geom": bindparam("wkb1")},
+                {"geom": bindparam("wkb2")},
+            ]
+        )
+        ewkb1 = bytes.fromhex(EWKB_HEX)
+        ewkb2 = memoryview(bytes.fromhex(EWKB_HEX))
+        params = {"wkb1": ewkb1, "wkb2": ewkb2}
+
+        clauseelement, _, expanded_params = _mariadb_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            params,
+            {},
+        )
+        compiled = clauseelement.compile(dialect=mariadb_dialect.MariaDBDialect())
+
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            bindparam("wkb1"),
+            default_srid=3857,
+        )
+        assert expanded_params[wkb_key] is ewkb1
+        assert expanded_params[srid_key] is ewkb1
+        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb1
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            bindparam("wkb2"),
+            default_srid=3857,
+        )
+        assert expanded_params[wkb_key] is ewkb2
+        assert expanded_params[srid_key] is ewkb2
+        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb2
+        assert self.normalize_sql(compiled).count("ST_GeomFromWKB") == 2
+
+    def test_before_execute_expands_dynamic_ewkb_params_for_mariadb(self):
+        class Conn:
+            dialect = mariadb_dialect.MariaDBDialect()
+
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+        ewkb = bytes.fromhex(EWKB_HEX)
+        params = {"wkb": ewkb}
+
+        _, multiparams, expanded_params = _mariadb_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            params,
+            {},
+        )
+
+        assert multiparams == ()
+        assert params == {"wkb": ewkb}
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
 
     def test_bind_processor_converts_wkbelement_for_wkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1283,6 +1283,16 @@ class TestMariaDBWKBConstructors:
     def normalize_sql(sql):
         return re.sub(r"\s+", " ", str(sql)).strip()
 
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(WKB_HEX),
+            bytes.fromhex(EWKB_HEX),
+        ],
+    )
+    def test_cast_converts_bytearray_to_hex_wkb_for_unhex_parameters(self, bindvalue):
+        assert _mariadb_admin._cast(bytearray(bindvalue)) == WKB_HEX
+
     def test_geom_from_ewkb_compiles_to_supported_wkb_constructor(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,12 +15,14 @@ from sqlalchemy.sql import insert
 from sqlalchemy.sql import text
 from sqlalchemy.sql import update
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.admin.dialects import mariadb as _mariadb_admin  # noqa: F401
 from geoalchemy2.admin.dialects import mysql as _mysql_admin  # noqa: F401
 from geoalchemy2.admin.dialects import postgresql as _postgresql_admin  # noqa: F401
 from geoalchemy2.admin.dialects import sqlite as _sqlite_admin  # noqa: F401
 from geoalchemy2.admin.dialects.geopackage import GeoPackageDialect
 from geoalchemy2.elements import WKBElement
+from geoalchemy2.elements import WKTElement
 from geoalchemy2.exc import ArgumentError
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
@@ -40,6 +42,13 @@ EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
 def eq_sql(a, b):
     a = re.sub(r"[\n\t]", "", str(a))
     assert a == b
+
+
+def test_split_wkb_srid_treats_strings_as_hex_wkb_only():
+    assert _wkb_wkt.split_wkb_srid(EWKB_HEX) == ("POINT (1 2)", 4326)
+
+    with pytest.raises(ValueError):
+        _wkb_wkt.split_wkb_srid("SRID=4326;POINT (1 2)")
 
 
 @pytest.fixture
@@ -747,6 +756,21 @@ class TestMySQLWKBConstructors:
             spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
         ) == bytes.fromhex(WKB_HEX)
 
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [bytes.fromhex(WKB_HEX), memoryview(bytes.fromhex(WKB_HEX))],
+    )
+    def test_bind_processor_converts_raw_wkb_for_text_constructor(self, bindvalue):
+        spatial_type = Geometry(srid=4326)
+
+        assert mysql_type.bind_processor_process(spatial_type, bindvalue) == "POINT (1 2)"
+
+    def test_bind_processor_validates_raw_ewkb_srid(self):
+        spatial_type = Geometry(srid=3857)
+
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mysql_type.bind_processor_process(spatial_type, bytes.fromhex(EWKB_HEX))
+
     def test_bind_processor_strips_ewkb_for_ewkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
 
@@ -1029,6 +1053,41 @@ class TestMariaDBWKBConstructors:
             == WKB_HEX
         )
 
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [bytes.fromhex(WKB_HEX), memoryview(bytes.fromhex(WKB_HEX))],
+    )
+    def test_bind_processor_converts_raw_wkb_for_text_constructor(self, bindvalue):
+        spatial_type = Geometry(srid=4326)
+
+        assert mariadb_type.bind_processor_process(spatial_type, bindvalue) == "POINT (1 2)"
+
+    def test_bind_processor_validates_raw_ewkb_srid(self):
+        spatial_type = Geometry(srid=3857)
+
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mariadb_type.bind_processor_process(spatial_type, bytes.fromhex(EWKB_HEX))
+
+    def test_bind_processor_normalizes_multipoint_wkt_for_wkbelement_and_raw_wkb(self):
+        spatial_type = Geometry(geometry_type="MULTIPOINT", srid=4326)
+        wkb = WKTElement("MULTIPOINT ((1 2), (3 4))").as_wkb().data
+
+        assert (
+            mariadb_type.bind_processor_process(spatial_type, WKBElement(wkb, srid=4326))
+            == "MULTIPOINT (1 2, 3 4)"
+        )
+        assert mariadb_type.bind_processor_process(spatial_type, wkb) == ("MULTIPOINT (1 2, 3 4)")
+
+    def test_bind_processor_preserves_empty_multipoint_for_wkbelement_and_raw_wkb(self):
+        spatial_type = Geometry(geometry_type="MULTIPOINT", srid=4326)
+        wkb = WKTElement("MULTIPOINT EMPTY").as_wkb().data
+
+        assert (
+            mariadb_type.bind_processor_process(spatial_type, WKBElement(wkb, srid=4326))
+            == "MULTIPOINT EMPTY"
+        )
+        assert mariadb_type.bind_processor_process(spatial_type, wkb) == "MULTIPOINT EMPTY"
+
 
 class TestPostgreSQLWKBConstructors:
     @staticmethod
@@ -1049,6 +1108,30 @@ class TestPostgreSQLWKBConstructors:
             spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
         ) == bytes.fromhex(WKB_HEX)
 
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [bytes.fromhex(WKB_HEX), memoryview(bytes.fromhex(WKB_HEX))],
+    )
+    def test_bind_processor_converts_raw_wkb_for_text_constructor(self, bindvalue):
+        spatial_type = Geometry(srid=4326)
+
+        assert (
+            postgresql_type.bind_processor_process(spatial_type, bindvalue)
+            == "SRID=4326;POINT (1 2)"
+        )
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [bytes.fromhex(EWKB_HEX), memoryview(bytes.fromhex(EWKB_HEX))],
+    )
+    def test_bind_processor_preserves_raw_ewkb_srid_for_unknown_column(self, bindvalue):
+        spatial_type = Geometry()
+
+        assert (
+            postgresql_type.bind_processor_process(spatial_type, bindvalue)
+            == "SRID=4326;POINT (1 2)"
+        )
+
 
 class TestSQLiteWKBConstructors:
     @staticmethod
@@ -1068,6 +1151,28 @@ class TestSQLiteWKBConstructors:
         assert sqlite_type.bind_processor_process(
             spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
         ) == bytes.fromhex(WKB_HEX)
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [bytes.fromhex(WKB_HEX), memoryview(bytes.fromhex(WKB_HEX))],
+    )
+    def test_bind_processor_converts_raw_wkb_for_text_constructor(self, bindvalue):
+        spatial_type = Geometry(srid=4326)
+
+        assert sqlite_type.bind_processor_process(spatial_type, bindvalue) == (
+            "SRID=4326;POINT(1 2)"
+        )
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [bytes.fromhex(EWKB_HEX), memoryview(bytes.fromhex(EWKB_HEX))],
+    )
+    def test_bind_processor_preserves_raw_ewkb_srid_for_unknown_column(self, bindvalue):
+        spatial_type = Geometry()
+
+        assert sqlite_type.bind_processor_process(spatial_type, bindvalue) == (
+            "SRID=4326;POINT(1 2)"
+        )
 
 
 class TestGeoPackage:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,16 +4,34 @@ import pytest
 from sqlalchemy import Column
 from sqlalchemy import MetaData
 from sqlalchemy import Table
+from sqlalchemy.dialects import mysql
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import sqlite
+from sqlalchemy.dialects.mysql import mariadb as mariadb_dialect
 from sqlalchemy.sql import func
 from sqlalchemy.sql import insert
 from sqlalchemy.sql import text
 
+from geoalchemy2.admin.dialects import mariadb as _mariadb_admin  # noqa: F401
+from geoalchemy2.admin.dialects import mysql as _mysql_admin  # noqa: F401
+from geoalchemy2.admin.dialects import postgresql as _postgresql_admin  # noqa: F401
+from geoalchemy2.admin.dialects import sqlite as _sqlite_admin  # noqa: F401
+from geoalchemy2.admin.dialects.geopackage import GeoPackageDialect
+from geoalchemy2.elements import WKBElement
 from geoalchemy2.exc import ArgumentError
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
+from geoalchemy2.types.dialects import geopackage as geopackage_type
+from geoalchemy2.types.dialects import mariadb as mariadb_type
+from geoalchemy2.types.dialects import mysql as mysql_type
+from geoalchemy2.types.dialects import postgresql as postgresql_type
+from geoalchemy2.types.dialects import sqlite as sqlite_type
 
 from . import select
+
+WKB_HEX = "0101000000000000000000f03f0000000000000040"
+EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
 
 
 def eq_sql(a, b):
@@ -218,6 +236,229 @@ class TestGeometryCollection:
     def test_get_col_spec(self):
         g = Geometry(geometry_type="GEOMETRYCOLLECTION", srid=900913)
         assert g.get_col_spec() == "geometry(GEOMETRYCOLLECTION,900913)"
+
+
+class TestMySQLWKBConstructors:
+    @staticmethod
+    def normalize_sql(sql):
+        return re.sub(r"\s+", " ", str(sql)).strip()
+
+    def test_geom_from_ewkb_compiles_to_supported_wkb_constructor(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        compiled = self.normalize_sql(compiled_expr)
+
+        assert compiled == "ST_GeomFromWKB(%s, 4326)"
+        assert compiled_expr.params == {"param_1": bytes.fromhex(WKB_HEX)}
+
+    def test_geom_from_ewkb_literal_compile_strips_ewkb_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
+
+        compiled = self.normalize_sql(expr.compile(dialect=mysql.dialect()))
+
+        assert compiled == "ST_GeomFromWKB(%s, 4326)"
+
+    def test_geom_from_ewkb_uses_embedded_srid_without_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))
+
+        compiled = self.normalize_sql(expr.compile(dialect=mysql.dialect()))
+
+        assert compiled == "ST_GeomFromWKB(%s, 4326)"
+
+    def test_bind_processor_converts_wkbelement_for_wkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
+
+        assert mysql_type.bind_processor_process(
+            spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
+        ) == bytes.fromhex(WKB_HEX)
+
+    def test_bind_processor_strips_ewkb_for_ewkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert mysql_type.bind_processor_process(
+            spatial_type, WKBElement(bytes.fromhex(EWKB_HEX), extended=True)
+        ) == bytes.fromhex(WKB_HEX)
+
+
+class TestMariaDBWKBConstructors:
+    @staticmethod
+    def normalize_sql(sql):
+        return re.sub(r"\s+", " ", str(sql)).strip()
+
+    def test_geom_from_ewkb_compiles_to_supported_wkb_constructor(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+        compiled = self.normalize_sql(compiled_expr)
+
+        assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+        assert compiled_expr.params == {"param_1": WKB_HEX}
+
+    def test_geom_from_ewkb_literal_compile_strips_ewkb_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(
+                dialect=mariadb_dialect.MariaDBDialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
+
+        compiled = self.normalize_sql(expr.compile(dialect=mariadb_dialect.MariaDBDialect()))
+
+        assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+
+    def test_geom_from_ewkb_uses_embedded_srid_without_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))
+
+        compiled = self.normalize_sql(expr.compile(dialect=mariadb_dialect.MariaDBDialect()))
+
+        assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+
+    def test_bind_processor_converts_wkbelement_for_wkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
+
+        assert (
+            mariadb_type.bind_processor_process(
+                spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
+            )
+            == WKB_HEX
+        )
+
+    def test_bind_processor_strips_ewkb_for_ewkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert (
+            mariadb_type.bind_processor_process(
+                spatial_type, WKBElement(bytes.fromhex(EWKB_HEX), extended=True)
+            )
+            == WKB_HEX
+        )
+
+
+class TestPostgreSQLWKBConstructors:
+    @staticmethod
+    def normalize_sql(sql):
+        return re.sub(r"\s+", " ", str(sql)).strip()
+
+    def test_geom_from_ewkb_compile_omits_srid_parameter(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(expr.compile(dialect=postgresql.dialect()))
+
+        assert compiled == "ST_GeomFromEWKB(%(ST_GeomFromEWKB_1)s)"
+
+    def test_bind_processor_preserves_wkbelement_for_wkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
+
+        assert postgresql_type.bind_processor_process(
+            spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
+        ) == bytes.fromhex(WKB_HEX)
+
+
+class TestSQLiteWKBConstructors:
+    @staticmethod
+    def normalize_sql(sql):
+        return re.sub(r"\s+", " ", str(sql)).strip()
+
+    def test_geom_from_ewkb_compile_omits_srid_parameter(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(expr.compile(dialect=sqlite.dialect()))
+
+        assert compiled == "GeomFromEWKB(?)"
+
+    def test_bind_processor_preserves_wkbelement_for_wkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
+
+        assert sqlite_type.bind_processor_process(
+            spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
+        ) == bytes.fromhex(WKB_HEX)
+
+
+class TestGeoPackage:
+    WKB_HEX = WKB_HEX
+    EWKB_HEX = EWKB_HEX
+
+    def normalize_sql(self, sql):
+        return re.sub(r"\s+", " ", str(sql)).strip()
+
+    def test_geom_from_wkb_literal_compile_keeps_srid(self):
+        wkb = bytes.fromhex(self.WKB_HEX)
+        expr = func.ST_GeomFromWKB(wkb, 4326)
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=GeoPackageDialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"GeomFromWKB(unhex('{self.WKB_HEX}'), 4326)"
+
+    def test_geom_from_ewkb_literal_compile_omits_srid(self):
+        ewkb = bytes.fromhex(self.EWKB_HEX)
+        expr = func.ST_GeomFromEWKB(ewkb, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=GeoPackageDialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"GeomFromEWKB(unhex('{self.EWKB_HEX}'))"
+
+    def test_geom_from_ewkb_compile_omits_srid_parameter(self):
+        ewkb = bytes.fromhex(self.EWKB_HEX)
+        expr = func.ST_GeomFromEWKB(ewkb, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(expr.compile(dialect=GeoPackageDialect()))
+
+        assert compiled == "GeomFromEWKB(?)"
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(WKB_HEX),
+            memoryview(bytes.fromhex(WKB_HEX)),
+            WKB_HEX,
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKBElement(WKB_HEX),
+        ],
+    )
+    def test_bind_processor_preserves_wkb_for_wkb_constructor(self, bindvalue):
+        wkb = bytes.fromhex(self.WKB_HEX)
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
+
+        assert geopackage_type.bind_processor_process(spatial_type, bindvalue) == wkb
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(EWKB_HEX),
+            memoryview(bytes.fromhex(EWKB_HEX)),
+            EWKB_HEX,
+            WKBElement(
+                bytes.fromhex(EWKB_HEX),
+                extended=True,
+            ),
+            WKBElement(EWKB_HEX, extended=True),
+        ],
+    )
+    def test_bind_processor_preserves_ewkb_for_ewkb_constructor(self, bindvalue):
+        ewkb = bytes.fromhex(self.EWKB_HEX)
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert geopackage_type.bind_processor_process(spatial_type, bindvalue) == ewkb
 
 
 class TestRaster:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -875,6 +875,16 @@ class TestMySQLWKBConstructors:
             spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
         ) == bytes.fromhex(WKB_HEX)
 
+    def test_bind_processor_converts_hex_wkb_string_for_wkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
+
+        assert mysql_type.bind_processor_process(spatial_type, WKB_HEX) == bytes.fromhex(WKB_HEX)
+
+    def test_bind_processor_strips_hex_ewkb_string_for_ewkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert mysql_type.bind_processor_process(spatial_type, EWKB_HEX) == bytes.fromhex(WKB_HEX)
+
     @pytest.mark.parametrize(
         "bindvalue",
         [bytes.fromhex(WKB_HEX), memoryview(bytes.fromhex(WKB_HEX))],
@@ -1259,6 +1269,11 @@ class TestMariaDBWKBConstructors:
             == WKB_HEX
         )
 
+    def test_bind_processor_converts_hex_wkb_string_for_wkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
+
+        assert mariadb_type.bind_processor_process(spatial_type, WKB_HEX) == WKB_HEX
+
     def test_bind_processor_strips_ewkb_for_ewkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
 
@@ -1268,6 +1283,11 @@ class TestMariaDBWKBConstructors:
             )
             == WKB_HEX
         )
+
+    def test_bind_processor_strips_hex_ewkb_string_for_ewkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert mariadb_type.bind_processor_process(spatial_type, EWKB_HEX) == WKB_HEX
 
     @pytest.mark.parametrize(
         "bindvalue",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,9 +3,11 @@ import weakref
 
 import pytest
 from sqlalchemy import Column
+from sqlalchemy import Integer
 from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import bindparam
+from sqlalchemy import column
 from sqlalchemy.dialects import mysql
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects import sqlite
@@ -24,9 +26,12 @@ from geoalchemy2.admin.dialects.geopackage import GeoPackageDialect
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.exc import ArgumentError
+from geoalchemy2.types import CompositeType
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
+from geoalchemy2.types import GeometryDump
 from geoalchemy2.types import Raster
+from geoalchemy2.types import SummaryStats
 from geoalchemy2.types.dialects import geopackage as geopackage_type
 from geoalchemy2.types.dialects import mariadb as mariadb_type
 from geoalchemy2.types.dialects import mysql as mysql_type
@@ -38,6 +43,19 @@ from . import select
 WKB_HEX = "0101000000000000000000f03f0000000000000040"
 EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
 ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
+
+
+class CustomCompositeType(CompositeType):
+    typemap = {"value": Integer}
+
+    cache_ok = True
+
+
+class BrokenReprCompositeType(CompositeType):
+    typemap = {}
+
+    def __repr__(self) -> str:
+        raise AssertionError("__repr__ should not be used for missing composite attributes")
 
 
 def eq_sql(a, b):
@@ -104,6 +122,30 @@ class TestGeometry:
     def test_get_col_spec_geometrym(self):
         g = Geometry(geometry_type="GEOMETRYM", srid=900913)
         assert g.get_col_spec() == "geometry(GEOMETRYM,900913)"
+
+    @pytest.mark.parametrize(
+        ("spatial_type", "expected"),
+        [
+            (Geometry(), "Geometry()"),
+            (
+                Geometry(geometry_type="POINT", srid=4326),
+                "Geometry(geometry_type='POINT', srid=4326)",
+            ),
+            (
+                Geometry(
+                    geometry_type=None,
+                    srid=4326,
+                    spatial_index=False,
+                    nullable=False,
+                ),
+                ("Geometry(geometry_type=None, srid=4326, spatial_index=False, nullable=False)"),
+            ),
+        ],
+    )
+    def test_repr_is_stable(self, spatial_type, expected):
+        assert repr(spatial_type) == expected
+        recreated = eval(expected, {"Geometry": Geometry})
+        assert repr(recreated) == expected
 
     def test_check_ctor_args_srid_not_enforced(self):
         with pytest.warns(UserWarning):
@@ -201,6 +243,12 @@ class TestGeography:
             "SELECT ST_AsBinary(name.geom) AS geom FROM "
             '(SELECT "table".geom AS geom FROM "table") AS name',
         )
+
+    def test_repr_is_stable(self):
+        geography = Geography(geometry_type="POINT", srid=4326)
+        assert repr(geography) == "Geography(geometry_type='POINT', srid=4326)"
+        recreated = eval(repr(geography), {"Geography": Geography})
+        assert repr(recreated) == repr(geography)
 
 
 class TestPoint:
@@ -1490,6 +1538,18 @@ class TestRaster:
         eq_sql(i, 'INSERT INTO "table" (rast) VALUES (raster(:rast))')
         assert i.compile().params == {"rast": b"\x01\x02"}
 
+    @pytest.mark.parametrize(
+        ("raster", "expected"),
+        [
+            (Raster(), "Raster()"),
+            (Raster(spatial_index=False), "Raster(spatial_index=False)"),
+        ],
+    )
+    def test_repr_is_stable(self, raster, expected):
+        assert repr(raster) == expected
+        recreated = eval(expected, {"Raster": Raster})
+        assert repr(recreated) == expected
+
     def test_function_call(self, raster_table):
         s = select([raster_table.c.rast.ST_Height()])
         eq_sql(s, 'SELECT ST_Height("table".rast) AS "ST_Height_1" FROM "table"')
@@ -1504,3 +1564,35 @@ class TestCompositeType:
         s = select([func.ST_Dump(geography_table.c.geom).geom.label("geom")])
 
         eq_sql(s, 'SELECT ST_AsEWKB((ST_Dump("table".geom)).geom) AS geom FROM "table"')
+
+    @pytest.mark.parametrize(
+        ("type_", "expected", "namespace"),
+        [
+            (GeometryDump(), "GeometryDump()", {"GeometryDump": GeometryDump}),
+            (SummaryStats(), "SummaryStats()", {"SummaryStats": SummaryStats}),
+            (
+                CustomCompositeType(),
+                "CustomCompositeType()",
+                {"CustomCompositeType": CustomCompositeType},
+            ),
+        ],
+    )
+    def test_repr_is_stable(self, type_, expected, namespace):
+        assert repr(type_) == expected
+        recreated = eval(expected, namespace)
+        assert repr(recreated) == expected
+
+    def test_custom_type_can_access_known_attributes(self):
+        stats = column("stats", CustomCompositeType())
+        query = select([stats.value.label("value")])
+
+        eq_sql(query, "SELECT (stats).value AS value")
+
+    def test_missing_attribute_does_not_use_type_repr(self):
+        stats = column("stats", BrokenReprCompositeType())
+
+        with pytest.raises(
+            AttributeError,
+            match="Type 'BrokenReprCompositeType' doesn't have an attribute: 'missing'",
+        ):
+            stats.comparator.missing  # noqa: B018

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,11 +3,9 @@ import weakref
 
 import pytest
 from sqlalchemy import Column
-from sqlalchemy import Integer
 from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import bindparam
-from sqlalchemy import column
 from sqlalchemy.dialects import mysql
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects import sqlite
@@ -26,12 +24,9 @@ from geoalchemy2.admin.dialects.geopackage import GeoPackageDialect
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.types import CompositeType
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
-from geoalchemy2.types import GeometryDump
 from geoalchemy2.types import Raster
-from geoalchemy2.types import SummaryStats
 from geoalchemy2.types.dialects import geopackage as geopackage_type
 from geoalchemy2.types.dialects import mariadb as mariadb_type
 from geoalchemy2.types.dialects import mysql as mysql_type
@@ -43,19 +38,6 @@ from . import select
 WKB_HEX = "0101000000000000000000f03f0000000000000040"
 EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
 ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
-
-
-class CustomCompositeType(CompositeType):
-    typemap = {"value": Integer}
-
-    cache_ok = True
-
-
-class BrokenReprCompositeType(CompositeType):
-    typemap = {}
-
-    def __repr__(self) -> str:
-        raise AssertionError("__repr__ should not be used for missing composite attributes")
 
 
 def eq_sql(a, b):
@@ -122,30 +104,6 @@ class TestGeometry:
     def test_get_col_spec_geometrym(self):
         g = Geometry(geometry_type="GEOMETRYM", srid=900913)
         assert g.get_col_spec() == "geometry(GEOMETRYM,900913)"
-
-    @pytest.mark.parametrize(
-        ("spatial_type", "expected"),
-        [
-            (Geometry(), "Geometry()"),
-            (
-                Geometry(geometry_type="POINT", srid=4326),
-                "Geometry(geometry_type='POINT', srid=4326)",
-            ),
-            (
-                Geometry(
-                    geometry_type=None,
-                    srid=4326,
-                    spatial_index=False,
-                    nullable=False,
-                ),
-                ("Geometry(geometry_type=None, srid=4326, spatial_index=False, nullable=False)"),
-            ),
-        ],
-    )
-    def test_repr_is_stable(self, spatial_type, expected):
-        assert repr(spatial_type) == expected
-        recreated = eval(expected, {"Geometry": Geometry})
-        assert repr(recreated) == expected
 
     def test_check_ctor_args_srid_not_enforced(self):
         with pytest.warns(UserWarning):
@@ -243,12 +201,6 @@ class TestGeography:
             "SELECT ST_AsBinary(name.geom) AS geom FROM "
             '(SELECT "table".geom AS geom FROM "table") AS name',
         )
-
-    def test_repr_is_stable(self):
-        geography = Geography(geometry_type="POINT", srid=4326)
-        assert repr(geography) == "Geography(geometry_type='POINT', srid=4326)"
-        recreated = eval(repr(geography), {"Geography": Geography})
-        assert repr(recreated) == repr(geography)
 
 
 class TestPoint:
@@ -1538,18 +1490,6 @@ class TestRaster:
         eq_sql(i, 'INSERT INTO "table" (rast) VALUES (raster(:rast))')
         assert i.compile().params == {"rast": b"\x01\x02"}
 
-    @pytest.mark.parametrize(
-        ("raster", "expected"),
-        [
-            (Raster(), "Raster()"),
-            (Raster(spatial_index=False), "Raster(spatial_index=False)"),
-        ],
-    )
-    def test_repr_is_stable(self, raster, expected):
-        assert repr(raster) == expected
-        recreated = eval(expected, {"Raster": Raster})
-        assert repr(recreated) == expected
-
     def test_function_call(self, raster_table):
         s = select([raster_table.c.rast.ST_Height()])
         eq_sql(s, 'SELECT ST_Height("table".rast) AS "ST_Height_1" FROM "table"')
@@ -1564,35 +1504,3 @@ class TestCompositeType:
         s = select([func.ST_Dump(geography_table.c.geom).geom.label("geom")])
 
         eq_sql(s, 'SELECT ST_AsEWKB((ST_Dump("table".geom)).geom) AS geom FROM "table"')
-
-    @pytest.mark.parametrize(
-        ("type_", "expected", "namespace"),
-        [
-            (GeometryDump(), "GeometryDump()", {"GeometryDump": GeometryDump}),
-            (SummaryStats(), "SummaryStats()", {"SummaryStats": SummaryStats}),
-            (
-                CustomCompositeType(),
-                "CustomCompositeType()",
-                {"CustomCompositeType": CustomCompositeType},
-            ),
-        ],
-    )
-    def test_repr_is_stable(self, type_, expected, namespace):
-        assert repr(type_) == expected
-        recreated = eval(expected, namespace)
-        assert repr(recreated) == expected
-
-    def test_custom_type_can_access_known_attributes(self):
-        stats = column("stats", CustomCompositeType())
-        query = select([stats.value.label("value")])
-
-        eq_sql(query, "SELECT (stats).value AS value")
-
-    def test_missing_attribute_does_not_use_type_repr(self):
-        stats = column("stats", BrokenReprCompositeType())
-
-        with pytest.raises(
-            AttributeError,
-            match="Type 'BrokenReprCompositeType' doesn't have an attribute: 'missing'",
-        ):
-            stats.comparator.missing  # noqa: B018

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1295,6 +1295,43 @@ class TestPostgreSQLWKBConstructors:
             == "SRID=4326;POINT (1 2)"
         )
 
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(EWKB_HEX),
+            bytearray(bytes.fromhex(EWKB_HEX)),
+            memoryview(bytes.fromhex(EWKB_HEX)),
+        ],
+    )
+    def test_bind_processor_preserves_matching_raw_ewkb_srid_for_fixed_column(self, bindvalue):
+        spatial_type = Geometry(srid=4326)
+
+        assert (
+            postgresql_type.bind_processor_process(spatial_type, bindvalue)
+            == "SRID=4326;POINT (1 2)"
+        )
+
+    def test_bind_processor_rejects_mismatched_raw_ewkb_srid_for_fixed_column(self):
+        spatial_type = Geometry(srid=3857)
+
+        with pytest.raises(ArgumentError) as exc:
+            postgresql_type.bind_processor_process(spatial_type, bytes.fromhex(EWKB_HEX))
+
+        assert str(exc.value) == (
+            "The SRID (4326) of the supplied value is different from the one of the column (3857)"
+        )
+
+    def test_bind_processor_uses_column_srid_for_zero_srid_raw_ewkb(self):
+        spatial_type = Geometry(srid=3857)
+
+        assert (
+            postgresql_type.bind_processor_process(
+                spatial_type,
+                bytes.fromhex(ZERO_SRID_EWKB_HEX),
+            )
+            == "SRID=3857;POINT (1 2)"
+        )
+
 
 class TestSQLiteWKBConstructors:
     @staticmethod

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -343,36 +343,65 @@ class TestMySQLWKBConstructors:
         assert processed_wkb == expected_wkb
         assert srid_processor(runtime_value) == expected_srid
 
-    def test_geom_from_ewkb_dynamic_bindparam_uses_type_srid_for_plain_wkb(self):
+    def test_geom_from_ewkb_fixed_srid_bindparam_uses_literal_srid(self):
         source_bind = bindparam("wkb")
         expr = func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))
         compiled_expr = expr.compile(dialect=mysql.dialect())
-        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
-            source_bind,
-            default_srid=3857,
-        )
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
-        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 3857)"
+        assert set(compiled_expr.params) == {"wkb"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
             WKB_HEX
         )
-        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(WKB_HEX)) == 3857
+        assert compiled_expr._bind_processors["wkb"](
+            _wkb_wkt.to_wkb(bytes.fromhex(WKB_HEX), srid=3857)
+        ) == bytes.fromhex(WKB_HEX)
+        assert compiled_expr._bind_processors["wkb"](
+            WKBElement(bytes.fromhex(WKB_HEX), srid=3857)
+        ) == bytes.fromhex(WKB_HEX)
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX))
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled_expr._bind_processors["wkb"](WKBElement(bytes.fromhex(WKB_HEX), srid=4326))
 
-    def test_geom_from_ewkb_dynamic_bindparam_treats_zero_srid_wkbelement_as_unknown(self):
+    def test_geom_from_ewkb_fixed_srid_bindparam_accepts_zero_srid(self):
         source_bind = bindparam("wkb")
         expr = func.ST_GeomFromEWKB(
             source_bind,
             type_=Geometry(srid=3857, from_text="ST_GeomFromEWKB"),
         )
         compiled_expr = expr.compile(dialect=mysql.dialect())
-        _, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
-            source_bind,
-            default_srid=3857,
-        )
 
-        srid_processor = compiled_expr._bind_processors[srid_key]
-        assert srid_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == 3857
-        assert srid_processor(bytes.fromhex(ZERO_SRID_EWKB_HEX)) == 3857
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 3857)"
+        assert wkb_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == bytes.fromhex(WKB_HEX)
+        assert wkb_processor(bytes.fromhex(ZERO_SRID_EWKB_HEX)) == bytes.fromhex(WKB_HEX)
+
+    def test_geom_from_ewkb_fixed_srid_dml_column_bind_skips_type_coerce(self, monkeypatch):
+        def coerce_ewkb_bind_clause_to_wkb(*args, **kwargs):
+            raise AssertionError("fixed-SRID DML column binds should use the column processor")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_coerce_ewkb_bind_clause_to_wkb",
+            coerce_ewkb_bind_clause_to_wkb,
+        )
+        table = Table(
+            "geom_table",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=4326, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        stmt = insert(table).values([{"geom": bytes.fromhex(EWKB_HEX)} for _ in range(4)])
+
+        compiled = stmt.compile(dialect=mysql.dialect())
+        sql = self.normalize_sql(compiled)
+
+        assert sql.count("ST_GeomFromWKB(%s, 4326)") == 4
+        assert sql.count("%s") == 4
+        assert len(compiled.params) == 4
 
     def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_literal(self):
         expr = func.ST_GeomFromEWKB(bindparam("wkb"), 3857)
@@ -431,13 +460,13 @@ class TestMySQLWKBConstructors:
         table = Table(
             "lake",
             MetaData(),
-            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+            Column("geom", Geometry(srid=0, from_text="ST_GeomFromEWKB")),
         )
         stmt = statement_factory(table)
         source_bind = bindparam(param_key)
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=3857,
+            default_srid=0,
         )
         ewkb = bytes.fromhex(EWKB_HEX)
 
@@ -461,7 +490,7 @@ class TestMySQLWKBConstructors:
             update,
         ],
     )
-    def test_before_execute_expands_dml_runtime_ewkb_binds_with_other_fixed_values(
+    def test_before_execute_does_not_expand_fixed_srid_dml_runtime_ewkb_binds(
         self,
         statement_factory,
     ):
@@ -491,13 +520,15 @@ class TestMySQLWKBConstructors:
         )
 
         assert clauseelement is stmt
-        assert expanded_params[wkb_key] is ewkb
-        assert expanded_params[srid_key] is ewkb
+        assert expanded_params == {"geom": ewkb}
+        assert wkb_key not in expanded_params
+        assert srid_key not in expanded_params
         compiled = clauseelement.compile(
             dialect=mysql.dialect(),
             column_keys=list(expanded_params),
         )
-        assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb
+        assert "ST_GeomFromWKB(%s, 3857)" in self.normalize_sql(compiled)
+        assert compiled.construct_params(params=expanded_params)["geom"] is ewkb
 
     def test_before_execute_expands_multivalue_dml_generated_dynamic_ewkb_binds(self):
         class Conn:
@@ -506,7 +537,7 @@ class TestMySQLWKBConstructors:
         table = Table(
             "lake",
             MetaData(),
-            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+            Column("geom", Geometry(srid=0, from_text="ST_GeomFromEWKB")),
         )
         stmt = insert(table).values(
             [
@@ -529,21 +560,21 @@ class TestMySQLWKBConstructors:
 
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             bindparam("wkb1"),
-            default_srid=3857,
+            default_srid=0,
         )
         assert expanded_params[wkb_key] is ewkb1
         assert expanded_params[srid_key] is ewkb1
         assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb1
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             bindparam("wkb2"),
-            default_srid=3857,
+            default_srid=0,
         )
         assert expanded_params[wkb_key] is ewkb2
         assert expanded_params[srid_key] is ewkb2
         assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb2
         assert self.normalize_sql(compiled).count("ST_GeomFromWKB") == 2
 
-    def test_before_execute_expands_dynamic_ewkb_params_without_mutating_source(self):
+    def test_before_execute_does_not_expand_fixed_srid_ewkb_params(self):
         class Conn:
             dialect = mysql.dialect()
 
@@ -560,9 +591,9 @@ class TestMySQLWKBConstructors:
 
         assert multiparams == ()
         assert params == {"wkb": ewkb}
-        assert expanded_params["wkb"] is ewkb
-        assert expanded_params[wkb_key] is ewkb
-        assert expanded_params[srid_key] is ewkb
+        assert expanded_params is params
+        assert wkb_key not in expanded_params
+        assert srid_key not in expanded_params
 
     def test_before_execute_skips_non_wkb_runtime_params(self, monkeypatch):
         class Conn:
@@ -807,25 +838,22 @@ class TestMySQLWKBConstructors:
         assert expanded_params[wkb_key] is ewkb
         assert expanded_params[srid_key] is ewkb
 
-    def test_before_execute_expands_reused_dynamic_ewkb_bind_for_distinct_default_srids(self):
+    def test_before_execute_expands_reused_ewkb_bind_only_for_unknown_srid(self):
         class Conn:
             dialect = mysql.dialect()
 
         source_bind = bindparam("wkb")
         stmt = select(
             [
-                func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=4326)),
                 func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857)),
+                func.ST_GeomFromEWKB(source_bind),
             ]
         )
-        wkb_key_4326, srid_key_4326 = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
-            source_bind,
-            default_srid=4326,
-        )
-        wkb_key_3857, srid_key_3857 = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+        fixed_wkb_key, fixed_srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
             default_srid=3857,
         )
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
         ewkb = bytes.fromhex(EWKB_HEX)
 
         _, _, expanded_params = _mysql_admin.before_execute(
@@ -836,10 +864,11 @@ class TestMySQLWKBConstructors:
             {},
         )
 
-        assert expanded_params[wkb_key_4326] is ewkb
-        assert expanded_params[srid_key_4326] is ewkb
-        assert expanded_params[wkb_key_3857] is ewkb
-        assert expanded_params[srid_key_3857] is ewkb
+        assert expanded_params["wkb"] is ewkb
+        assert expanded_params[wkb_key] is ewkb
+        assert expanded_params[srid_key] is ewkb
+        assert fixed_wkb_key not in expanded_params
+        assert fixed_srid_key not in expanded_params
 
     def test_before_execute_leaves_already_expanded_dynamic_ewkb_params_unchanged(self):
         class Conn:
@@ -952,6 +981,103 @@ class TestMySQLWKBConstructors:
             spatial_type, WKBElement(bytes.fromhex(EWKB_HEX), extended=True)
         ) == bytes.fromhex(WKB_HEX)
 
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(EWKB_HEX),
+            memoryview(bytes.fromhex(EWKB_HEX)),
+            EWKB_HEX,
+            WKBElement(bytes.fromhex(EWKB_HEX), extended=True),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=0),
+            bytes.fromhex(ZERO_SRID_EWKB_HEX),
+            bytes.fromhex(WKB_HEX),
+        ],
+    )
+    def test_bind_processor_strips_ewkb_constructor_values_for_fixed_srid(self, bindvalue):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert mysql_type.bind_processor_process(spatial_type, bindvalue) == bytes.fromhex(WKB_HEX)
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(EWKB_HEX),
+            EWKB_HEX,
+            WKBElement(bytes.fromhex(EWKB_HEX), srid=3857, extended=True),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+        ],
+    )
+    def test_bind_processor_validates_ewkb_constructor_fixed_srid(self, bindvalue):
+        spatial_type = Geometry(srid=3857, from_text="ST_GeomFromEWKB")
+
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mysql_type.bind_processor_process(spatial_type, bindvalue)
+
+    def test_fixed_srid_dml_bind_processor_strips_and_validates_ewkb_constructor(self):
+        table = Table(
+            "geom_table",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=4326, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        compiled = insert(table).values(geom=bindparam("geom")).compile(dialect=mysql.dialect())
+        wkb_processor = compiled._bind_processors["geom"]
+
+        assert wkb_processor(bytes.fromhex(EWKB_HEX)) == bytes.fromhex(WKB_HEX)
+        assert wkb_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == bytes.fromhex(WKB_HEX)
+
+        mismatch_table = Table(
+            "geom_table_mismatch",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=3857, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        mismatch_compiled = (
+            insert(mismatch_table).values(geom=bindparam("geom")).compile(dialect=mysql.dialect())
+        )
+        mismatch_processor = mismatch_compiled._bind_processors["geom"]
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mismatch_processor(bytes.fromhex(EWKB_HEX))
+
+    def test_fixed_srid_dml_fast_path_respects_dynamic_split_disable_option(
+        self,
+        monkeypatch,
+    ):
+        def coerce_ewkb_bind_clause_to_wkb(*args, **kwargs):
+            raise AssertionError("fixed-SRID DML column binds should use the column processor")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_coerce_ewkb_bind_clause_to_wkb",
+            coerce_ewkb_bind_clause_to_wkb,
+        )
+        table = Table(
+            "geom_table",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=3857, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        stmt = (
+            insert(table)
+            .values(geom=bindparam("geom"))
+            .execution_options(**{_mysql_admin._MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION: True})
+        )
+
+        compiled = stmt.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled) == (
+            "INSERT INTO geom_table (geom) VALUES (ST_GeomFromWKB(%s, 3857))"
+        )
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled._bind_processors["geom"](bytes.fromhex(EWKB_HEX))
+
 
 class TestMariaDBWKBConstructors:
     @staticmethod
@@ -1048,34 +1174,87 @@ class TestMariaDBWKBConstructors:
         assert wkb_processor(runtime_value) == expected_wkb
         assert srid_processor(runtime_value) == expected_srid
 
-    def test_geom_from_ewkb_dynamic_bindparam_uses_type_srid_for_plain_wkb(self):
+    def test_geom_from_ewkb_fixed_srid_bindparam_uses_literal_srid(self):
         source_bind = bindparam("wkb")
         expr = func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))
         compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
-        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
-            source_bind,
-            default_srid=3857,
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 3857)"
+        assert set(compiled_expr.params) == {"wkb"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(WKB_HEX)) == WKB_HEX
+        assert (
+            compiled_expr._bind_processors["wkb"](
+                _wkb_wkt.to_wkb(bytes.fromhex(WKB_HEX), srid=3857)
+            )
+            == WKB_HEX
         )
+        assert (
+            compiled_expr._bind_processors["wkb"](WKBElement(bytes.fromhex(WKB_HEX), srid=3857))
+            == WKB_HEX
+        )
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX))
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled_expr._bind_processors["wkb"](WKBElement(bytes.fromhex(WKB_HEX), srid=4326))
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
-        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(WKB_HEX)) == WKB_HEX
-        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(WKB_HEX)) == 3857
-
-    def test_geom_from_ewkb_dynamic_bindparam_treats_zero_srid_wkbelement_as_unknown(self):
+    def test_geom_from_ewkb_fixed_srid_bindparam_accepts_zero_srid(self):
         source_bind = bindparam("wkb")
         expr = func.ST_GeomFromEWKB(
             source_bind,
             type_=Geometry(srid=3857, from_text="ST_GeomFromEWKB"),
         )
         compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
-        _, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
-            source_bind,
-            default_srid=3857,
-        )
 
-        srid_processor = compiled_expr._bind_processors[srid_key]
-        assert srid_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == 3857
-        assert srid_processor(bytes.fromhex(ZERO_SRID_EWKB_HEX)) == 3857
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 3857)"
+        assert wkb_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == WKB_HEX
+        assert wkb_processor(bytes.fromhex(ZERO_SRID_EWKB_HEX)) == WKB_HEX
+
+    def test_geom_from_ewkb_multivalue_fixed_srid_uses_one_bind_per_row(self):
+        class CustomGeometry(Geometry):
+            from_text = "ST_GeomFromEWKB"
+            as_binary = "ST_AsEWKB"
+            cache_ok = True
+
+        table = Table(
+            "geom_table",
+            MetaData(),
+            Column("geom", CustomGeometry(geometry_type="POINT", srid=4326)),
+        )
+        stmt = insert(table).values([{"geom": bytes.fromhex(EWKB_HEX)} for _ in range(4)])
+
+        compiled = stmt.compile(dialect=mariadb_dialect.MariaDBDialect())
+        sql = self.normalize_sql(compiled)
+
+        assert sql.count("ST_GeomFromWKB(unhex(%s), 4326)") == 4
+        assert sql.count("%s") == 4
+        assert len(compiled.params) == 4
+
+    def test_geom_from_ewkb_fixed_srid_dml_column_bind_skips_type_coerce(self, monkeypatch):
+        def coerce_ewkb_bind_clause_to_wkb(*args, **kwargs):
+            raise AssertionError("fixed-SRID DML column binds should use the column processor")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_coerce_ewkb_bind_clause_to_wkb",
+            coerce_ewkb_bind_clause_to_wkb,
+        )
+        table = Table(
+            "geom_table",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=4326, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        stmt = insert(table).values([{"geom": bytes.fromhex(EWKB_HEX)} for _ in range(4)])
+
+        compiled = stmt.compile(dialect=mariadb_dialect.MariaDBDialect())
+        sql = self.normalize_sql(compiled)
+
+        assert sql.count("ST_GeomFromWKB(unhex(%s), 4326)") == 4
+        assert sql.count("%s") == 4
+        assert len(compiled.params) == 4
 
     def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_literal(self):
         expr = func.ST_GeomFromEWKB(bindparam("wkb"), 3857)
@@ -1130,13 +1309,13 @@ class TestMariaDBWKBConstructors:
         table = Table(
             "lake",
             MetaData(),
-            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+            Column("geom", Geometry(srid=0, from_text="ST_GeomFromEWKB")),
         )
         stmt = statement_factory(table)
         source_bind = bindparam(param_key)
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=3857,
+            default_srid=0,
         )
         ewkb = bytes.fromhex(EWKB_HEX)
 
@@ -1160,7 +1339,7 @@ class TestMariaDBWKBConstructors:
         table = Table(
             "lake",
             MetaData(),
-            Column("geom", Geometry(srid=3857, from_text="ST_GeomFromEWKB")),
+            Column("geom", Geometry(srid=0, from_text="ST_GeomFromEWKB")),
         )
         stmt = insert(table).values(
             [
@@ -1183,21 +1362,21 @@ class TestMariaDBWKBConstructors:
 
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             bindparam("wkb1"),
-            default_srid=3857,
+            default_srid=0,
         )
         assert expanded_params[wkb_key] is ewkb1
         assert expanded_params[srid_key] is ewkb1
         assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb1
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             bindparam("wkb2"),
-            default_srid=3857,
+            default_srid=0,
         )
         assert expanded_params[wkb_key] is ewkb2
         assert expanded_params[srid_key] is ewkb2
         assert compiled.construct_params(params=expanded_params)[wkb_key] is ewkb2
         assert self.normalize_sql(compiled).count("ST_GeomFromWKB") == 2
 
-    def test_before_execute_expands_dynamic_ewkb_params_for_mariadb(self):
+    def test_before_execute_does_not_expand_fixed_srid_ewkb_params_for_mariadb(self):
         class Conn:
             dialect = mariadb_dialect.MariaDBDialect()
 
@@ -1220,8 +1399,9 @@ class TestMariaDBWKBConstructors:
 
         assert multiparams == ()
         assert params == {"wkb": ewkb}
-        assert expanded_params[wkb_key] is ewkb
-        assert expanded_params[srid_key] is ewkb
+        assert expanded_params is params
+        assert wkb_key not in expanded_params
+        assert srid_key not in expanded_params
 
     def test_before_execute_expands_none_dynamic_ewkb_params_for_mariadb_without_compile(
         self,
@@ -1239,11 +1419,8 @@ class TestMariaDBWKBConstructors:
             compile_bind_name_map,
         )
         source_bind = bindparam("wkb")
-        stmt = select([func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))])
-        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
-            source_bind,
-            default_srid=3857,
-        )
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
         params = {"wkb": None}
 
         _, multiparams, expanded_params = _mariadb_admin.before_execute(
@@ -1288,6 +1465,109 @@ class TestMariaDBWKBConstructors:
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
 
         assert mariadb_type.bind_processor_process(spatial_type, EWKB_HEX) == WKB_HEX
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(EWKB_HEX),
+            memoryview(bytes.fromhex(EWKB_HEX)),
+            EWKB_HEX,
+            WKBElement(bytes.fromhex(EWKB_HEX), extended=True),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=0),
+            bytes.fromhex(ZERO_SRID_EWKB_HEX),
+            bytes.fromhex(WKB_HEX),
+        ],
+    )
+    def test_bind_processor_strips_ewkb_constructor_values_for_fixed_srid(self, bindvalue):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert mariadb_type.bind_processor_process(spatial_type, bindvalue) == WKB_HEX
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            bytes.fromhex(EWKB_HEX),
+            EWKB_HEX,
+            WKBElement(bytes.fromhex(EWKB_HEX), srid=3857, extended=True),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+        ],
+    )
+    def test_bind_processor_validates_ewkb_constructor_fixed_srid(self, bindvalue):
+        spatial_type = Geometry(srid=3857, from_text="ST_GeomFromEWKB")
+
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mariadb_type.bind_processor_process(spatial_type, bindvalue)
+
+    def test_fixed_srid_dml_bind_processor_strips_and_validates_ewkb_constructor(self):
+        table = Table(
+            "geom_table",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=4326, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        compiled = (
+            insert(table)
+            .values(geom=bindparam("geom"))
+            .compile(dialect=mariadb_dialect.MariaDBDialect())
+        )
+        wkb_processor = compiled._bind_processors["geom"]
+
+        assert wkb_processor(bytes.fromhex(EWKB_HEX)) == WKB_HEX
+        assert wkb_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == WKB_HEX
+
+        mismatch_table = Table(
+            "geom_table_mismatch",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=3857, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        mismatch_compiled = (
+            insert(mismatch_table)
+            .values(geom=bindparam("geom"))
+            .compile(dialect=mariadb_dialect.MariaDBDialect())
+        )
+        mismatch_processor = mismatch_compiled._bind_processors["geom"]
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mismatch_processor(bytes.fromhex(EWKB_HEX))
+
+    def test_fixed_srid_dml_fast_path_respects_dynamic_split_disable_option(
+        self,
+        monkeypatch,
+    ):
+        def coerce_ewkb_bind_clause_to_wkb(*args, **kwargs):
+            raise AssertionError("fixed-SRID DML column binds should use the column processor")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_coerce_ewkb_bind_clause_to_wkb",
+            coerce_ewkb_bind_clause_to_wkb,
+        )
+        table = Table(
+            "geom_table",
+            MetaData(),
+            Column(
+                "geom",
+                Geometry(geometry_type="POINT", srid=3857, from_text="ST_GeomFromEWKB"),
+            ),
+        )
+        stmt = (
+            insert(table)
+            .values(geom=bindparam("geom"))
+            .execution_options(**{_mysql_admin._MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION: True})
+        )
+
+        compiled = stmt.compile(dialect=mariadb_dialect.MariaDBDialect())
+
+        assert self.normalize_sql(compiled) == (
+            "INSERT INTO geom_table (geom) VALUES (ST_GeomFromWKB(unhex(%s), 3857))"
+        )
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled._bind_processors["geom"](bytes.fromhex(EWKB_HEX))
 
     @pytest.mark.parametrize(
         "bindvalue",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,6 +37,7 @@ from . import select
 
 WKB_HEX = "0101000000000000000000f03f0000000000000040"
 EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
+ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
 
 
 def eq_sql(a, b):
@@ -355,6 +356,22 @@ class TestMySQLWKBConstructors:
             WKB_HEX
         )
         assert compiled_expr._bind_processors[srid_key](bytes.fromhex(WKB_HEX)) == 3857
+
+    def test_geom_from_ewkb_dynamic_bindparam_treats_zero_srid_wkbelement_as_unknown(self):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(
+            source_bind,
+            type_=Geometry(srid=3857, from_text="ST_GeomFromEWKB"),
+        )
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        _, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+
+        srid_processor = compiled_expr._bind_processors[srid_key]
+        assert srid_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == 3857
+        assert srid_processor(bytes.fromhex(ZERO_SRID_EWKB_HEX)) == 3857
 
     def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_literal(self):
         expr = func.ST_GeomFromEWKB(bindparam("wkb"), 3857)
@@ -960,6 +977,22 @@ class TestMariaDBWKBConstructors:
         assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
         assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(WKB_HEX)) == WKB_HEX
         assert compiled_expr._bind_processors[srid_key](bytes.fromhex(WKB_HEX)) == 3857
+
+    def test_geom_from_ewkb_dynamic_bindparam_treats_zero_srid_wkbelement_as_unknown(self):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(
+            source_bind,
+            type_=Geometry(srid=3857, from_text="ST_GeomFromEWKB"),
+        )
+        compiled_expr = expr.compile(dialect=mariadb_dialect.MariaDBDialect())
+        _, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+
+        srid_processor = compiled_expr._bind_processors[srid_key]
+        assert srid_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=0)) == 3857
+        assert srid_processor(bytes.fromhex(ZERO_SRID_EWKB_HEX)) == 3857
 
     def test_geom_from_ewkb_dynamic_bindparam_with_explicit_srid_literal(self):
         expr = func.ST_GeomFromEWKB(bindparam("wkb"), 3857)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -34,6 +34,7 @@ from geoalchemy2.types.dialects import mariadb as mariadb_type
 from geoalchemy2.types.dialects import mysql as mysql_type
 from geoalchemy2.types.dialects import postgresql as postgresql_type
 from geoalchemy2.types.dialects import sqlite as sqlite_type
+from geoalchemy2.types.dialects.common import as_binary_ewkb
 from geoalchemy2.types.dialects.common import as_wkb_hex
 
 from . import select
@@ -79,6 +80,31 @@ def test_is_known_srid(srid, expected):
 )
 def test_as_wkb_hex_preserves_known_wkbelement_srid(bindvalue, expected):
     assert as_wkb_hex(bindvalue, strip_srid=False) == expected
+
+
+@pytest.mark.parametrize(
+    ("bindvalue", "column_srid", "expected"),
+    [
+        (WKBElement(bytes.fromhex(WKB_HEX), srid=4326), None, bytes.fromhex(EWKB_HEX)),
+        (bytes.fromhex(WKB_HEX), 4326, bytes.fromhex(EWKB_HEX)),
+        (memoryview(bytes.fromhex(WKB_HEX)), 4326, bytes.fromhex(EWKB_HEX)),
+        (bytes.fromhex(EWKB_HEX), None, bytes.fromhex(EWKB_HEX)),
+    ],
+)
+def test_as_binary_ewkb_embeds_or_preserves_known_srid(bindvalue, column_srid, expected):
+    assert as_binary_ewkb(bindvalue, column_srid=column_srid) == expected
+
+
+@pytest.mark.parametrize(
+    "bindvalue",
+    [
+        WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+        bytes.fromhex(EWKB_HEX),
+    ],
+)
+def test_as_binary_ewkb_validates_column_srid(bindvalue):
+    with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+        as_binary_ewkb(bindvalue, column_srid=3857)
 
 
 @pytest.fixture
@@ -296,6 +322,23 @@ class TestMySQLWKBConstructors:
 
     def test_geom_from_ewkb_literal_compile_strips_ewkb_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKTElement("POINT (1 2)", srid=4326).as_wkb(),
+            WKTElement("POINT (1 2)", srid=4326).as_ewkb(),
+        ],
+    )
+    def test_geom_from_ewkb_literal_compile_unwraps_wkbelement_constructor(self, value):
+        expr = func.ST_GeomFromEWKB(value, type_=Geometry(srid=4326))
 
         compiled = self.normalize_sql(
             expr.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
@@ -1225,6 +1268,26 @@ class TestMariaDBWKBConstructors:
 
         assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKTElement("POINT (1 2)", srid=4326).as_wkb(),
+            WKTElement("POINT (1 2)", srid=4326).as_ewkb(),
+        ],
+    )
+    def test_geom_from_ewkb_literal_compile_unwraps_wkbelement_constructor(self, value):
+        expr = func.ST_GeomFromEWKB(value, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(
+                dialect=mariadb_dialect.MariaDBDialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
     def test_geom_from_wkb_omits_unknown_srid(self):
         expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), -1)
 
@@ -1878,12 +1941,61 @@ class TestPostgreSQLWKBConstructors:
 
         assert compiled == "ST_GeomFromEWKB(%(ST_GeomFromEWKB_1)s)"
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKTElement("POINT (1 2)", srid=4326).as_wkb(),
+            WKTElement("POINT (1 2)", srid=4326).as_ewkb(),
+        ],
+    )
+    def test_geom_from_ewkb_literal_compile_unwraps_wkbelement_constructor(self, value):
+        expr = func.ST_GeomFromEWKB(value, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"ST_GeomFromEWKB(decode('{EWKB_HEX}', 'hex'))"
+
+    def test_geom_from_ewkb_literal_compile_preserves_bound_none(self):
+        expr = func.ST_GeomFromEWKB(
+            bindparam("wkb", None),
+            type_=Geometry(srid=4326),
+        )
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == "ST_GeomFromEWKB(decode(NULL, 'hex'))"
+
     def test_bind_processor_preserves_wkbelement_for_wkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
 
         assert postgresql_type.bind_processor_process(
             spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
         ) == bytes.fromhex(WKB_HEX)
+
+    def test_bind_processor_embeds_wkbelement_srid_for_ewkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert postgresql_type.bind_processor_process(
+            spatial_type, WKBElement(bytes.fromhex(WKB_HEX), srid=4326)
+        ) == bytes.fromhex(EWKB_HEX)
+
+    def test_bind_processor_embeds_column_srid_for_raw_wkb_ewkb_constructor(self):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert postgresql_type.bind_processor_process(
+            spatial_type, bytes.fromhex(WKB_HEX)
+        ) == bytes.fromhex(EWKB_HEX)
+
+    def test_bind_processor_validates_ewkb_constructor_fixed_srid(self):
+        spatial_type = Geometry(srid=3857, from_text="ST_GeomFromEWKB")
+
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            postgresql_type.bind_processor_process(spatial_type, bytes.fromhex(EWKB_HEX))
 
     @pytest.mark.parametrize(
         "bindvalue",
@@ -1971,6 +2083,35 @@ class TestSQLiteWKBConstructors:
         )
 
         assert compiled == f"GeomFromEWKB('{EWKB_HEX}')"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKTElement("POINT (1 2)", srid=4326).as_wkb(),
+            WKTElement("POINT (1 2)", srid=4326).as_ewkb(),
+        ],
+    )
+    def test_geom_from_ewkb_literal_compile_unwraps_wkbelement_constructor(self, value):
+        expr = func.ST_GeomFromEWKB(value, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"GeomFromEWKB('{EWKB_HEX}')"
+
+    def test_geom_from_ewkb_literal_compile_preserves_bound_none(self):
+        expr = func.ST_GeomFromEWKB(
+            bindparam("wkb", None),
+            type_=Geometry(srid=4326),
+        )
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == "GeomFromEWKB(NULL)"
 
     def test_geom_from_ewkb_bindparam_converts_runtime_value_to_hex_text(self):
         expr = func.ST_GeomFromEWKB(bindparam("wkb"))
@@ -2071,6 +2212,35 @@ class TestGeoPackage:
         )
 
         assert compiled == f"GeomFromEWKB('{self.EWKB_HEX}')"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKTElement("POINT (1 2)", srid=4326).as_wkb(),
+            WKTElement("POINT (1 2)", srid=4326).as_ewkb(),
+        ],
+    )
+    def test_geom_from_ewkb_literal_compile_unwraps_wkbelement_constructor(self, value):
+        expr = func.ST_GeomFromEWKB(value, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=GeoPackageDialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"GeomFromEWKB('{self.EWKB_HEX}')"
+
+    def test_geom_from_ewkb_literal_compile_preserves_bound_none(self):
+        expr = func.ST_GeomFromEWKB(
+            bindparam("wkb", None),
+            type_=Geometry(srid=4326),
+        )
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=GeoPackageDialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == "GeomFromEWKB(NULL)"
 
     def test_geom_from_ewkb_compile_omits_srid_parameter(self):
         ewkb = bytes.fromhex(self.EWKB_HEX)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -41,6 +41,7 @@ from . import select
 
 WKB_HEX = "0101000000000000000000f03f0000000000000040"
 EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
+EWKB_3857_HEX = "0101000020110f0000000000000000f03f0000000000000040"
 ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
 
 
@@ -93,6 +94,14 @@ def test_as_wkb_hex_preserves_known_wkbelement_srid(bindvalue, expected):
 )
 def test_as_binary_ewkb_embeds_or_preserves_known_srid(bindvalue, column_srid, expected):
     assert as_binary_ewkb(bindvalue, column_srid=column_srid) == expected
+
+
+def test_as_binary_ewkb_respects_wkbelement_srid_override_for_ewkb():
+    bindvalue = WKBElement(bytes.fromhex(EWKB_HEX), srid=3857, extended=True)
+    expected = bindvalue.as_ewkb().data
+
+    assert expected == bytes.fromhex(EWKB_3857_HEX)
+    assert as_binary_ewkb(bindvalue) == expected
 
 
 @pytest.mark.parametrize(
@@ -1991,6 +2000,16 @@ class TestPostgreSQLWKBConstructors:
             spatial_type, bytes.fromhex(WKB_HEX)
         ) == bytes.fromhex(EWKB_HEX)
 
+    def test_geom_from_ewkb_return_type_bindparam_embeds_srid_for_raw_wkb(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), type_=Geometry(srid=4326))
+        compiled_expr = expr.compile(dialect=postgresql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromEWKB(%(wkb)s)"
+        assert "wkb" in compiled_expr._bind_processors
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
+            EWKB_HEX
+        )
+
     def test_bind_processor_validates_ewkb_constructor_fixed_srid(self):
         spatial_type = Geometry(srid=3857, from_text="ST_GeomFromEWKB")
 
@@ -2119,6 +2138,45 @@ class TestSQLiteWKBConstructors:
 
         assert self.normalize_sql(compiled_expr) == "GeomFromEWKB(?)"
         assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == EWKB_HEX
+
+    @pytest.mark.parametrize(
+        "runtime_value",
+        [
+            bytes.fromhex(WKB_HEX),
+            memoryview(bytes.fromhex(WKB_HEX)),
+            WKB_HEX,
+        ],
+    )
+    def test_bind_processor_embeds_column_srid_for_raw_wkb_ewkb_constructor(self, runtime_value):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert sqlite_type.bind_processor_process(spatial_type, runtime_value) == EWKB_HEX
+
+    @pytest.mark.parametrize(
+        "runtime_value",
+        [
+            bytes.fromhex(WKB_HEX),
+            memoryview(bytes.fromhex(WKB_HEX)),
+            WKB_HEX,
+        ],
+    )
+    def test_geom_from_ewkb_insert_bindparam_embeds_column_srid_for_raw_wkb(
+        self,
+        runtime_value,
+    ):
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=4326, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = insert(table).values(geom=bindparam("geom"))
+
+        compiled_expr = stmt.compile(dialect=sqlite.dialect())
+
+        assert self.normalize_sql(compiled_expr) == (
+            "INSERT INTO lake (geom) VALUES (GeomFromEWKB(?))"
+        )
+        assert compiled_expr._bind_processors["geom"](runtime_value) == EWKB_HEX
 
     def test_bind_processor_preserves_wkbelement_for_wkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
@@ -2289,6 +2347,45 @@ class TestGeoPackage:
         )
         assert isinstance(compiled_expr.binds["geom"].type, Geometry)
         assert compiled_expr._bind_processors["geom"](bytes.fromhex(self.EWKB_HEX)) == self.EWKB_HEX
+
+    @pytest.mark.parametrize(
+        "runtime_value",
+        [
+            bytes.fromhex(WKB_HEX),
+            memoryview(bytes.fromhex(WKB_HEX)),
+            WKB_HEX,
+        ],
+    )
+    def test_bind_processor_embeds_column_srid_for_raw_wkb_ewkb_constructor(self, runtime_value):
+        spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
+
+        assert geopackage_type.bind_processor_process(spatial_type, runtime_value) == self.EWKB_HEX
+
+    @pytest.mark.parametrize(
+        "runtime_value",
+        [
+            bytes.fromhex(WKB_HEX),
+            memoryview(bytes.fromhex(WKB_HEX)),
+            WKB_HEX,
+        ],
+    )
+    def test_geom_from_ewkb_insert_bindparam_embeds_column_srid_for_raw_wkb(
+        self,
+        runtime_value,
+    ):
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=4326, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = insert(table).values(geom=bindparam("geom"))
+
+        compiled_expr = stmt.compile(dialect=GeoPackageDialect())
+
+        assert self.normalize_sql(compiled_expr) == (
+            "INSERT INTO lake (geom) VALUES (GeomFromEWKB(?))"
+        )
+        assert compiled_expr._bind_processors["geom"](runtime_value) == self.EWKB_HEX
 
     @pytest.mark.parametrize(
         "bindvalue",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -765,6 +765,24 @@ class TestMySQLWKBConstructors:
 
         assert mysql_type.bind_processor_process(spatial_type, bindvalue) == "POINT (1 2)"
 
+    def test_bind_processor_reuses_split_wkb_for_raw_text_constructor(self, monkeypatch):
+        spatial_type = Geometry(srid=4326)
+        bindvalue = bytearray(bytes.fromhex(EWKB_HEX))
+        calls = []
+
+        def split_wkb_srid(value):
+            calls.append(value)
+            return "POINT Z (1 2 3)", 4326
+
+        def to_wkt_no_srid(value):
+            raise AssertionError("raw bind processor should reuse split WKT")
+
+        monkeypatch.setattr(mysql_type._wkb_wkt, "split_wkb_srid", split_wkb_srid)
+        monkeypatch.setattr(mysql_type._wkb_wkt, "to_wkt_no_srid", to_wkt_no_srid)
+
+        assert mysql_type.bind_processor_process(spatial_type, bindvalue) == "POINT Z (1 2 3)"
+        assert calls == [bindvalue]
+
     def test_bind_processor_validates_raw_ewkb_srid(self):
         spatial_type = Geometry(srid=3857)
 
@@ -1062,6 +1080,26 @@ class TestMariaDBWKBConstructors:
 
         assert mariadb_type.bind_processor_process(spatial_type, bindvalue) == "POINT (1 2)"
 
+    def test_bind_processor_reuses_split_wkb_for_raw_text_constructor(self, monkeypatch):
+        spatial_type = Geometry(srid=4326)
+        bindvalue = bytearray(bytes.fromhex(EWKB_HEX))
+        calls = []
+
+        def split_wkb_srid(value):
+            calls.append(value)
+            return "MULTIPOINT ((1 2), (3 4))", 4326
+
+        def to_wkt_no_srid(value):
+            raise AssertionError("raw bind processor should reuse split WKT")
+
+        monkeypatch.setattr(mariadb_type._wkb_wkt, "split_wkb_srid", split_wkb_srid)
+        monkeypatch.setattr(mariadb_type._wkb_wkt, "to_wkt_no_srid", to_wkt_no_srid)
+
+        assert mariadb_type.bind_processor_process(spatial_type, bindvalue) == (
+            "MULTIPOINT (1 2, 3 4)"
+        )
+        assert calls == [bindvalue]
+
     def test_bind_processor_validates_raw_ewkb_srid(self):
         spatial_type = Geometry(srid=3857)
 
@@ -1162,6 +1200,26 @@ class TestSQLiteWKBConstructors:
         assert sqlite_type.bind_processor_process(spatial_type, bindvalue) == (
             "SRID=4326;POINT(1 2)"
         )
+
+    def test_bind_processor_reuses_split_wkb_for_raw_text_constructor(self, monkeypatch):
+        spatial_type = Geometry(srid=3857)
+        bindvalue = bytearray(bytes.fromhex(EWKB_HEX))
+        calls = []
+
+        def split_wkb_srid(value):
+            calls.append(value)
+            return "POINT Z (1 2 3)", 4326
+
+        def to_wkt_no_srid(value):
+            raise AssertionError("raw bind processor should reuse split WKT")
+
+        monkeypatch.setattr(sqlite_type._wkb_wkt, "split_wkb_srid", split_wkb_srid)
+        monkeypatch.setattr(sqlite_type._wkb_wkt, "to_wkt_no_srid", to_wkt_no_srid)
+
+        assert sqlite_type.bind_processor_process(spatial_type, bindvalue) == (
+            "SRID=4326;POINT(1 2 3)"
+        )
+        assert calls == [bindvalue]
 
     @pytest.mark.parametrize(
         "bindvalue",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -35,6 +35,7 @@ from geoalchemy2.types.dialects import mysql as mysql_type
 from geoalchemy2.types.dialects import postgresql as postgresql_type
 from geoalchemy2.types.dialects import sqlite as sqlite_type
 from geoalchemy2.types.dialects.common import as_binary_ewkb
+from geoalchemy2.types.dialects.common import as_ewkb_hex
 from geoalchemy2.types.dialects.common import as_wkb_hex
 
 from . import select
@@ -72,15 +73,21 @@ def test_is_known_srid(srid, expected):
 
 
 @pytest.mark.parametrize(
-    ("bindvalue", "expected"),
+    "bindvalue",
     [
-        (WKBElement(bytes.fromhex(WKB_HEX), srid=4326), EWKB_HEX),
-        (WKBElement(bytes.fromhex(WKB_HEX), srid=0), WKB_HEX),
-        (WKBElement(bytes.fromhex(WKB_HEX), srid=-1), WKB_HEX),
+        bytes.fromhex(EWKB_HEX),
+        memoryview(bytes.fromhex(EWKB_HEX)),
+        EWKB_HEX,
+        WKBElement(bytes.fromhex(EWKB_HEX), extended=True),
     ],
 )
-def test_as_wkb_hex_preserves_known_wkbelement_srid(bindvalue, expected):
-    assert as_wkb_hex(bindvalue, strip_srid=False) == expected
+def test_as_wkb_hex_strips_or_validates_srid(bindvalue):
+    assert as_wkb_hex(bindvalue, column_srid=4326) == WKB_HEX
+
+
+def test_as_wkb_hex_validates_column_srid():
+    with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+        as_wkb_hex(bytes.fromhex(EWKB_HEX), column_srid=3857)
 
 
 @pytest.mark.parametrize(
@@ -102,6 +109,25 @@ def test_as_binary_ewkb_respects_wkbelement_srid_override_for_ewkb():
 
     assert expected == bytes.fromhex(EWKB_3857_HEX)
     assert as_binary_ewkb(bindvalue) == expected
+
+
+@pytest.mark.parametrize(
+    ("bindvalue", "column_srid", "expected"),
+    [
+        (bytes.fromhex(WKB_HEX), 4326, EWKB_HEX),
+        (memoryview(bytes.fromhex(WKB_HEX)), 4326, EWKB_HEX),
+        (WKB_HEX, 4326, EWKB_HEX),
+        (None, 4326, None),
+    ],
+)
+def test_as_ewkb_hex_embeds_or_preserves_known_srid(bindvalue, column_srid, expected):
+    assert as_ewkb_hex(bindvalue, column_srid=column_srid) == expected
+
+
+def test_as_ewkb_hex_respects_wkbelement_srid_override_for_ewkb():
+    bindvalue = WKBElement(bytes.fromhex(EWKB_HEX), srid=3857, extended=True)
+
+    assert as_ewkb_hex(bindvalue) == EWKB_3857_HEX
 
 
 @pytest.mark.parametrize(
@@ -2009,6 +2035,70 @@ class TestPostgreSQLWKBConstructors:
         assert compiled_expr._bind_processors["wkb"](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
             EWKB_HEX
         )
+
+    def test_geom_from_ewkb_insert_bindparam_uses_geometry_bind_processor(
+        self,
+        monkeypatch,
+    ):
+        def fail_process_bind_param(self, value, dialect):
+            raise AssertionError("Geometry bind processor should handle EWKB column binds")
+
+        monkeypatch.setattr(
+            _postgresql_admin._PostgreSQLEWKBBindType,
+            "process_bind_param",
+            fail_process_bind_param,
+        )
+        table = Table(
+            "lake",
+            MetaData(),
+            Column("geom", Geometry(srid=4326, from_text="ST_GeomFromEWKB")),
+        )
+        stmt = insert(table).values(geom=bindparam("geom"))
+
+        compiled_expr = stmt.compile(dialect=postgresql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == (
+            "INSERT INTO lake (geom) VALUES (ST_GeomFromEWKB(%(geom)s))"
+        )
+        assert isinstance(compiled_expr.binds["geom"].type, Geometry)
+        assert compiled_expr._bind_processors["geom"](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
+            EWKB_HEX
+        )
+
+    def test_geom_from_ewkb_geometry_typed_bindparam_uses_geometry_bind_processor(
+        self,
+        monkeypatch,
+    ):
+        def fail_process_bind_param(self, value, dialect):
+            raise AssertionError("Typed Geometry bindparam should handle EWKB binds")
+
+        monkeypatch.setattr(
+            _postgresql_admin._PostgreSQLEWKBBindType,
+            "process_bind_param",
+            fail_process_bind_param,
+        )
+        expr = func.ST_GeomFromEWKB(
+            bindparam("wkb", type_=Geometry(srid=4326, from_text="ST_GeomFromEWKB")),
+            type_=Geometry(srid=4326),
+        )
+
+        compiled_expr = expr.compile(dialect=postgresql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromEWKB(%(wkb)s)"
+        assert isinstance(compiled_expr.binds["wkb"].type, Geometry)
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
+            EWKB_HEX
+        )
+
+    def test_geom_from_ewkb_return_type_bindparam_preserves_embedded_srid_for_ewkb(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
+        compiled_expr = expr.compile(dialect=postgresql.dialect())
+        param_key = next(iter(compiled_expr.params))
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromEWKB(%(ST_GeomFromEWKB_1)s)"
+        assert compiled_expr._bind_processors[param_key](
+            compiled_expr.params[param_key]
+        ) == bytes.fromhex(EWKB_HEX)
 
     def test_bind_processor_validates_ewkb_constructor_fixed_srid(self):
         spatial_type = Geometry(srid=3857, from_text="ST_GeomFromEWKB")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -567,7 +567,12 @@ class TestMySQLWKBConstructors:
 
         assert calls == [stmt]
 
-    def test_before_execute_avoids_statement_compile_for_named_bindparam(self, monkeypatch):
+    @pytest.mark.parametrize("runtime_value", [bytes.fromhex(EWKB_HEX), None])
+    def test_before_execute_avoids_statement_compile_for_named_bindparam(
+        self,
+        monkeypatch,
+        runtime_value,
+    ):
         class Conn:
             dialect = mysql.dialect()
 
@@ -581,19 +586,68 @@ class TestMySQLWKBConstructors:
         )
         source_bind = bindparam("wkb")
         stmt = select([func.ST_GeomFromEWKB(source_bind)])
-        ewkb = bytes.fromhex(EWKB_HEX)
 
         _, _, expanded_params = _mysql_admin.before_execute(
             Conn(),
             stmt,
             (),
-            {"wkb": ewkb},
+            {"wkb": runtime_value},
             {},
         )
 
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
-        assert expanded_params[wkb_key] is ewkb
-        assert expanded_params[srid_key] is ewkb
+        assert expanded_params[wkb_key] is runtime_value
+        assert expanded_params[srid_key] is runtime_value
+
+    def test_before_execute_prefilter_short_circuits_candidate_values(self):
+        class ShortCircuitValues(dict):
+            def values(self):
+                yield bytes.fromhex(EWKB_HEX)
+                raise AssertionError("candidate value scan should short-circuit")
+
+        assert _mysql_admin._parameters_may_need_dynamic_ewkb(
+            (),
+            ShortCircuitValues({"wkb": bytes.fromhex(EWKB_HEX), "other": object()}),
+        )
+
+    def test_dynamic_ewkb_key_collection_uses_candidate_membership(self):
+        class NoIterationKeys(dict):
+            def __iter__(self):
+                raise AssertionError("source key lookup should use direct membership")
+
+        present_keys = _mysql_admin._collect_present_mysql_dynamic_ewkb_parameter_keys(
+            (),
+            NoIterationKeys({f"other_{i}": object() for i in range(1000)} | {"wkb": None}),
+            [("wkb",)],
+        )
+
+        assert present_keys == {"wkb"}
+
+    def test_before_execute_respects_dynamic_ewkb_split_disable_option(self, monkeypatch):
+        class Conn:
+            dialect = mysql.dialect()
+
+        def collect_source_binds(clauseelement):
+            raise AssertionError("disabled dynamic splitting should not traverse the statement")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_collect_mysql_dynamic_ewkb_source_binds",
+            collect_source_binds,
+        )
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        params = {"wkb": bytes.fromhex(EWKB_HEX)}
+
+        result = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            params,
+            {_mysql_admin._MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION: True},
+        )
+
+        assert result == (stmt, (), params)
 
     def test_before_execute_wraps_multivalue_dml_without_runtime_params(self):
         class Conn:
@@ -649,7 +703,7 @@ class TestMySQLWKBConstructors:
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
         ewkb = bytes.fromhex(EWKB_HEX)
         wkb = bytes.fromhex(WKB_HEX)
-        multiparams = ({"wkb": ewkb}, {"wkb": wkb})
+        multiparams = ({"wkb": ewkb}, {"wkb": wkb}, {"wkb": None})
 
         _, expanded_multiparams, expanded_params = _mysql_admin.before_execute(
             Conn(),
@@ -660,11 +714,13 @@ class TestMySQLWKBConstructors:
         )
 
         assert expanded_params == {}
-        assert multiparams == ({"wkb": ewkb}, {"wkb": wkb})
+        assert multiparams == ({"wkb": ewkb}, {"wkb": wkb}, {"wkb": None})
         assert expanded_multiparams[0][wkb_key] is ewkb
         assert expanded_multiparams[0][srid_key] is ewkb
         assert expanded_multiparams[1][wkb_key] is wkb
         assert expanded_multiparams[1][srid_key] is wkb
+        assert expanded_multiparams[2][wkb_key] is None
+        assert expanded_multiparams[2][srid_key] is None
 
     def test_before_execute_expands_dynamic_ewkb_unique_compiled_name(self):
         class Conn:
@@ -1050,6 +1106,42 @@ class TestMariaDBWKBConstructors:
         assert params == {"wkb": ewkb}
         assert expanded_params[wkb_key] is ewkb
         assert expanded_params[srid_key] is ewkb
+
+    def test_before_execute_expands_none_dynamic_ewkb_params_for_mariadb_without_compile(
+        self,
+        monkeypatch,
+    ):
+        class Conn:
+            dialect = mariadb_dialect.MariaDBDialect()
+
+        def compile_bind_name_map(clauseelement, dialect):
+            raise AssertionError("named bindparams should not need a statement compile")
+
+        monkeypatch.setattr(
+            _mysql_admin,
+            "_compile_mysql_statement_bind_name_map",
+            compile_bind_name_map,
+        )
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=3857,
+        )
+        params = {"wkb": None}
+
+        _, multiparams, expanded_params = _mariadb_admin.before_execute(
+            Conn(),
+            stmt,
+            (),
+            params,
+            {},
+        )
+
+        assert multiparams == ()
+        assert params == {"wkb": None}
+        assert expanded_params[wkb_key] is None
+        assert expanded_params[srid_key] is None
 
     def test_bind_processor_converts_wkbelement_for_wkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -856,6 +856,33 @@ class TestMySQLWKBConstructors:
         assert mysql_type.bind_processor_process(spatial_type, bindvalue) == "POINT Z (1 2 3)"
         assert calls == [bindvalue]
 
+    @pytest.mark.parametrize(
+        "spatial_type",
+        [
+            pytest.param(Geometry(), id="default-srid"),
+            pytest.param(Geometry(srid=0), id="zero-srid"),
+        ],
+    )
+    def test_bind_processor_accepts_raw_ewkb_srid_for_non_fixed_column(self, spatial_type):
+        assert (
+            mysql_type.bind_processor_process(
+                spatial_type,
+                bytes.fromhex(EWKB_HEX),
+            )
+            == "POINT (1 2)"
+        )
+
+    def test_bind_processor_accepts_zero_raw_ewkb_srid_for_fixed_column(self):
+        spatial_type = Geometry(srid=3857)
+
+        assert (
+            mysql_type.bind_processor_process(
+                spatial_type,
+                bytes.fromhex(ZERO_SRID_EWKB_HEX),
+            )
+            == "POINT (1 2)"
+        )
+
     def test_bind_processor_validates_raw_ewkb_srid(self):
         spatial_type = Geometry(srid=3857)
 
@@ -1224,6 +1251,33 @@ class TestMariaDBWKBConstructors:
             "MULTIPOINT (1 2, 3 4)"
         )
         assert calls == [bindvalue]
+
+    @pytest.mark.parametrize(
+        "spatial_type",
+        [
+            pytest.param(Geometry(), id="default-srid"),
+            pytest.param(Geometry(srid=0), id="zero-srid"),
+        ],
+    )
+    def test_bind_processor_accepts_raw_ewkb_srid_for_non_fixed_column(self, spatial_type):
+        assert (
+            mariadb_type.bind_processor_process(
+                spatial_type,
+                bytes.fromhex(EWKB_HEX),
+            )
+            == "POINT (1 2)"
+        )
+
+    def test_bind_processor_accepts_zero_raw_ewkb_srid_for_fixed_column(self):
+        spatial_type = Geometry(srid=3857)
+
+        assert (
+            mariadb_type.bind_processor_process(
+                spatial_type,
+                bytes.fromhex(ZERO_SRID_EWKB_HEX),
+            )
+            == "POINT (1 2)"
+        )
 
     def test_bind_processor_validates_raw_ewkb_srid(self):
         spatial_type = Geometry(srid=3857)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,6 +17,7 @@ from sqlalchemy.sql import text
 from sqlalchemy.sql import update
 
 from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.admin.dialects import mariadb as _mariadb_admin  # noqa: F401
 from geoalchemy2.admin.dialects import mysql as _mysql_admin  # noqa: F401
 from geoalchemy2.admin.dialects import postgresql as _postgresql_admin  # noqa: F401
@@ -33,6 +34,7 @@ from geoalchemy2.types.dialects import mariadb as mariadb_type
 from geoalchemy2.types.dialects import mysql as mysql_type
 from geoalchemy2.types.dialects import postgresql as postgresql_type
 from geoalchemy2.types.dialects import sqlite as sqlite_type
+from geoalchemy2.types.dialects.common import as_wkb_hex
 
 from . import select
 
@@ -51,6 +53,32 @@ def test_split_wkb_srid_treats_strings_as_hex_wkb_only():
 
     with pytest.raises(ValueError):
         _wkb_wkt.split_wkb_srid("SRID=4326;POINT (1 2)")
+
+
+@pytest.mark.parametrize(
+    ("srid", "expected"),
+    [
+        (None, False),
+        (-1, False),
+        (0, False),
+        (1, True),
+        (4326, True),
+    ],
+)
+def test_is_known_srid(srid, expected):
+    assert is_known_srid(srid) is expected
+
+
+@pytest.mark.parametrize(
+    ("bindvalue", "expected"),
+    [
+        (WKBElement(bytes.fromhex(WKB_HEX), srid=4326), EWKB_HEX),
+        (WKBElement(bytes.fromhex(WKB_HEX), srid=0), WKB_HEX),
+        (WKBElement(bytes.fromhex(WKB_HEX), srid=-1), WKB_HEX),
+    ],
+)
+def test_as_wkb_hex_preserves_known_wkbelement_srid(bindvalue, expected):
+    assert as_wkb_hex(bindvalue, strip_srid=False) == expected
 
 
 @pytest.fixture
@@ -816,6 +844,38 @@ class TestMySQLWKBConstructors:
         assert expanded_multiparams[2][wkb_key] is None
         assert expanded_multiparams[2][srid_key] is None
 
+    def test_before_execute_expands_dynamic_ewkb_executemany_rows(self):
+        class Conn:
+            dialect = mysql.dialect()
+
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+        ewkb = bytes.fromhex(EWKB_HEX)
+        wkb = bytes.fromhex(WKB_HEX)
+        row1 = {"wkb": ewkb}
+        row2 = {"wkb": wkb}
+        multiparams = ([row1, row2],)
+
+        _, expanded_multiparams, expanded_params = _mysql_admin.before_execute(
+            Conn(),
+            stmt,
+            multiparams,
+            {},
+            {},
+        )
+
+        assert expanded_params == {}
+        assert expanded_multiparams != multiparams
+        assert isinstance(expanded_multiparams, tuple)
+        assert isinstance(expanded_multiparams[0], list)
+        assert expanded_multiparams[0][0][wkb_key] is ewkb
+        assert expanded_multiparams[0][0][srid_key] is ewkb
+        assert expanded_multiparams[0][1][wkb_key] is wkb
+        assert expanded_multiparams[0][1][srid_key] is wkb
+        assert row1 == {"wkb": ewkb}
+        assert row2 == {"wkb": wkb}
+
     def test_before_execute_expands_dynamic_ewkb_unique_compiled_name(self):
         class Conn:
             dialect = mysql.dialect()
@@ -957,6 +1017,32 @@ class TestMySQLWKBConstructors:
             == "POINT (1 2)"
         )
 
+    @pytest.mark.parametrize(
+        "spatial_type",
+        [
+            pytest.param(Geometry(), id="default-srid"),
+            pytest.param(Geometry(srid=0), id="zero-srid"),
+        ],
+    )
+    def test_bind_processor_accepts_known_srid_for_non_fixed_column(self, spatial_type):
+        result = mysql_type.bind_processor_process(
+            spatial_type,
+            WKTElement("POINT (1 2)", srid=4326),
+        )
+
+        assert mysql_type.bind_processor_process(spatial_type, "SRID=4326;POINT(1 2)") == (
+            "POINT(1 2)"
+        )
+        assert result.data == "POINT (1 2)"
+        assert result.srid == 4326
+        assert (
+            mysql_type.bind_processor_process(
+                spatial_type,
+                WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+            )
+            == "POINT (1 2)"
+        )
+
     def test_bind_processor_accepts_zero_raw_ewkb_srid_for_fixed_column(self):
         spatial_type = Geometry(srid=3857)
 
@@ -968,11 +1054,46 @@ class TestMySQLWKBConstructors:
             == "POINT (1 2)"
         )
 
+    def test_bind_processor_accepts_unknown_srid_for_fixed_column(self):
+        spatial_type = Geometry(srid=3857)
+
+        result = mysql_type.bind_processor_process(
+            spatial_type,
+            WKTElement("POINT (1 2)", srid=0),
+        )
+
+        assert mysql_type.bind_processor_process(spatial_type, "SRID=0;POINT(1 2)") == (
+            "POINT(1 2)"
+        )
+        assert result.data == "POINT (1 2)"
+        assert result.srid == 3857
+        assert (
+            mysql_type.bind_processor_process(
+                spatial_type,
+                WKBElement(bytes.fromhex(WKB_HEX), srid=0),
+            )
+            == "POINT (1 2)"
+        )
+
     def test_bind_processor_validates_raw_ewkb_srid(self):
         spatial_type = Geometry(srid=3857)
 
         with pytest.raises(ArgumentError, match=r"column \(3857\)"):
             mysql_type.bind_processor_process(spatial_type, bytes.fromhex(EWKB_HEX))
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            "SRID=4326;POINT(1 2)",
+            WKTElement("POINT (1 2)", srid=4326),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+        ],
+    )
+    def test_bind_processor_validates_known_srid_for_fixed_column(self, bindvalue):
+        spatial_type = Geometry(srid=3857)
+
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mysql_type.bind_processor_process(spatial_type, bindvalue)
 
     def test_bind_processor_strips_ewkb_for_ewkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromEWKB")
@@ -1436,6 +1557,38 @@ class TestMariaDBWKBConstructors:
         assert expanded_params[wkb_key] is None
         assert expanded_params[srid_key] is None
 
+    def test_before_execute_expands_dynamic_ewkb_executemany_rows_for_mariadb(self):
+        class Conn:
+            dialect = mariadb_dialect.MariaDBDialect()
+
+        source_bind = bindparam("wkb")
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(source_bind)
+        ewkb = bytes.fromhex(EWKB_HEX)
+        wkb = bytes.fromhex(WKB_HEX)
+        row1 = {"wkb": ewkb}
+        row2 = {"wkb": wkb}
+        multiparams = ([row1, row2],)
+
+        _, expanded_multiparams, expanded_params = _mariadb_admin.before_execute(
+            Conn(),
+            stmt,
+            multiparams,
+            {},
+            {},
+        )
+
+        assert expanded_params == {}
+        assert expanded_multiparams != multiparams
+        assert isinstance(expanded_multiparams, tuple)
+        assert isinstance(expanded_multiparams[0], list)
+        assert expanded_multiparams[0][0][wkb_key] is ewkb
+        assert expanded_multiparams[0][0][srid_key] is ewkb
+        assert expanded_multiparams[0][1][wkb_key] is wkb
+        assert expanded_multiparams[0][1][srid_key] is wkb
+        assert row1 == {"wkb": ewkb}
+        assert row2 == {"wkb": wkb}
+
     def test_bind_processor_converts_wkbelement_for_wkb_constructor(self):
         spatial_type = Geometry(srid=4326, from_text="ST_GeomFromWKB")
 
@@ -1614,6 +1767,32 @@ class TestMariaDBWKBConstructors:
             == "POINT (1 2)"
         )
 
+    @pytest.mark.parametrize(
+        "spatial_type",
+        [
+            pytest.param(Geometry(), id="default-srid"),
+            pytest.param(Geometry(srid=0), id="zero-srid"),
+        ],
+    )
+    def test_bind_processor_accepts_known_srid_for_non_fixed_column(self, spatial_type):
+        result = mariadb_type.bind_processor_process(
+            spatial_type,
+            WKTElement("POINT (1 2)", srid=4326),
+        )
+
+        assert mariadb_type.bind_processor_process(spatial_type, "SRID=4326;POINT(1 2)") == (
+            "POINT(1 2)"
+        )
+        assert result.data == "POINT (1 2)"
+        assert result.srid == 4326
+        assert (
+            mariadb_type.bind_processor_process(
+                spatial_type,
+                WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+            )
+            == "POINT (1 2)"
+        )
+
     def test_bind_processor_accepts_zero_raw_ewkb_srid_for_fixed_column(self):
         spatial_type = Geometry(srid=3857)
 
@@ -1625,11 +1804,46 @@ class TestMariaDBWKBConstructors:
             == "POINT (1 2)"
         )
 
+    def test_bind_processor_accepts_unknown_srid_for_fixed_column(self):
+        spatial_type = Geometry(srid=3857)
+
+        result = mariadb_type.bind_processor_process(
+            spatial_type,
+            WKTElement("POINT (1 2)", srid=0),
+        )
+
+        assert mariadb_type.bind_processor_process(spatial_type, "SRID=0;POINT(1 2)") == (
+            "POINT(1 2)"
+        )
+        assert result.data == "POINT (1 2)"
+        assert result.srid == 3857
+        assert (
+            mariadb_type.bind_processor_process(
+                spatial_type,
+                WKBElement(bytes.fromhex(WKB_HEX), srid=0),
+            )
+            == "POINT (1 2)"
+        )
+
     def test_bind_processor_validates_raw_ewkb_srid(self):
         spatial_type = Geometry(srid=3857)
 
         with pytest.raises(ArgumentError, match=r"column \(3857\)"):
             mariadb_type.bind_processor_process(spatial_type, bytes.fromhex(EWKB_HEX))
+
+    @pytest.mark.parametrize(
+        "bindvalue",
+        [
+            "SRID=4326;POINT(1 2)",
+            WKTElement("POINT (1 2)", srid=4326),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+        ],
+    )
+    def test_bind_processor_validates_known_srid_for_fixed_column(self, bindvalue):
+        spatial_type = Geometry(srid=3857)
+
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            mariadb_type.bind_processor_process(spatial_type, bindvalue)
 
     def test_bind_processor_normalizes_multipoint_wkt_for_wkbelement_and_raw_wkb(self):
         spatial_type = Geometry(geometry_type="MULTIPOINT", srid=4326)
@@ -1822,6 +2036,7 @@ class TestSQLiteWKBConstructors:
             EWKB_HEX,
             WKBElement(bytes.fromhex(EWKB_HEX), extended=True),
             WKBElement(EWKB_HEX, extended=True),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
         ],
     )
     def test_bind_processor_converts_ewkb_to_hex_for_ewkb_constructor(self, bindvalue):
@@ -1932,6 +2147,7 @@ class TestGeoPackage:
                 extended=True,
             ),
             WKBElement(EWKB_HEX, extended=True),
+            WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
         ],
     )
     def test_bind_processor_converts_ewkb_to_hex_for_ewkb_constructor(self, bindvalue):

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -1053,6 +1053,7 @@ class TestMSSQLBindAndResultProcessing:
         wkb = bytes.fromhex(
             "01020000000200000000000000000000000000000000000000000000000000f03f000000000000f03f"
         )
+        ewkb = WKBElement(wkb, srid=4326).as_ewkb().data
 
         with pytest.raises(ArgumentError, match=r"column \(0\)"):
             bind_processor("SRID=4326;LINESTRING(0 0,1 1)")
@@ -1062,6 +1063,9 @@ class TestMSSQLBindAndResultProcessing:
 
         with pytest.raises(ArgumentError, match=r"column \(0\)"):
             bind_processor(WKBElement(wkb, srid=4326))
+
+        with pytest.raises(ArgumentError, match=r"column \(0\)"):
+            bind_processor(ewkb)
 
     def test_bind_processor_resolves_typedecorator_metadata_for_srid_validation(self):
         wrapped_geography = WrappedGeography()
@@ -1113,7 +1117,7 @@ class TestMSSQLBindAndResultProcessing:
             "POINT (0.12345678901234566 123456789.12345679)"
         )
 
-    def test_wkb_parser_handles_hex_empty_and_geometrycollection_inputs(self):
+    def test_converter_handles_hex_empty_and_geometrycollection_inputs(self):
         empty_linestring_z = _pack_iso_wkb(2, struct.pack("<I", 0), has_z=True)
         empty_linestring_m = _pack_iso_wkb(2, struct.pack("<I", 0), has_m=True)
         empty_polygon = _pack_iso_wkb(3, struct.pack("<I", 0))
@@ -1131,7 +1135,23 @@ class TestMSSQLBindAndResultProcessing:
             == "POINT EMPTY"
         )
 
-    def test_wkb_parser_rejects_unsupported_values(self):
+    @pytest.mark.parametrize(
+        ("wkt", "expected"),
+        [
+            ("POINT Z EMPTY", "POINT EMPTY"),
+            ("LINESTRING M EMPTY", "LINESTRING EMPTY"),
+            ("GEOMETRYCOLLECTION ZM EMPTY", "GEOMETRYCOLLECTION EMPTY"),
+            ("POINTZM(1 2 3 4)", "POINT(1 2 3 4)"),
+            (
+                "MULTIPOLYGONZM(((1 2 3 4,1 2 3 4,1 2 3 4,1 2 3 4)))",
+                "MULTIPOLYGON(((1 2 3 4,1 2 3 4,1 2 3 4,1 2 3 4)))",
+            ),
+        ],
+    )
+    def test_normalize_wkt_for_mssql_strips_dimension_suffix_from_empty_forms(self, wkt, expected):
+        assert mssql_type._normalize_wkt_for_mssql(wkt) == expected
+
+    def test_converter_rejects_unsupported_wkb_values(self):
         unsupported_wkb = b"\x01" + struct.pack("<I", 999)
 
         with pytest.raises(ValueError, match="Unsupported WKB geometry type"):
@@ -1141,29 +1161,17 @@ class TestMSSQLBindAndResultProcessing:
         with pytest.raises(TypeError, match="Unsupported WKB value type"):
             mssql_type._wkb_to_mssql_wkt(object())
 
-    def test_to_mssql_wkt_falls_back_to_shape_conversion(self, monkeypatch):
-        class Shape:
-            wkt = "POINT Z (1 2 3)"
+    def test_to_mssql_wkt_normalizes_wkt_elements_without_wkb_conversion(self, monkeypatch):
+        def raise_conversion_error(value):
+            raise ValueError("unsupported converter path")
 
-        shaped_values = []
-
-        def raise_parse_error(value):
-            raise ValueError("unsupported parser path")
-
-        def fake_to_shape(value):
-            shaped_values.append(value)
-            return Shape()
-
-        monkeypatch.setattr(mssql_type, "_wkb_to_mssql_wkt", raise_parse_error)
-        monkeypatch.setattr(mssql_type, "to_shape", fake_to_shape)
+        monkeypatch.setattr(mssql_type, "_wkb_to_mssql_wkt", raise_conversion_error)
 
         assert mssql_type._to_mssql_wkt(WKTElement("POINT Z (1 2 3)", srid=4326)) == (
             "POINT (1 2 3)"
         )
-        assert isinstance(shaped_values[-1], WKTElement)
-
-        assert mssql_type._to_mssql_wkt(b"\x01") == "POINT (1 2 3)"
-        assert isinstance(shaped_values[-1], WKBElement)
+        with pytest.raises(ValueError, match="unsupported converter path"):
+            mssql_type._to_mssql_wkt(b"\x01")
 
     def test_bind_coercion_helpers_keep_non_bind_clauses(self):
         table = Table("raw_values", MetaData(), Column("value", Integer))
@@ -1586,6 +1594,7 @@ class TestMSSQLBindAndResultProcessing:
 
         assert bind_processor(WKBElement(wkb, srid=4326)) == "POINT (1 2 3 4)"
         assert bind_processor(wkb) == "POINT (1 2 3 4)"
+        assert bind_processor(memoryview(wkb)) == "POINT (1 2 3 4)"
         assert bind_processor(WKBElement(wkb, srid=4326).as_ewkb()) == "POINT (1 2 3 4)"
 
     def test_bind_processor_preserves_zm_dimension_for_nested_iso_wkb_inputs(self):
@@ -1605,6 +1614,10 @@ class TestMSSQLBindAndResultProcessing:
             "((10 20 30 40, 50 60 70 80, 90 100 110 120, 10 20 30 40)))"
         )
         assert bind_processor(WKBElement(wkb, srid=4326).as_ewkb()) == (
+            "MULTIPOLYGON (((1 2 3 4, 5 6 7 8, 9 10 11 12, 1 2 3 4)), "
+            "((10 20 30 40, 50 60 70 80, 90 100 110 120, 10 20 30 40)))"
+        )
+        assert bind_processor(wkb) == (
             "MULTIPOLYGON (((1 2 3 4, 5 6 7 8, 9 10 11 12, 1 2 3 4)), "
             "((10 20 30 40, 50 60 70 80, 90 100 110 120, 10 20 30 40)))"
         )

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -1050,6 +1050,17 @@ class TestMSSQLBindAndResultProcessing:
 
         assert bind_processor(zero_srid_ewkb) == "LINESTRING (0 0, 1 1)"
 
+    def test_bind_processor_accepts_zero_srid_for_fixed_column(self):
+        geom = Geometry(geometry_type="LINESTRING", srid=4326)
+        bind_processor = geom.bind_processor(self.dialect)
+        wkb = bytes.fromhex(
+            "01020000000200000000000000000000000000000000000000000000000000f03f000000000000f03f"
+        )
+
+        assert bind_processor("SRID=0;LINESTRING(0 0,1 1)") == "LINESTRING(0 0,1 1)"
+        assert bind_processor(WKTElement("LINESTRING(0 0,1 1)", srid=0)) == ("LINESTRING(0 0,1 1)")
+        assert bind_processor(WKBElement(wkb, srid=0)) == "LINESTRING (0 0, 1 1)"
+
     def test_bind_processor_accepts_runtime_srid_for_unconstrained_column(self):
         geom = Geometry(geometry_type="LINESTRING", srid=-1)
         bind_processor = geom.bind_processor(self.dialect)

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -1027,12 +1027,28 @@ class TestMSSQLBindAndResultProcessing:
     def test_bind_processor_validates_srid(self):
         geom = Geometry(geometry_type="LINESTRING", srid=4326)
         bind_processor = geom.bind_processor(self.dialect)
+        wkb = bytes.fromhex(
+            "01020000000200000000000000000000000000000000000000000000000000f03f000000000000f03f"
+        )
 
         with pytest.raises(ArgumentError):
             bind_processor("SRID=2154;LINESTRING(0 0,1 1)")
 
         with pytest.raises(ArgumentError):
             bind_processor(WKTElement("LINESTRING(0 0,1 1)", srid=2154))
+
+        with pytest.raises(ArgumentError):
+            bind_processor(WKBElement(wkb, srid=2154).as_ewkb().data)
+
+    def test_bind_processor_accepts_zero_srid_raw_ewkb_for_fixed_column(self):
+        geom = Geometry(geometry_type="LINESTRING", srid=4326)
+        bind_processor = geom.bind_processor(self.dialect)
+        zero_srid_ewkb = bytes.fromhex(
+            "0102000020000000000200000000000000000000000000000000000000000000000000f03f"
+            "000000000000f03f"
+        )
+
+        assert bind_processor(zero_srid_ewkb) == "LINESTRING (0 0, 1 1)"
 
     def test_bind_processor_accepts_runtime_srid_for_unconstrained_column(self):
         geom = Geometry(geometry_type="LINESTRING", srid=-1)

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -1173,6 +1173,25 @@ class TestMSSQLBindAndResultProcessing:
         with pytest.raises(ValueError, match="unsupported converter path"):
             mssql_type._to_mssql_wkt(b"\x01")
 
+    def test_bind_processor_reuses_split_wkb_for_raw_text_constructor(self, monkeypatch):
+        geom = Geometry(geometry_type="POINT", srid=4326)
+        bind_processor = geom.bind_processor(self.dialect)
+        bindvalue = bytearray(b"\x01\x01\x00\x00\x00")
+        calls = []
+
+        def split_wkb_srid(value):
+            calls.append(value)
+            return "POINT Z (1 2 3)", 4326
+
+        def to_wkt_no_srid(value):
+            raise AssertionError("raw bind processor should reuse split WKT")
+
+        monkeypatch.setattr(mssql_type._wkb_wkt, "split_wkb_srid", split_wkb_srid)
+        monkeypatch.setattr(mssql_type._wkb_wkt, "to_wkt_no_srid", to_wkt_no_srid)
+
+        assert bind_processor(bindvalue) == "POINT (1 2 3)"
+        assert calls == [bytes(bindvalue)]
+
     def test_bind_coercion_helpers_keep_non_bind_clauses(self):
         table = Table("raw_values", MetaData(), Column("value", Integer))
 

--- a/tools/benchmark_wkt_element_fast_paths.py
+++ b/tools/benchmark_wkt_element_fast_paths.py
@@ -6,15 +6,18 @@ branch dependencies installed, for example:
     ./test_container/run.sh /output/py312-sqlalatest/bin/python \
         /geoalchemy2/tools/benchmark_wkt_element_fast_paths.py
 
-The "rust_path" functions model the converter-based implementation. The
-"regex_current" functions model the current branch implementation. The
-"partition_candidate" functions model a faster string-only alternative for
-EWKT prefix stripping.
+The current implementation is hybrid: plain/non-extended WKT uses cheap Python
+constructors, while already-extended EWKT uses the Rust-backed converter.
+The "converter/Rust path" functions force converter use for comparison. The
+"old regex" functions model the historical regex prefix stripper. The
+"rejected strict partition candidate" functions keep a local string-only
+candidate for comparison only.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import timeit
 from collections.abc import Callable
 from statistics import median
@@ -22,39 +25,60 @@ from statistics import median
 from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import WKTElement
 
+OLD_REMOVE_SRID = re.compile("(SRID=([0-9]+); ?)?(.*)")
 
-def strip_srid_partition(data: str) -> str:
-    wkt = data.partition(";")[2]
-    if wkt.startswith(" "):
-        wkt = wkt[1:]
-    return wkt
+
+def strip_srid_old_regex(data: str) -> str:
+    match = OLD_REMOVE_SRID.match(data)
+    assert match is not None
+    return match.group(3)
+
+
+def strip_srid_rejected_strict_partition(data: str) -> str:
+    if data[:5] == "SRID=":
+        header, separator, wkt = data.partition(";")
+        srid_text = header[5:]
+        if separator and srid_text.isascii() and srid_text.isdigit() and wkt[:2] != "  ":
+            if wkt[:1] == " ":
+                return wkt[1:]
+            return wkt
+    return data
 
 
 def bench(
     label: str,
     current: Callable[[], WKTElement],
-    rust_path: Callable[[], WKTElement],
+    converter_path: Callable[[], WKTElement],
     *,
     number: int,
     repeat: int,
 ) -> None:
     current_value = current()
-    rust_value = rust_path()
-    assert current_value.data == rust_value.data, (label, current_value.data, rust_value.data)
-    assert current_value.srid == rust_value.srid, (label, current_value.srid, rust_value.srid)
-    assert current_value.extended == rust_value.extended, (
+    converter_value = converter_path()
+    assert current_value.data == converter_value.data, (
+        label,
+        current_value.data,
+        converter_value.data,
+    )
+    assert current_value.srid == converter_value.srid, (
+        label,
+        current_value.srid,
+        converter_value.srid,
+    )
+    assert current_value.extended == converter_value.extended, (
         label,
         current_value.extended,
-        rust_value.extended,
+        converter_value.extended,
     )
 
     current_times = timeit.repeat(current, repeat=repeat, number=number)
-    rust_times = timeit.repeat(rust_path, repeat=repeat, number=number)
+    converter_times = timeit.repeat(converter_path, repeat=repeat, number=number)
     current_med = median(current_times) / number * 1_000_000
-    rust_med = median(rust_times) / number * 1_000_000
+    converter_med = median(converter_times) / number * 1_000_000
     print(
-        f"{label}: current={current_med:.3f} us/op "
-        f"rust_path={rust_med:.3f} us/op speedup={rust_med / current_med:.2f}x"
+        f"{label}: current_hybrid={current_med:.3f} us/op "
+        f"converter_rust={converter_med:.3f} us/op "
+        f"converter/current={converter_med / current_med:.2f}x"
     )
 
 
@@ -80,110 +104,136 @@ def main() -> None:
     ewkt = WKTElement("SRID=4326;POINT (1 2)", extended=True)
     ewkt_space = WKTElement("SRID=4326; POINT (1 2)", extended=True)
 
-    def regex_as_wkt_plain() -> WKTElement:
+    def current_as_wkt_plain() -> WKTElement:
         return plain.as_wkt()
 
-    def rust_as_wkt_plain() -> WKTElement:
+    def converter_as_wkt_plain() -> WKTElement:
         return WKTElement(_wkb_wkt.to_wkt_no_srid(plain.data), srid=plain.srid, extended=False)
 
-    def regex_as_wkt_extended() -> WKTElement:
+    def current_as_wkt_extended() -> WKTElement:
         return ewkt.as_wkt()
 
-    def rust_as_wkt_extended() -> WKTElement:
+    def converter_as_wkt_extended() -> WKTElement:
         return WKTElement(_wkb_wkt.to_wkt_no_srid(ewkt.data), srid=ewkt.srid, extended=False)
 
-    def regex_as_ewkt_plain() -> WKTElement:
+    def current_as_ewkt_plain() -> WKTElement:
         return plain.as_ewkt()
 
-    def rust_as_ewkt_plain() -> WKTElement:
+    def converter_as_ewkt_plain() -> WKTElement:
         return WKTElement(_wkb_wkt.to_wkt(plain.data, srid=plain.srid), extended=True)
 
-    def regex_as_ewkt_extended() -> WKTElement:
+    def current_as_ewkt_extended() -> WKTElement:
         return ewkt.as_ewkt()
 
-    def rust_as_ewkt_extended() -> WKTElement:
+    def converter_as_ewkt_extended() -> WKTElement:
         return WKTElement(_wkb_wkt.to_wkt(ewkt.data, srid=ewkt.srid), extended=True)
 
-    def partition_as_wkt_extended() -> WKTElement:
-        return WKTElement(strip_srid_partition(ewkt.data), ewkt.srid, extended=False)
+    def rejected_strict_partition_as_wkt_extended() -> WKTElement:
+        return WKTElement(
+            strip_srid_rejected_strict_partition(ewkt.data),
+            ewkt.srid,
+            extended=False,
+        )
 
-    def partition_as_wkt_extended_space() -> WKTElement:
-        return WKTElement(strip_srid_partition(ewkt_space.data), ewkt_space.srid, extended=False)
+    def rejected_strict_partition_as_wkt_extended_space() -> WKTElement:
+        return WKTElement(
+            strip_srid_rejected_strict_partition(ewkt_space.data),
+            ewkt_space.srid,
+            extended=False,
+        )
 
-    def partition_as_ewkt_extended() -> WKTElement:
-        return WKTElement(f"SRID={ewkt.srid};{strip_srid_partition(ewkt.data)}", extended=True)
+    def rejected_strict_partition_as_ewkt_extended() -> WKTElement:
+        return WKTElement(
+            f"SRID={ewkt.srid};{strip_srid_rejected_strict_partition(ewkt.data)}",
+            extended=True,
+        )
 
-    print("Current implementation versus converter-based Rust path")
+    print("Hybrid current implementation versus converter/Rust path")
     bench(
-        "as_wkt plain WKT",
-        regex_as_wkt_plain,
-        rust_as_wkt_plain,
+        "as_wkt plain WKT (current Python fast path)",
+        current_as_wkt_plain,
+        converter_as_wkt_plain,
         number=args.number,
         repeat=args.repeat,
     )
     bench(
-        "as_wkt EWKT strip SRID",
-        regex_as_wkt_extended,
-        rust_as_wkt_extended,
+        "as_wkt EWKT strip SRID (current Rust path)",
+        current_as_wkt_extended,
+        converter_as_wkt_extended,
         number=args.number,
         repeat=args.repeat,
     )
     bench(
-        "as_ewkt plain WKT add SRID",
-        regex_as_ewkt_plain,
-        rust_as_ewkt_plain,
+        "as_ewkt plain WKT add SRID (current Python fast path)",
+        current_as_ewkt_plain,
+        converter_as_ewkt_plain,
         number=args.number,
         repeat=args.repeat,
     )
     bench(
-        "as_ewkt EWKT normalize prefix",
-        regex_as_ewkt_extended,
-        rust_as_ewkt_extended,
+        "as_ewkt EWKT normalize prefix (current Rust path)",
+        current_as_ewkt_extended,
+        converter_as_ewkt_extended,
         number=args.number,
         repeat=args.repeat,
     )
 
     print()
-    print("EWKT prefix stripping alternatives")
+    print("Rejected EWKT string-only alternatives")
+
+    def old_regex_as_wkt_extended() -> WKTElement:
+        return WKTElement(strip_srid_old_regex(ewkt.data), ewkt.srid, extended=False)
+
+    def old_regex_as_ewkt_extended() -> WKTElement:
+        return WKTElement(f"SRID={ewkt.srid};{strip_srid_old_regex(ewkt.data)}", extended=True)
+
+    assert strip_srid_rejected_strict_partition(ewkt.data) == strip_srid_old_regex(ewkt.data)
+    assert strip_srid_rejected_strict_partition(ewkt_space.data) == strip_srid_old_regex(
+        ewkt_space.data
+    )
+    assert (
+        strip_srid_rejected_strict_partition("SRID=4326;  POINT (1 2)") == "SRID=4326;  POINT (1 2)"
+    )
+
     bench_one(
-        "as_wkt EWKT regex current",
-        regex_as_wkt_extended,
+        "as_wkt EWKT old regex",
+        old_regex_as_wkt_extended,
         number=args.number,
         repeat=args.repeat,
     )
     bench_one(
-        "as_wkt EWKT partition candidate",
-        partition_as_wkt_extended,
+        "as_wkt EWKT rejected strict partition candidate",
+        rejected_strict_partition_as_wkt_extended,
         number=args.number,
         repeat=args.repeat,
     )
     bench_one(
-        "as_wkt EWKT partition with space candidate",
-        partition_as_wkt_extended_space,
+        "as_wkt EWKT rejected strict partition candidate with space",
+        rejected_strict_partition_as_wkt_extended_space,
         number=args.number,
         repeat=args.repeat,
     )
     bench_one(
-        "as_wkt EWKT rust path",
-        rust_as_wkt_extended,
+        "as_wkt EWKT converter/Rust path",
+        converter_as_wkt_extended,
         number=args.number,
         repeat=args.repeat,
     )
     bench_one(
-        "as_ewkt EWKT regex current",
-        regex_as_ewkt_extended,
+        "as_ewkt EWKT old regex",
+        old_regex_as_ewkt_extended,
         number=args.number,
         repeat=args.repeat,
     )
     bench_one(
-        "as_ewkt EWKT partition candidate",
-        partition_as_ewkt_extended,
+        "as_ewkt EWKT rejected strict partition candidate",
+        rejected_strict_partition_as_ewkt_extended,
         number=args.number,
         repeat=args.repeat,
     )
     bench_one(
-        "as_ewkt EWKT rust path",
-        rust_as_ewkt_extended,
+        "as_ewkt EWKT converter/Rust path",
+        converter_as_ewkt_extended,
         number=args.number,
         repeat=args.repeat,
     )

--- a/tools/benchmark_wkt_element_fast_paths.py
+++ b/tools/benchmark_wkt_element_fast_paths.py
@@ -1,0 +1,193 @@
+"""Benchmark WKTElement WKT-only conversion paths.
+
+Run from the GeoAlchemy2 source tree with a tox environment that has the
+branch dependencies installed, for example:
+
+    ./test_container/run.sh /output/py312-sqlalatest/bin/python \
+        /geoalchemy2/tools/benchmark_wkt_element_fast_paths.py
+
+The "rust_path" functions model the converter-based implementation. The
+"regex_current" functions model the current branch implementation. The
+"partition_candidate" functions model a faster string-only alternative for
+EWKT prefix stripping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import timeit
+from collections.abc import Callable
+from statistics import median
+
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2.elements import WKTElement
+
+
+def strip_srid_partition(data: str) -> str:
+    wkt = data.partition(";")[2]
+    if wkt.startswith(" "):
+        wkt = wkt[1:]
+    return wkt
+
+
+def bench(
+    label: str,
+    current: Callable[[], WKTElement],
+    rust_path: Callable[[], WKTElement],
+    *,
+    number: int,
+    repeat: int,
+) -> None:
+    current_value = current()
+    rust_value = rust_path()
+    assert current_value.data == rust_value.data, (label, current_value.data, rust_value.data)
+    assert current_value.srid == rust_value.srid, (label, current_value.srid, rust_value.srid)
+    assert current_value.extended == rust_value.extended, (
+        label,
+        current_value.extended,
+        rust_value.extended,
+    )
+
+    current_times = timeit.repeat(current, repeat=repeat, number=number)
+    rust_times = timeit.repeat(rust_path, repeat=repeat, number=number)
+    current_med = median(current_times) / number * 1_000_000
+    rust_med = median(rust_times) / number * 1_000_000
+    print(
+        f"{label}: current={current_med:.3f} us/op "
+        f"rust_path={rust_med:.3f} us/op speedup={rust_med / current_med:.2f}x"
+    )
+
+
+def bench_one(
+    label: str,
+    func: Callable[[], WKTElement],
+    *,
+    number: int,
+    repeat: int,
+) -> None:
+    times = timeit.repeat(func, repeat=repeat, number=number)
+    func()
+    print(f"{label}: {median(times) / number * 1_000_000:.3f} us/op")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--number", type=int, default=200_000)
+    parser.add_argument("--repeat", type=int, default=9)
+    args = parser.parse_args()
+
+    plain = WKTElement("POINT (1 2)", srid=4326)
+    ewkt = WKTElement("SRID=4326;POINT (1 2)", extended=True)
+    ewkt_space = WKTElement("SRID=4326; POINT (1 2)", extended=True)
+
+    def regex_as_wkt_plain() -> WKTElement:
+        return plain.as_wkt()
+
+    def rust_as_wkt_plain() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt_no_srid(plain.data), srid=plain.srid, extended=False)
+
+    def regex_as_wkt_extended() -> WKTElement:
+        return ewkt.as_wkt()
+
+    def rust_as_wkt_extended() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt_no_srid(ewkt.data), srid=ewkt.srid, extended=False)
+
+    def regex_as_ewkt_plain() -> WKTElement:
+        return plain.as_ewkt()
+
+    def rust_as_ewkt_plain() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt(plain.data, srid=plain.srid), extended=True)
+
+    def regex_as_ewkt_extended() -> WKTElement:
+        return ewkt.as_ewkt()
+
+    def rust_as_ewkt_extended() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt(ewkt.data, srid=ewkt.srid), extended=True)
+
+    def partition_as_wkt_extended() -> WKTElement:
+        return WKTElement(strip_srid_partition(ewkt.data), ewkt.srid, extended=False)
+
+    def partition_as_wkt_extended_space() -> WKTElement:
+        return WKTElement(strip_srid_partition(ewkt_space.data), ewkt_space.srid, extended=False)
+
+    def partition_as_ewkt_extended() -> WKTElement:
+        return WKTElement(f"SRID={ewkt.srid};{strip_srid_partition(ewkt.data)}", extended=True)
+
+    print("Current implementation versus converter-based Rust path")
+    bench(
+        "as_wkt plain WKT",
+        regex_as_wkt_plain,
+        rust_as_wkt_plain,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench(
+        "as_wkt EWKT strip SRID",
+        regex_as_wkt_extended,
+        rust_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench(
+        "as_ewkt plain WKT add SRID",
+        regex_as_ewkt_plain,
+        rust_as_ewkt_plain,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench(
+        "as_ewkt EWKT normalize prefix",
+        regex_as_ewkt_extended,
+        rust_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+
+    print()
+    print("EWKT prefix stripping alternatives")
+    bench_one(
+        "as_wkt EWKT regex current",
+        regex_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_wkt EWKT partition candidate",
+        partition_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_wkt EWKT partition with space candidate",
+        partition_as_wkt_extended_space,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_wkt EWKT rust path",
+        rust_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_ewkt EWKT regex current",
+        regex_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_ewkt EWKT partition candidate",
+        partition_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_ewkt EWKT rust path",
+        rust_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_benchmarks.py
+++ b/tools/compare_benchmarks.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from html import escape
 from pathlib import Path
 from typing import Any
+from xml.etree import ElementTree
 
 METRICS = ("min", "max", "mean", "median", "stddev", "iqr")
 TIME_UNITS = {
@@ -41,6 +42,7 @@ class BenchmarkRun:
     path: Path
     data: dict[str, Any]
     benchmarks: dict[str, dict[str, Any]]
+    outcome_filter: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -81,6 +83,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="compare",
         required=True,
         help="Compare saved benchmark name or JSON file path.",
+    )
+    parser.add_argument(
+        "--base-junitxml",
+        type=Path,
+        default=None,
+        help="JUnit XML report for the base benchmark run.",
+    )
+    parser.add_argument(
+        "--compare-junitxml",
+        type=Path,
+        default=None,
+        help="JUnit XML report for the compare benchmark run.",
     )
     parser.add_argument(
         "--output",
@@ -140,7 +154,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Do not export SVG charts.",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if bool(args.base_junitxml) != bool(args.compare_junitxml):
+        parser.error("--base-junitxml and --compare-junitxml must be provided together")
+    return args
 
 
 def find_run_file(storage: Path, label_or_path: str) -> Path:
@@ -179,6 +196,72 @@ def load_run(label: str, path: Path) -> BenchmarkRun:
     data = json.loads(path.read_text(encoding="utf-8"))
     benchmarks = {benchmark["fullname"]: benchmark for benchmark in data.get("benchmarks", [])}
     return BenchmarkRun(label=label, path=path, data=data, benchmarks=benchmarks)
+
+
+def filter_run_by_junitxml(run: BenchmarkRun, junitxml: Path) -> BenchmarkRun:
+    outcomes = load_junit_outcomes(junitxml)
+    excluded = {
+        "failed": 0,
+        "error": 0,
+        "skipped": 0,
+        "missing-outcome": 0,
+    }
+    benchmarks = {}
+    for name, benchmark in run.benchmarks.items():
+        outcome = outcomes.get(name)
+        if outcome == "passed":
+            benchmarks[name] = benchmark
+        elif outcome is None:
+            excluded["missing-outcome"] += 1
+        else:
+            excluded[outcome] += 1
+
+    data = dict(run.data)
+    data["benchmarks"] = [
+        benchmark
+        for benchmark in run.data.get("benchmarks", [])
+        if benchmark.get("fullname") in benchmarks
+    ]
+    return BenchmarkRun(
+        label=run.label,
+        path=run.path,
+        data=data,
+        benchmarks=benchmarks,
+        outcome_filter={
+            "junitxml": str(junitxml),
+            "kept": len(benchmarks),
+            "excluded": excluded,
+        },
+    )
+
+
+def load_junit_outcomes(path: Path) -> dict[str, str]:
+    root = ElementTree.parse(path).getroot()
+    outcomes: dict[str, str] = {}
+    for testcase in root.iter():
+        if _local_name(testcase.tag) != "testcase":
+            continue
+        classname = testcase.attrib.get("classname")
+        name = testcase.attrib.get("name")
+        if not classname or not name:
+            continue
+        nodeid = junit_nodeid(classname, name)
+        outcomes[nodeid] = _merge_outcome(outcomes.get(nodeid), _junit_testcase_outcome(testcase))
+    return outcomes
+
+
+def junit_nodeid(classname: str, name: str) -> str:
+    parts = classname.split(".")
+    module_end = next(
+        (index for index, part in enumerate(parts) if part[:1].isupper()),
+        len(parts),
+    )
+    module_parts = parts[:module_end]
+    class_parts = parts[module_end:]
+    nodeid = f"{'/'.join(module_parts)}.py::{name}"
+    if class_parts:
+        nodeid = f"{'/'.join(module_parts)}.py::{'::'.join(class_parts)}::{name}"
+    return nodeid
 
 
 def compare_runs(
@@ -632,12 +715,24 @@ def main(argv: list[str] | None = None) -> int:
     compare_path = find_run_file(args.storage, args.compare)
     base = load_run(args.base, base_path)
     compare = load_run(args.compare, compare_path)
+    filtering_enabled = False
+    if args.base_junitxml and args.compare_junitxml:
+        filtering_enabled = True
+        base = filter_run_by_junitxml(base, args.base_junitxml)
+        compare = filter_run_by_junitxml(compare, args.compare_junitxml)
+    else:
+        print(
+            "Warning: benchmark outcome filtering is disabled. Pass both "
+            "--base-junitxml and --compare-junitxml to avoid comparing failed, "
+            "errored, skipped, or xfailed benchmark tests.",
+            file=sys.stderr,
+        )
     records = compare_runs(
         base,
         compare,
         metric=args.metric,
         tolerance_percent=args.tolerance_percent,
-        only_common=args.only_common,
+        only_common=args.only_common or filtering_enabled,
     )
     records = sort_records(records, sort_by=args.sort_by, sort_order=args.sort_order)
     exported = export_reports(
@@ -654,6 +749,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Base:    {base.path}")
     print(f"Compare: {compare.path}")
     print(f"Metric:  {args.metric}")
+    print_filter_summary(base)
+    print_filter_summary(compare)
     print()
     print("\n".join(format_table(records, base.label, compare.label, args.metric, unit)))
     print()
@@ -741,13 +838,52 @@ def _row(record: ComparisonRecord, metric: str) -> dict[str, Any]:
 
 
 def _run_summary(run: BenchmarkRun) -> dict[str, Any]:
-    return {
+    summary = {
         "label": run.label,
         "path": str(run.path),
         "commit_info": run.data.get("commit_info", {}),
         "machine_info": run.data.get("machine_info", {}),
         "benchmark_count": len(run.benchmarks),
     }
+    if run.outcome_filter is not None:
+        summary["outcome_filter"] = run.outcome_filter
+    return summary
+
+
+def print_filter_summary(run: BenchmarkRun) -> None:
+    if run.outcome_filter is None:
+        return
+    excluded = run.outcome_filter["excluded"]
+    excluded_total = sum(excluded.values())
+    details = (
+        ", ".join(f"{reason}={count}" for reason, count in excluded.items() if count) or "none"
+    )
+    print(
+        f"{run.label} outcome filter: kept {run.outcome_filter['kept']} "
+        f"benchmark(s), excluded {excluded_total} ({details})"
+    )
+
+
+def _junit_testcase_outcome(testcase: ElementTree.Element) -> str:
+    child_tags = {_local_name(child.tag) for child in testcase}
+    if "error" in child_tags:
+        return "error"
+    if "failure" in child_tags:
+        return "failed"
+    if "skipped" in child_tags:
+        return "skipped"
+    return "passed"
+
+
+def _merge_outcome(existing: str | None, new: str) -> str:
+    if existing is None:
+        return new
+    priority = {"passed": 0, "skipped": 1, "failed": 2, "error": 3}
+    return new if priority[new] > priority[existing] else existing
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
 
 
 def _plain_table(headers: list[str], rows: list[list[str]]) -> list[str]:

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist = py{310,311,312,313}-sqla{14,latest}, pypy3-sqla{14,latest}, lint, coverage, docs
 requires=
-    setuptools>42
+    setuptools>77
 
 [gh-actions]
 python =
     3.10: py310-sqla{14, latest}, lint
-    3.11: py311-sqla{14, latest}, docs
+    3.11: py311-sqla{14, latest}
     3.12: py312-sqla{14, latest}
-    3.13: py313-sqla{14, latest}
+    3.13: py313-sqla{14, latest}, docs
     pypy-3.11: pypy3-sqla{14, latest}
 
 [testenv]
@@ -87,7 +87,7 @@ commands =
     prek run --all-files
 
 [testenv:docs]
-basepython = python3.11
+basepython = python3.13
 changedir = doc
 allowlist_externals = make
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps=
     -rrequirements-mypy.txt
 commands=
     pip freeze --all
-    pytest -v \
+    pytest \
         --basetemp={envtmpdir} \
         --cov=geoalchemy2 \
         --cov-branch \


### PR DESCRIPTION
## Summary

This PR centralizes WKB/WKT conversion through `wkb-wkt-converter>=0.6.1` and makes SRID handling more consistent across GeoAlchemy2 elements, bind processors, and dialect compilers.

## Changes

- Add private `_wkb_wkt` conversion helpers and cross-format element methods:
  - `WKTElement.as_wkb()`
  - `WKTElement.as_ewkb()`
  - `WKBElement.as_wkt()`
  - `WKBElement.as_ewkt()`
- Normalize how unknown, zero, plain, and embedded SRIDs are handled across WKB, EWKB, WKT, and EWKT paths.
- Update MySQL and MariaDB EWKB handling to compile through supported WKB constructors, strip embedded SRIDs when needed, and split runtime EWKB bind values into WKB and SRID bind parameters.
- Improve raw WKB/EWKB and `WKBElement` bind processing for PostgreSQL, SQLite, GeoPackage, MSSQL, MySQL, and MariaDB.
- Add SpatiaLite/GeoPackage EWKB hex-text handling and share more WKB compiler behavior between SQLite and GeoPackage.
- Expand tests for element conversion, dialect compilation, dynamic bind expansion, SRID validation, raw WKB/EWKB inputs, MSSQL WKT normalization, and benchmark insert/select behavior.
- Chunk MSSQL benchmark inserts to respect SQL Server’s row-value limit.
