### PR TITLE
Fix: Add MySQL and MariaDB constructor compilation fixes

### DIFF
--- a/geoalchemy2/admin/dialects/common.py
+++ b/geoalchemy2/admin/dialects/common.py
@@ -5,8 +5,10 @@ from packaging import version
 from sqlalchemy import Column
 from sqlalchemy import String
 from sqlalchemy.sql import expression
+from sqlalchemy.sql.elements import BindParameter
 from sqlalchemy.types import TypeDecorator
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.types import Geometry
 
@@ -108,8 +110,13 @@ def after_drop(table, bind, **kw):
 
 def compile_bin_literal(wkb_clause):
     """Compile a binary literal for WKBElement."""
+    if not hasattr(wkb_clause, "value"):
+        return wkb_clause
+
     wkb_data = wkb_clause.value
-    if isinstance(wkb_data, (bytes, memoryview, WKBElement)):
+    if isinstance(wkb_data, (bytes, bytearray, memoryview, WKBElement)):
+        if isinstance(wkb_data, bytearray):
+            wkb_data = bytes(wkb_data)
         if isinstance(wkb_data, memoryview):
             wkb_data = wkb_data.tobytes()
         if isinstance(wkb_data, bytes):
@@ -124,3 +131,44 @@ def compile_bin_literal(wkb_clause):
             unique=True,
         )
     return wkb_clause
+
+
+def _is_auto_constructor_bindparam(clause, constructor_name):
+    return (
+        isinstance(clause, BindParameter)
+        and getattr(clause, "unique", False)
+        and getattr(clause, "_orig_key", None) == constructor_name
+    )
+
+
+def _has_known_literal_srid(clause):
+    if not hasattr(clause, "value"):
+        return True
+
+    try:
+        return _wkb_wkt.is_known_srid(int(clause.value))
+    except (TypeError, ValueError):
+        return True
+
+
+def unwrap_wkb_constructor_clauses(clauses):
+    if len(clauses) != 1:
+        return clauses, None
+
+    from geoalchemy2 import functions
+
+    inner_constructor = clauses[0]
+    constructor_names = (
+        ("ST_GeomFromWKB", functions.ST_GeomFromWKB),
+        ("ST_GeomFromEWKB", functions.ST_GeomFromEWKB),
+    )
+    for constructor_name, constructor_class in constructor_names:
+        if not isinstance(inner_constructor, constructor_class):
+            continue
+        inner_clauses = list(inner_constructor.clauses)
+        if inner_clauses and _is_auto_constructor_bindparam(inner_clauses[0], constructor_name):
+            if len(inner_clauses) > 1 and not _has_known_literal_srid(inner_clauses[1]):
+                inner_clauses = inner_clauses[:1]
+            return inner_clauses, inner_constructor
+
+    return clauses, None

--- a/geoalchemy2/admin/dialects/mariadb.py
+++ b/geoalchemy2/admin/dialects/mariadb.py
@@ -4,6 +4,14 @@ from sqlalchemy.ext.compiler import compiles
 
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import compile_bin_literal
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
+from geoalchemy2.admin.dialects.mysql import _coerce_ewkb_bind_clause_to_wkb
+from geoalchemy2.admin.dialects.mysql import _coerce_known_ewkb_clause_to_wkb
+from geoalchemy2.admin.dialects.mysql import _compile_srid_arg
+from geoalchemy2.admin.dialects.mysql import _ewkb_processor_fixed_srid
+from geoalchemy2.admin.dialects.mysql import _has_effective_srid_argument
+from geoalchemy2.admin.dialects.mysql import _is_bindparam_clause
+from geoalchemy2.admin.dialects.mysql import _runtime_ewkb_processor_context
 from geoalchemy2.admin.dialects.mysql import after_create  # noqa
 from geoalchemy2.admin.dialects.mysql import after_drop  # noqa
 from geoalchemy2.admin.dialects.mysql import before_create  # noqa
@@ -16,6 +24,8 @@ from geoalchemy2.elements import WKTElement
 def _cast(param):
     if isinstance(param, memoryview):
         param = param.tobytes()
+    if isinstance(param, bytearray):
+        param = bytes(param)
     if isinstance(param, bytes):
         param = WKBElement(param)
     if isinstance(param, WKBElement):
@@ -86,23 +96,65 @@ def _compile_GeomFromText_MariaDB(element, compiler, **kw):
     return res
 
 
-def _compile_GeomFromWKB_MariaDB(element, compiler, **kw):
+def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
     identifier = "ST_GeomFromWKB"
     # Store the SRID
     clauses = list(element.clauses)
-    try:
-        srid = clauses[1].value
-    except (IndexError, TypeError, ValueError):
-        srid = element.type.srid
+    if kw.get("literal_binds", False):
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
 
-    wkb_clause = compile_bin_literal(clauses[0]) if kw.get("literal_binds", False) else clauses[0]
+    inferred_srid = None
+    if coerce_ewkb:
+        original_wkb_clause = clauses[0]
+        should_process_at_runtime = (
+            _is_bindparam_clause(original_wkb_clause)
+            and not kw.get("literal_binds", False)
+            and (
+                getattr(original_wkb_clause, "value", None) is None
+                or getattr(original_wkb_clause, "callable", None) is not None
+            )
+        )
+        if should_process_at_runtime:
+            has_srid_argument = _has_effective_srid_argument(clauses)
+            fixed_srid = None
+            if not has_srid_argument:
+                fixed_srid = _ewkb_processor_fixed_srid(element, clauses)
+            processor_context = _runtime_ewkb_processor_context(
+                compiler,
+                original_wkb_clause,
+                fixed_srid=fixed_srid,
+                has_srid_argument=has_srid_argument,
+            )
+            wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
+                original_wkb_clause,
+                as_hex=True,
+                fixed_srid=fixed_srid,
+                has_srid_argument=has_srid_argument,
+                processor_context=processor_context,
+            )
+        else:
+            wkb_value_clause, inferred_srid = _coerce_known_ewkb_clause_to_wkb(
+                element,
+                compiler,
+                original_wkb_clause,
+                clauses,
+                as_hex=True,
+                preserve_user_bind=not kw.get("literal_binds", False),
+            )
+    else:
+        wkb_value_clause = clauses[0]
+
+    wkb_clause = wkb_value_clause
+    if kw.get("literal_binds", False):
+        wkb_clause = compile_bin_literal(wkb_value_clause)
     prefix = "unhex("
     suffix = ")"
 
     compiled = compiler.process(wkb_clause, **kw)
+    compiled_srid = _compile_srid_arg(element, clauses, inferred_srid, compiler, **kw)
 
-    if srid > 0:
-        return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
+    if compiled_srid is not None:
+        return f"{identifier}({prefix}{compiled}{suffix}, {compiled_srid})"
     else:
         return f"{identifier}({prefix}{compiled}{suffix})"
 
@@ -124,4 +176,4 @@ def _MariaDB_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "mariadb")  # type: ignore
 def _MariaDB_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_MariaDB(element, compiler, **kw)
+    return _compile_GeomFromWKB_MariaDB(element, compiler, coerce_ewkb=True, **kw)

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -3,13 +3,24 @@
 from sqlalchemy import text
 from sqlalchemy.dialects.mysql.base import ischema_names as _mysql_ischema_names
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import expression
+from sqlalchemy.sql.elements import BindParameter
+from sqlalchemy.sql.elements import Null
 from sqlalchemy.sql.sqltypes import NullType
+from sqlalchemy.types import LargeBinary
+from sqlalchemy.types import String
+from sqlalchemy.types import TypeDecorator
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.exc import ArgumentError
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 
@@ -181,35 +192,431 @@ def _compile_GeomFromText_MySql(element, compiler, **kw):
     compiled = compiler.process(element.clauses, **kw)
     srid = element.type.srid
 
-    if srid > 0:
+    if is_known_srid(srid):
         return f"{identifier}({compiled}, {srid})"
     else:
         return f"{identifier}({compiled})"
 
 
-def _compile_GeomFromWKB_MySql(element, compiler, **kw):
+def _known_wkb_bindvalue_srids(bindvalue):
+    if isinstance(bindvalue, bytearray):
+        bindvalue = bytes(bindvalue)
+
+    srids = []
+    if isinstance(bindvalue, WKBElement):
+        if is_known_srid(bindvalue.srid):
+            srids.append(bindvalue.srid)
+        bindvalue = bindvalue.data
+
+    if isinstance(bindvalue, (bytes, bytearray, memoryview, str)):
+        srid = _wkb_wkt.wkb_srid(bindvalue)
+        if is_known_srid(srid):
+            srids.append(srid)
+
+    return srids
+
+
+def _validate_wkb_bindvalue_srid(bindvalue, column_srid):
+    if not is_known_srid(column_srid):
+        return
+
+    srids = _known_wkb_bindvalue_srids(bindvalue)
+    for srid in srids:
+        if srid != column_srid:
+            raise ArgumentError(
+                f"The SRID ({srid}) of the supplied value is different "
+                f"from the one of the column ({column_srid})"
+            )
+
+
+class _MySQLEWKBProcessorContext:
+    def __init__(self):
+        self.fixed_srids = set()
+        self.reject_known_srid_without_argument = False
+
+    def add_context(self, *, fixed_srid=None, has_srid_argument=False):
+        if is_known_srid(fixed_srid):
+            self.fixed_srids.add(fixed_srid)
+        elif not has_srid_argument:
+            self.reject_known_srid_without_argument = True
+
+
+def _validate_wkb_bindvalue_context(bindvalue, processor_context):
+    if processor_context is None:
+        return
+
+    srids = _known_wkb_bindvalue_srids(bindvalue)
+    if processor_context.reject_known_srid_without_argument and srids:
+        raise ArgumentError(
+            "Runtime ST_GeomFromEWKB values with an embedded SRID require "
+            "a fixed column SRID or an explicit SRID argument for MySQL/MariaDB compilation"
+        )
+
+    for fixed_srid in sorted(processor_context.fixed_srids):
+        for srid in srids:
+            if srid != fixed_srid:
+                raise ArgumentError(
+                    f"The SRID ({srid}) of the supplied value is different "
+                    f"from the one of the column ({fixed_srid})"
+                )
+
+
+def _ewkb_to_wkb_data(
+    value,
+    *,
+    as_hex=False,
+    fixed_srid=None,
+    has_srid_argument=False,
+    processor_context=None,
+):
+    if value is None:
+        return None
+
+    if processor_context is not None:
+        _validate_wkb_bindvalue_context(value, processor_context)
+    else:
+        _validate_wkb_bindvalue_srid(value, fixed_srid)
+    if processor_context is None and not is_known_srid(fixed_srid) and not has_srid_argument:
+        srids = _known_wkb_bindvalue_srids(value)
+        if srids:
+            raise ArgumentError(
+                "Runtime ST_GeomFromEWKB values with an embedded SRID require "
+                "a fixed column SRID or an explicit SRID argument for MySQL/MariaDB compilation"
+            )
+
+    if isinstance(value, bytearray):
+        value = bytes(value)
+
+    if isinstance(value, WKBElement):
+        value = value.data
+    if as_hex:
+        return _wkb_wkt.to_hex_wkb_no_srid(value).lower()
+    return _wkb_wkt.to_wkb_no_srid(value)
+
+
+class _MySQLEWKBBindType(TypeDecorator):
+    impl = LargeBinary
+    cache_ok = False
+
+    def __init__(
+        self,
+        *,
+        as_hex=False,
+        fixed_srid=None,
+        has_srid_argument=False,
+        processor_context=None,
+    ):
+        super().__init__()
+        self.as_hex = as_hex
+        self.fixed_srid = fixed_srid
+        self.has_srid_argument = has_srid_argument
+        self._processor_context = processor_context
+
+    def load_dialect_impl(self, dialect):
+        impl = String() if self.as_hex else LargeBinary()
+        return dialect.type_descriptor(impl)
+
+    def process_bind_param(self, value, dialect):
+        return _ewkb_to_wkb_data(
+            value,
+            as_hex=self.as_hex,
+            fixed_srid=self.fixed_srid,
+            has_srid_argument=self.has_srid_argument,
+            processor_context=self._processor_context,
+        )
+
+
+def _is_bindparam_clause(clause):
+    return isinstance(clause, BindParameter)
+
+
+def _is_mysql_auto_constructor_bindparam(clause, constructor_name):
+    return (
+        _is_bindparam_clause(clause)
+        and getattr(clause, "unique", False)
+        and getattr(clause, "_orig_key", None) == constructor_name
+    )
+
+
+def _is_user_bindparam_clause(clause, *constructor_names):
+    return _is_bindparam_clause(clause) and not any(
+        _is_mysql_auto_constructor_bindparam(clause, constructor_name)
+        for constructor_name in constructor_names
+    )
+
+
+def _is_runtime_bindparam_clause(clause):
+    return _is_bindparam_clause(clause) and (
+        getattr(clause, "required", False) or getattr(clause, "callable", None) is not None
+    )
+
+
+def _is_effective_srid_clause(srid_clause):
+    if isinstance(srid_clause, Null):
+        return False
+
+    if _is_user_bindparam_clause(
+        srid_clause,
+        "ST_GeomFromEWKB",
+        "ST_GeomFromWKB",
+    ) and _is_runtime_bindparam_clause(srid_clause):
+        return True
+
+    if hasattr(srid_clause, "value"):
+        value = srid_clause.value
+        if value is None:
+            return False
+        try:
+            srid = int(value)
+        except (TypeError, ValueError):
+            return True
+        return is_known_srid(srid)
+    return True
+
+
+def _has_effective_srid_argument(clauses):
+    return len(clauses) > 1 and _is_effective_srid_clause(clauses[1])
+
+
+def _ewkb_processor_fixed_srid(element, clauses, inferred_srid=None):
+    if inferred_srid is not None:
+        return inferred_srid
+    if len(clauses) == 1 and is_known_srid(element.type.srid):
+        return element.type.srid
+    return None
+
+
+def _runtime_bind_identifier(source_bind):
+    return getattr(source_bind, "_identifying_key", source_bind.key)
+
+
+def _runtime_ewkb_processor_context(
+    compiler,
+    source_bind,
+    *,
+    fixed_srid=None,
+    has_srid_argument=False,
+):
+    contexts = getattr(compiler, "_geoalchemy2_mysql_ewkb_processor_contexts", None)
+    if contexts is None:
+        contexts = {}
+        compiler._geoalchemy2_mysql_ewkb_processor_contexts = contexts
+
+    context_key = _runtime_bind_identifier(source_bind)
+    processor_context = contexts.get(context_key)
+    if processor_context is None:
+        processor_context = _MySQLEWKBProcessorContext()
+        contexts[context_key] = processor_context
+
+    processor_context.add_context(
+        fixed_srid=fixed_srid,
+        has_srid_argument=has_srid_argument,
+    )
+    return processor_context
+
+
+def _coerce_ewkb_clause_to_wkb(wkb_clause, *, as_hex=False):
+    try:
+        wkb_data = wkb_clause.value
+    except AttributeError:
+        return wkb_clause, None
+
+    if isinstance(wkb_data, WKBElement):
+        srid = wkb_data.srid if is_known_srid(wkb_data.srid) else None
+        wkb_data = wkb_data.data
+    elif isinstance(wkb_data, (bytes, bytearray, memoryview, str)):
+        srid = _wkb_wkt.wkb_srid(wkb_data)
+        srid = srid if is_known_srid(srid) else None
+    else:
+        return wkb_clause, None
+
+    if as_hex:
+        wkb_data = _wkb_wkt.to_hex_wkb_no_srid(wkb_data).lower()
+    else:
+        wkb_data = _wkb_wkt.to_wkb_no_srid(wkb_data)
+
+    bindparam_args = {
+        "key": wkb_clause.key,
+        "value": wkb_data,
+        "unique": True,
+    }
+    if not as_hex:
+        bindparam_args["type_"] = wkb_clause.type
+
+    return expression.bindparam(**bindparam_args), srid
+
+
+def _coerce_ewkb_bind_clause_to_wkb(
+    wkb_clause,
+    *,
+    as_hex=False,
+    literal=False,
+    fixed_srid=None,
+    has_srid_argument=False,
+    processor_context=None,
+):
+    if not hasattr(wkb_clause, "value"):
+        return wkb_clause
+
+    if literal:
+        wkb_clause, _ = _coerce_ewkb_clause_to_wkb(wkb_clause, as_hex=as_hex)
+        return wkb_clause
+
+    return expression.type_coerce(
+        wkb_clause,
+        _MySQLEWKBBindType(
+            as_hex=as_hex,
+            fixed_srid=fixed_srid,
+            has_srid_argument=has_srid_argument,
+            processor_context=processor_context,
+        ),
+    )
+
+
+def _coerce_known_ewkb_clause_to_wkb(
+    element,
+    compiler,
+    original_wkb_clause,
+    clauses,
+    *,
+    as_hex=False,
+    preserve_user_bind=True,
+):
+    wkb_value_clause, inferred_srid = _coerce_ewkb_clause_to_wkb(
+        original_wkb_clause,
+        as_hex=as_hex,
+    )
+    if (
+        not preserve_user_bind
+        or wkb_value_clause is original_wkb_clause
+        or not _is_user_bindparam_clause(original_wkb_clause, "ST_GeomFromEWKB")
+    ):
+        return wkb_value_clause, inferred_srid
+
+    has_srid_argument = _has_effective_srid_argument(clauses)
+    fixed_srid = None
+    if not has_srid_argument:
+        fixed_srid = _ewkb_processor_fixed_srid(
+            element,
+            clauses,
+            inferred_srid=inferred_srid,
+        )
+    processor_context = _runtime_ewkb_processor_context(
+        compiler,
+        original_wkb_clause,
+        fixed_srid=fixed_srid,
+        has_srid_argument=has_srid_argument,
+    )
+    wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
+        original_wkb_clause,
+        as_hex=as_hex,
+        fixed_srid=fixed_srid,
+        has_srid_argument=has_srid_argument,
+        processor_context=processor_context,
+    )
+    return wkb_value_clause, inferred_srid
+
+
+def _compile_srid_clause(srid_clause, compiler, **kw):
+    if isinstance(srid_clause, Null):
+        return None
+
+    is_user_bindparam = _is_user_bindparam_clause(
+        srid_clause,
+        "ST_GeomFromEWKB",
+        "ST_GeomFromWKB",
+    )
+    if is_user_bindparam and _is_runtime_bindparam_clause(srid_clause):
+        return compiler.process(srid_clause, **kw)
+
+    if hasattr(srid_clause, "value"):
+        value = srid_clause.value
+        if value is None:
+            return None
+        try:
+            srid = int(value)
+        except (TypeError, ValueError):
+            return compiler.process(srid_clause, **kw)
+        if not is_known_srid(srid):
+            return None
+        return compiler.process(srid_clause, **kw) if is_user_bindparam else str(srid)
+    return compiler.process(srid_clause, **kw)
+
+
+def _compile_srid_arg(element, clauses, inferred_srid, compiler, **kw):
+    if len(clauses) > 1:
+        compiled_srid = _compile_srid_clause(clauses[1], compiler, **kw)
+        if compiled_srid is not None:
+            return compiled_srid
+        return str(inferred_srid) if inferred_srid is not None else None
+
+    srid = inferred_srid if inferred_srid is not None else element.type.srid
+    return str(srid) if is_known_srid(srid) else None
+
+
+def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewkb=False, **kw):
+    identifier = identifier or element.identifier
+
     # Store the SRID
     clauses = list(element.clauses)
-    try:
-        srid = clauses[1].value
-    except (IndexError, TypeError, ValueError):
-        srid = element.type.srid
+    if kw.get("literal_binds", False):
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
+
+    inferred_srid = None
+    if coerce_ewkb:
+        original_wkb_clause = clauses[0]
+        should_process_at_runtime = (
+            _is_bindparam_clause(original_wkb_clause)
+            and not kw.get("literal_binds", False)
+            and (
+                getattr(original_wkb_clause, "value", None) is None
+                or getattr(original_wkb_clause, "callable", None) is not None
+            )
+        )
+        if should_process_at_runtime:
+            has_srid_argument = _has_effective_srid_argument(clauses)
+            fixed_srid = None
+            if not has_srid_argument:
+                fixed_srid = _ewkb_processor_fixed_srid(element, clauses)
+            processor_context = _runtime_ewkb_processor_context(
+                compiler,
+                original_wkb_clause,
+                fixed_srid=fixed_srid,
+                has_srid_argument=has_srid_argument,
+            )
+            wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
+                original_wkb_clause,
+                fixed_srid=fixed_srid,
+                has_srid_argument=has_srid_argument,
+                processor_context=processor_context,
+            )
+        else:
+            wkb_value_clause, inferred_srid = _coerce_known_ewkb_clause_to_wkb(
+                element,
+                compiler,
+                original_wkb_clause,
+                clauses,
+                preserve_user_bind=not kw.get("literal_binds", False),
+            )
+    else:
+        wkb_value_clause = clauses[0]
 
     if kw.get("literal_binds", False):
-        wkb_clause = compile_bin_literal(clauses[0])
+        wkb_clause = compile_bin_literal(wkb_value_clause)
         prefix = "unhex("
         suffix = ")"
     else:
-        wkb_clause = clauses[0]
+        wkb_clause = wkb_value_clause
         prefix = ""
         suffix = ""
 
     compiled = compiler.process(wkb_clause, **kw)
+    compiled_srid = _compile_srid_arg(element, clauses, inferred_srid, compiler, **kw)
 
-    if srid > 0:
-        return f"{element.identifier}({prefix}{compiled}{suffix}, {srid})"
+    if compiled_srid is not None:
+        return f"{identifier}({prefix}{compiled}{suffix}, {compiled_srid})"
     else:
-        return f"{element.identifier}({prefix}{compiled}{suffix})"
+        return f"{identifier}({prefix}{compiled}{suffix})"
 
 
 @compiles(functions.ST_GeomFromText, "mysql")  # type: ignore
@@ -229,4 +636,6 @@ def _MySQL_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "mysql")  # type: ignore
 def _MySQL_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_MySql(element, compiler, **kw)
+    return _compile_GeomFromWKB_MySql(
+        element, compiler, identifier="ST_GeomFromWKB", coerce_ewkb=True, **kw
+    )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,16 +4,28 @@ import pytest
 from sqlalchemy import Column
 from sqlalchemy import MetaData
 from sqlalchemy import Table
+from sqlalchemy import bindparam
+from sqlalchemy.dialects import mysql
+from sqlalchemy.dialects.mysql import mariadb as mariadb_dialect
 from sqlalchemy.sql import func
 from sqlalchemy.sql import insert
 from sqlalchemy.sql import text
 
+from geoalchemy2.admin.dialects import mariadb as _mariadb_admin  # noqa: F401
+from geoalchemy2.admin.dialects import mysql as _mysql_admin  # noqa: F401
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.elements import WKTElement
 from geoalchemy2.exc import ArgumentError
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
 
 from . import select
+
+WKB_HEX = "0101000000000000000000f03f0000000000000040"
+EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
+WEB_MERCATOR_EWKB_HEX = "0101000020110f0000000000000000f03f0000000000000040"
+ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
 
 
 def eq_sql(a, b):
@@ -218,6 +230,380 @@ class TestGeometryCollection:
     def test_get_col_spec(self):
         g = Geometry(geometry_type="GEOMETRYCOLLECTION", srid=900913)
         assert g.get_col_spec() == "geometry(GEOMETRYCOLLECTION,900913)"
+
+
+class TestMySQLWKBConstructors:
+    @staticmethod
+    def normalize_sql(sql):
+        return re.sub(r"\s+", " ", str(sql)).strip()
+
+    def test_geom_from_ewkb_compiles_to_supported_wkb_constructor(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 4326)"
+        assert compiled_expr.params == {"param_1": bytes.fromhex(WKB_HEX)}
+
+    def test_geom_from_ewkb_literal_compile_strips_ewkb_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKTElement("POINT (1 2)", srid=4326).as_wkb(),
+            WKTElement("POINT (1 2)", srid=4326).as_ewkb(),
+        ],
+    )
+    def test_geom_from_ewkb_literal_compile_unwraps_wkbelement_constructor(self, value):
+        expr = func.ST_GeomFromEWKB(value, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    def test_geom_from_wkb_omits_unknown_srid(self):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), -1)
+
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        compiled_literal = expr.compile(
+            dialect=mysql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s)"
+        assert self.normalize_sql(compiled_literal) == f"ST_GeomFromWKB(unhex('{WKB_HEX}'))"
+
+    @pytest.mark.parametrize("srid", [None, -1, 0])
+    def test_geom_from_wkb_omits_fixed_unknown_srid_bindparam(self, srid):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), bindparam("srid", srid))
+
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s)"
+        assert "srid" not in compiled_expr.params
+
+    def test_geom_from_wkb_keeps_runtime_srid_bindparam(self):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), bindparam("srid"))
+
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert "srid" in compiled_expr.params
+
+    def test_wkbelement_literal_compile_omits_unknown_srid(self):
+        query = select([func.ST_AsText(WKBElement(bytes.fromhex(WKB_HEX)))])
+
+        compiled = self.normalize_sql(
+            query.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert f"ST_GeomFromWKB(unhex('{WKB_HEX}'))" in compiled
+        assert ", -1" not in compiled
+
+    def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
+
+        compiled = self.normalize_sql(expr.compile(dialect=mysql.dialect()))
+
+        assert compiled == "ST_GeomFromWKB(%s, 4326)"
+
+    def test_geom_from_ewkb_uses_embedded_srid_without_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))
+
+        compiled = self.normalize_sql(expr.compile(dialect=mysql.dialect()))
+
+        assert compiled == "ST_GeomFromWKB(%s, 4326)"
+
+    @pytest.mark.parametrize("srid", [None, -1, 0])
+    def test_geom_from_ewkb_omitted_explicit_srid_uses_embedded_srid(self, srid):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), srid)
+
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 4326)"
+        assert list(compiled_expr.params.values()) == [bytes.fromhex(WKB_HEX)]
+
+    @pytest.mark.parametrize("srid", [None, -1, 0])
+    def test_geom_from_ewkb_runtime_bind_with_omitted_explicit_srid_rejects_ewkb(
+        self,
+        srid,
+    ):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), srid)
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s)"
+        assert set(compiled_expr.params) == {"wkb"}
+        assert wkb_processor(bytes.fromhex(WKB_HEX)) == bytes.fromhex(WKB_HEX)
+        with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
+            wkb_processor(bytes.fromhex(EWKB_HEX))
+
+    def test_geom_from_ewkb_defaulted_bindparam_preserves_key_and_processor(self):
+        source_bind = bindparam("wkb", bytes.fromhex(EWKB_HEX))
+        expr = func.ST_GeomFromEWKB(source_bind)
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+        override = bytes.fromhex(WKB_HEX)
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 4326)"
+        assert compiled_expr.params == {"wkb": bytes.fromhex(EWKB_HEX)}
+        assert compiled_expr.construct_params({"wkb": override}) == {"wkb": override}
+        assert wkb_processor(compiled_expr.params["wkb"]) == bytes.fromhex(WKB_HEX)
+        assert wkb_processor(bytes.fromhex(EWKB_HEX)) == bytes.fromhex(WKB_HEX)
+        with pytest.raises(ArgumentError, match=r"column \(4326\)"):
+            wkb_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))
+
+    def test_geom_from_ewkb_fixed_srid_bindparam_strips_runtime_ewkb(self):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 3857)"
+        assert set(compiled_expr.params) == {"wkb"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(WKB_HEX)) == bytes.fromhex(
+            WKB_HEX
+        )
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(ZERO_SRID_EWKB_HEX)) == (
+            bytes.fromhex(WKB_HEX)
+        )
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX))
+
+    @pytest.mark.parametrize("srids", [(3857, 4326), (4326, 3857)])
+    def test_geom_from_ewkb_reused_fixed_srid_bind_validates_all_contexts(self, srids):
+        source_bind = bindparam("wkb")
+        stmt = select(
+            [
+                func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=srids[0])),
+                func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=srids[1])),
+            ]
+        )
+        compiled_expr = stmt.compile(dialect=mysql.dialect())
+        compiled = self.normalize_sql(compiled_expr)
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+
+        assert f"ST_GeomFromWKB(%s, {srids[0]})" in compiled
+        assert f"ST_GeomFromWKB(%s, {srids[1]})" in compiled
+        assert wkb_processor(bytes.fromhex(WKB_HEX)) == bytes.fromhex(WKB_HEX)
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            wkb_processor(bytes.fromhex(EWKB_HEX))
+
+    def test_geom_from_ewkb_runtime_bind_without_srid_rejects_embedded_srid(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s)"
+        assert wkb_processor(bytes.fromhex(WKB_HEX)) == bytes.fromhex(WKB_HEX)
+        with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
+            wkb_processor(bytes.fromhex(EWKB_HEX))
+        with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
+            wkb_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=4326))
+
+    def test_geom_from_ewkb_explicit_srid_bindparam_strips_runtime_ewkb(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), bindparam("srid"))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert set(compiled_expr.params) == {"wkb", "srid"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == bytes.fromhex(
+            WKB_HEX
+        )
+
+
+class TestMariaDBWKBConstructors:
+    @staticmethod
+    def normalize_sql(sql):
+        return re.sub(r"\s+", " ", str(sql)).strip()
+
+    @staticmethod
+    def dialect():
+        return mariadb_dialect.MariaDBDialect()
+
+    def test_geom_from_ewkb_compiles_to_supported_wkb_constructor(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled_expr = expr.compile(dialect=self.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 4326)"
+        assert compiled_expr.params == {"param_1": WKB_HEX}
+
+    def test_geom_from_ewkb_literal_compile_strips_ewkb_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=self.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            WKBElement(bytes.fromhex(WKB_HEX)),
+            WKTElement("POINT (1 2)", srid=4326).as_wkb(),
+            WKTElement("POINT (1 2)", srid=4326).as_ewkb(),
+        ],
+    )
+    def test_geom_from_ewkb_literal_compile_unwraps_wkbelement_constructor(self, value):
+        expr = func.ST_GeomFromEWKB(value, type_=Geometry(srid=4326))
+
+        compiled = self.normalize_sql(
+            expr.compile(dialect=self.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == f"ST_GeomFromWKB(unhex('{WKB_HEX}'), 4326)"
+
+    def test_geom_from_wkb_omits_unknown_srid(self):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), -1)
+
+        compiled_expr = expr.compile(dialect=self.dialect())
+        compiled_literal = expr.compile(
+            dialect=self.dialect(), compile_kwargs={"literal_binds": True}
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s))"
+        assert self.normalize_sql(compiled_literal) == f"ST_GeomFromWKB(unhex('{WKB_HEX}'))"
+
+    @pytest.mark.parametrize("srid", [None, -1, 0])
+    def test_geom_from_wkb_omits_fixed_unknown_srid_bindparam(self, srid):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), bindparam("srid", srid))
+
+        compiled_expr = expr.compile(dialect=self.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s))"
+        assert "srid" not in compiled_expr.params
+
+    def test_geom_from_wkb_keeps_runtime_srid_bindparam(self):
+        expr = func.ST_GeomFromWKB(bytes.fromhex(WKB_HEX), bindparam("srid"))
+
+        compiled_expr = expr.compile(dialect=self.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert "srid" in compiled_expr.params
+
+    def test_wkbelement_literal_compile_omits_unknown_srid(self):
+        query = select([func.ST_AsText(WKBElement(bytes.fromhex(WKB_HEX)))])
+
+        compiled = self.normalize_sql(
+            query.compile(dialect=self.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
+        assert f"ST_GeomFromWKB(unhex('{WKB_HEX}'))" in compiled
+        assert ", -1" not in compiled
+
+    def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
+
+        compiled = self.normalize_sql(expr.compile(dialect=self.dialect()))
+
+        assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+
+    def test_geom_from_ewkb_uses_embedded_srid_without_return_type_srid(self):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))
+
+        compiled = self.normalize_sql(expr.compile(dialect=self.dialect()))
+
+        assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+
+    @pytest.mark.parametrize("srid", [None, -1, 0])
+    def test_geom_from_ewkb_omitted_explicit_srid_uses_embedded_srid(self, srid):
+        expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), srid)
+
+        compiled_expr = expr.compile(dialect=self.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 4326)"
+        assert list(compiled_expr.params.values()) == [WKB_HEX]
+
+    @pytest.mark.parametrize("srid", [None, -1, 0])
+    def test_geom_from_ewkb_runtime_bind_with_omitted_explicit_srid_rejects_ewkb(
+        self,
+        srid,
+    ):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), srid)
+        compiled_expr = expr.compile(dialect=self.dialect())
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s))"
+        assert set(compiled_expr.params) == {"wkb"}
+        assert wkb_processor(bytes.fromhex(WKB_HEX)) == WKB_HEX
+        with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
+            wkb_processor(bytes.fromhex(EWKB_HEX))
+
+    def test_geom_from_ewkb_defaulted_bindparam_preserves_key_and_processor(self):
+        source_bind = bindparam("wkb", bytes.fromhex(EWKB_HEX))
+        expr = func.ST_GeomFromEWKB(source_bind)
+        compiled_expr = expr.compile(dialect=self.dialect())
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+        override = bytes.fromhex(WKB_HEX)
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 4326)"
+        assert compiled_expr.params == {"wkb": bytes.fromhex(EWKB_HEX)}
+        assert compiled_expr.construct_params({"wkb": override}) == {"wkb": override}
+        assert wkb_processor(compiled_expr.params["wkb"]) == WKB_HEX
+        assert wkb_processor(bytes.fromhex(EWKB_HEX)) == WKB_HEX
+        with pytest.raises(ArgumentError, match=r"column \(4326\)"):
+            wkb_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))
+
+    def test_geom_from_ewkb_fixed_srid_bindparam_strips_runtime_ewkb(self):
+        source_bind = bindparam("wkb")
+        expr = func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=3857))
+        compiled_expr = expr.compile(dialect=self.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 3857)"
+        assert set(compiled_expr.params) == {"wkb"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(WKB_HEX)) == WKB_HEX
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(ZERO_SRID_EWKB_HEX)) == WKB_HEX
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX))
+
+    @pytest.mark.parametrize("srids", [(3857, 4326), (4326, 3857)])
+    def test_geom_from_ewkb_reused_fixed_srid_bind_validates_all_contexts(self, srids):
+        source_bind = bindparam("wkb")
+        stmt = select(
+            [
+                func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=srids[0])),
+                func.ST_GeomFromEWKB(source_bind, type_=Geometry(srid=srids[1])),
+            ]
+        )
+        compiled_expr = stmt.compile(dialect=self.dialect())
+        compiled = self.normalize_sql(compiled_expr)
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+
+        assert f"ST_GeomFromWKB(unhex(%s), {srids[0]})" in compiled
+        assert f"ST_GeomFromWKB(unhex(%s), {srids[1]})" in compiled
+        assert wkb_processor(bytes.fromhex(WKB_HEX)) == WKB_HEX
+        with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+            wkb_processor(bytes.fromhex(EWKB_HEX))
+
+    def test_geom_from_ewkb_runtime_bind_without_srid_rejects_embedded_srid(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"))
+        compiled_expr = expr.compile(dialect=self.dialect())
+        wkb_processor = compiled_expr._bind_processors["wkb"]
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s))"
+        assert wkb_processor(bytes.fromhex(WKB_HEX)) == WKB_HEX
+        with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
+            wkb_processor(bytes.fromhex(EWKB_HEX))
+        with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
+            wkb_processor(WKBElement(bytes.fromhex(WKB_HEX), srid=4326))
+
+    def test_geom_from_ewkb_explicit_srid_bindparam_strips_runtime_ewkb(self):
+        expr = func.ST_GeomFromEWKB(bindparam("wkb"), bindparam("srid"))
+        compiled_expr = expr.compile(dialect=self.dialect())
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert set(compiled_expr.params) == {"wkb", "srid"}
+        assert compiled_expr._bind_processors["wkb"](bytes.fromhex(EWKB_HEX)) == WKB_HEX
 
 
 class TestRaster:


### PR DESCRIPTION
Fix MySQL and MariaDB compilation for WKB/EWKB geometry constructors.

This builds on `converter_foundation_element_api` by using the new converter-backed WKB helpers when compiling spatial constructors for MySQL/MariaDB, where EWKB is not accepted directly by the database constructor APIs.
