### PR TITLE
Feat: Add benchmark tooling

### DIFF
--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -11,8 +11,6 @@ from geoalchemy2.elements import WKTElement
 from .. import create_points
 from .. import select
 
-ROUNDS = 5
-
 
 class SuccessfulTest(BaseException):
     """A custom exception used to mark the successful test."""
@@ -251,6 +249,7 @@ def _insert_fail_or_success_type(
     ],
 )
 def test_insert(
+    insert_select_rounds,
     benchmark,
     GeomTable,
     conn,
@@ -274,7 +273,7 @@ def test_insert(
             raw_input=is_raw_input,
             extended_input=is_extended_input,
             N=N,
-            rounds=ROUNDS,
+            rounds=insert_select_rounds,
         )
 
         assert (
@@ -283,7 +282,7 @@ def test_insert(
                 .select_from(GeomTable.__table__)
                 .where(GeomTable.__table__.c.geom.is_not(None))
             ).scalar()
-            == N * N * ROUNDS
+            == N * N * insert_select_rounds
         )
 
     except SuccessfulTest:
@@ -342,6 +341,7 @@ def _actual_test_insert_select(
     output_representation,
     is_extended_output,
     is_default_geom_type,
+    insert_select_rounds,
 ):
     """Actual test for insert and select operations."""
     convert_wkb = input_representation == "WKB"
@@ -354,7 +354,7 @@ def _actual_test_insert_select(
         raw_input=is_raw_input,
         extended_input=is_extended_input,
         N=N,
-        rounds=ROUNDS,
+        rounds=insert_select_rounds,
     )
 
     assert (
@@ -363,9 +363,9 @@ def _actual_test_insert_select(
                 GeomTable.__table__.select().where(GeomTable.__table__.c.geom.is_not(None))
             ).fetchall()
         )
-        == N * N * ROUNDS
+        == N * N * insert_select_rounds
     )
-    assert len(all_points) == N * N * ROUNDS
+    assert len(all_points) == N * N * insert_select_rounds
 
     res = conn.execute(select([GeomTable.__table__.c.geom])).fetchone()
     expected_extended_output = is_extended_output
@@ -388,6 +388,7 @@ def _actual_test_insert_select(
     ],
 )
 def test_insert_select(
+    insert_select_rounds,
     benchmark,
     GeomTable,
     conn,
@@ -415,6 +416,7 @@ def test_insert_select(
             output_representation,
             is_extended_output,
             is_default_geom_type,
+            insert_select_rounds,
         )
     except SuccessfulTest:
         # Handle the successful test case

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,22 @@ def pytest_addoption(parser):
         default=False,
         help="If set to True, tests marked as long benchmarks will be run.",
     )
+    parser.addoption(
+        "--insert-select-rounds",
+        action="store",
+        type=int,
+        default=5,
+        help="Number of benchmark rounds for insert/select benchmarks.",
+    )
+
+
+@pytest.fixture
+def insert_select_rounds(request):
+    """Number of rounds used by insert/select benchmarks."""
+    rounds = request.config.getoption("--insert-select-rounds")
+    if rounds <= 0:
+        raise pytest.UsageError("--insert-select-rounds must be a positive integer.")
+    return rounds
 
 
 def pytest_configure(config):

--- a/tests/test_compare_benchmarks.py
+++ b/tests/test_compare_benchmarks.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.sax.saxutils import quoteattr
+
+import pytest
+
+from tools import compare_benchmarks
+
+
+def test_filter_run_by_junitxml_keeps_only_passed_benchmarks(tmp_path: Path) -> None:
+    passed = _nodeid("test_insert[passed]")
+    failed = _nodeid("test_insert[failed]")
+    errored = _nodeid("test_insert[errored]")
+    skipped = _nodeid("test_insert[skipped]")
+    missing = _nodeid("test_insert[missing]")
+    run = _run(tmp_path, "branch", [passed, failed, errored, skipped, missing])
+    junitxml = _junitxml(
+        tmp_path,
+        "branch",
+        [
+            ("tests.benchmarks.test_insert_select", "test_insert[passed]", "passed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[failed]", "failed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[errored]", "error"),
+            ("tests.benchmarks.test_insert_select", "test_insert[skipped]", "skipped"),
+        ],
+    )
+
+    filtered = compare_benchmarks.filter_run_by_junitxml(run, junitxml)
+
+    assert set(filtered.benchmarks) == {passed}
+    assert [benchmark["fullname"] for benchmark in filtered.data["benchmarks"]] == [passed]
+    assert filtered.outcome_filter == {
+        "junitxml": str(junitxml),
+        "kept": 1,
+        "excluded": {
+            "failed": 1,
+            "error": 1,
+            "skipped": 1,
+            "missing-outcome": 1,
+        },
+    }
+
+
+def test_filter_run_by_junitxml_maps_class_based_nodeids(tmp_path: Path) -> None:
+    nodeid = "tests/test_elements.py::TestDynamicElements::test_create_elements[WKTElement]"
+    run = _run(tmp_path, "branch", [nodeid])
+    junitxml = _junitxml(
+        tmp_path,
+        "branch",
+        [
+            (
+                "tests.test_elements.TestDynamicElements",
+                "test_create_elements[WKTElement]",
+                "passed",
+            ),
+        ],
+    )
+
+    filtered = compare_benchmarks.filter_run_by_junitxml(run, junitxml)
+
+    assert set(filtered.benchmarks) == {nodeid}
+
+
+def test_main_filters_before_comparison(tmp_path: Path) -> None:
+    passed = _nodeid("test_insert[passed]")
+    failed = _nodeid("test_insert[failed]")
+    base_json = _benchmark_json(tmp_path, "base", {passed: 1.0, failed: 2.0})
+    compare_json = _benchmark_json(tmp_path, "compare", {passed: 1.5, failed: 0.1})
+    base_xml = _junitxml(
+        tmp_path,
+        "base",
+        [
+            ("tests.benchmarks.test_insert_select", "test_insert[passed]", "passed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[failed]", "passed"),
+        ],
+    )
+    compare_xml = _junitxml(
+        tmp_path,
+        "compare",
+        [
+            ("tests.benchmarks.test_insert_select", "test_insert[passed]", "passed"),
+            ("tests.benchmarks.test_insert_select", "test_insert[failed]", "failed"),
+        ],
+    )
+    output = tmp_path / "comparison"
+
+    result = compare_benchmarks.main(
+        [
+            "--base",
+            str(base_json),
+            "--compare",
+            str(compare_json),
+            "--base-junitxml",
+            str(base_xml),
+            "--compare-junitxml",
+            str(compare_xml),
+            "--output",
+            str(output),
+            "--no-charts",
+        ]
+    )
+
+    comparison = json.loads((output / "comparison.json").read_text(encoding="utf-8"))
+    assert result == 0
+    assert [benchmark["name"] for benchmark in comparison["benchmarks"]] == [passed]
+    assert comparison["benchmarks"][0]["status"] == "slower"
+    assert comparison["compare"]["outcome_filter"]["excluded"]["failed"] == 1
+
+
+def test_main_warns_when_outcome_filtering_is_disabled(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    nodeid = _nodeid("test_insert[passed]")
+    base_json = _benchmark_json(tmp_path, "base", {nodeid: 1.0})
+    compare_json = _benchmark_json(tmp_path, "compare", {nodeid: 1.5})
+
+    result = compare_benchmarks.main(
+        [
+            "--base",
+            str(base_json),
+            "--compare",
+            str(compare_json),
+            "--output",
+            str(tmp_path / "comparison"),
+            "--no-charts",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "benchmark outcome filtering is disabled" in captured.err
+
+
+def test_parse_args_requires_both_junitxml_paths(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        compare_benchmarks.parse_args(
+            [
+                "--base",
+                "base",
+                "--compare",
+                "compare",
+                "--base-junitxml",
+                str(tmp_path / "base.xml"),
+                "--output",
+                str(tmp_path / "comparison"),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def _nodeid(name: str) -> str:
+    return f"tests/benchmarks/test_insert_select.py::{name}"
+
+
+def _run(tmp_path: Path, label: str, nodeids: list[str]) -> compare_benchmarks.BenchmarkRun:
+    path = _benchmark_json(tmp_path, label, dict.fromkeys(nodeids, 1.0))
+    return compare_benchmarks.load_run(label, path)
+
+
+def _benchmark_json(tmp_path: Path, label: str, values: dict[str, float]) -> Path:
+    path = tmp_path / f"{label}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "benchmarks": [
+                    {"fullname": nodeid, "stats": {"mean": value}}
+                    for nodeid, value in values.items()
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _junitxml(tmp_path: Path, label: str, cases: list[tuple[str, str, str]]) -> Path:
+    path = tmp_path / f"{label}.xml"
+    testcases = [_testcase_xml(classname, name, outcome) for classname, name, outcome in cases]
+    path.write_text(
+        f"<testsuites><testsuite>{''.join(testcases)}</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _testcase_xml(classname: str, name: str, outcome: str) -> str:
+    children = {
+        "passed": "",
+        "failed": "<failure />",
+        "error": "<error />",
+        "skipped": "<skipped />",
+    }[outcome]
+    return (
+        f"<testcase classname={quoteattr(classname)} name={quoteattr(name)}>{children}</testcase>"
+    )

--- a/tools/compare_benchmarks.py
+++ b/tools/compare_benchmarks.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from html import escape
 from pathlib import Path
 from typing import Any
+from xml.etree import ElementTree
 
 METRICS = ("min", "max", "mean", "median", "stddev", "iqr")
 TIME_UNITS = {
@@ -41,6 +42,7 @@ class BenchmarkRun:
     path: Path
     data: dict[str, Any]
     benchmarks: dict[str, dict[str, Any]]
+    outcome_filter: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -81,6 +83,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="compare",
         required=True,
         help="Compare saved benchmark name or JSON file path.",
+    )
+    parser.add_argument(
+        "--base-junitxml",
+        type=Path,
+        default=None,
+        help="JUnit XML report for the base benchmark run.",
+    )
+    parser.add_argument(
+        "--compare-junitxml",
+        type=Path,
+        default=None,
+        help="JUnit XML report for the compare benchmark run.",
     )
     parser.add_argument(
         "--output",
@@ -140,7 +154,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Do not export SVG charts.",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if bool(args.base_junitxml) != bool(args.compare_junitxml):
+        parser.error("--base-junitxml and --compare-junitxml must be provided together")
+    return args
 
 
 def find_run_file(storage: Path, label_or_path: str) -> Path:
@@ -179,6 +196,72 @@ def load_run(label: str, path: Path) -> BenchmarkRun:
     data = json.loads(path.read_text(encoding="utf-8"))
     benchmarks = {benchmark["fullname"]: benchmark for benchmark in data.get("benchmarks", [])}
     return BenchmarkRun(label=label, path=path, data=data, benchmarks=benchmarks)
+
+
+def filter_run_by_junitxml(run: BenchmarkRun, junitxml: Path) -> BenchmarkRun:
+    outcomes = load_junit_outcomes(junitxml)
+    excluded = {
+        "failed": 0,
+        "error": 0,
+        "skipped": 0,
+        "missing-outcome": 0,
+    }
+    benchmarks = {}
+    for name, benchmark in run.benchmarks.items():
+        outcome = outcomes.get(name)
+        if outcome == "passed":
+            benchmarks[name] = benchmark
+        elif outcome is None:
+            excluded["missing-outcome"] += 1
+        else:
+            excluded[outcome] += 1
+
+    data = dict(run.data)
+    data["benchmarks"] = [
+        benchmark
+        for benchmark in run.data.get("benchmarks", [])
+        if benchmark.get("fullname") in benchmarks
+    ]
+    return BenchmarkRun(
+        label=run.label,
+        path=run.path,
+        data=data,
+        benchmarks=benchmarks,
+        outcome_filter={
+            "junitxml": str(junitxml),
+            "kept": len(benchmarks),
+            "excluded": excluded,
+        },
+    )
+
+
+def load_junit_outcomes(path: Path) -> dict[str, str]:
+    root = ElementTree.parse(path).getroot()
+    outcomes: dict[str, str] = {}
+    for testcase in root.iter():
+        if _local_name(testcase.tag) != "testcase":
+            continue
+        classname = testcase.attrib.get("classname")
+        name = testcase.attrib.get("name")
+        if not classname or not name:
+            continue
+        nodeid = junit_nodeid(classname, name)
+        outcomes[nodeid] = _merge_outcome(outcomes.get(nodeid), _junit_testcase_outcome(testcase))
+    return outcomes
+
+
+def junit_nodeid(classname: str, name: str) -> str:
+    parts = classname.split(".")
+    module_end = next(
+        (index for index, part in enumerate(parts) if part[:1].isupper()),
+        len(parts),
+    )
+    module_parts = parts[:module_end]
+    class_parts = parts[module_end:]
+    nodeid = f"{'/'.join(module_parts)}.py::{name}"
+    if class_parts:
+        nodeid = f"{'/'.join(module_parts)}.py::{'::'.join(class_parts)}::{name}"
+    return nodeid
 
 
 def compare_runs(
@@ -632,12 +715,24 @@ def main(argv: list[str] | None = None) -> int:
     compare_path = find_run_file(args.storage, args.compare)
     base = load_run(args.base, base_path)
     compare = load_run(args.compare, compare_path)
+    filtering_enabled = False
+    if args.base_junitxml and args.compare_junitxml:
+        filtering_enabled = True
+        base = filter_run_by_junitxml(base, args.base_junitxml)
+        compare = filter_run_by_junitxml(compare, args.compare_junitxml)
+    else:
+        print(
+            "Warning: benchmark outcome filtering is disabled. Pass both "
+            "--base-junitxml and --compare-junitxml to avoid comparing failed, "
+            "errored, skipped, or xfailed benchmark tests.",
+            file=sys.stderr,
+        )
     records = compare_runs(
         base,
         compare,
         metric=args.metric,
         tolerance_percent=args.tolerance_percent,
-        only_common=args.only_common,
+        only_common=args.only_common or filtering_enabled,
     )
     records = sort_records(records, sort_by=args.sort_by, sort_order=args.sort_order)
     exported = export_reports(
@@ -654,6 +749,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Base:    {base.path}")
     print(f"Compare: {compare.path}")
     print(f"Metric:  {args.metric}")
+    print_filter_summary(base)
+    print_filter_summary(compare)
     print()
     print("\n".join(format_table(records, base.label, compare.label, args.metric, unit)))
     print()
@@ -741,13 +838,52 @@ def _row(record: ComparisonRecord, metric: str) -> dict[str, Any]:
 
 
 def _run_summary(run: BenchmarkRun) -> dict[str, Any]:
-    return {
+    summary = {
         "label": run.label,
         "path": str(run.path),
         "commit_info": run.data.get("commit_info", {}),
         "machine_info": run.data.get("machine_info", {}),
         "benchmark_count": len(run.benchmarks),
     }
+    if run.outcome_filter is not None:
+        summary["outcome_filter"] = run.outcome_filter
+    return summary
+
+
+def print_filter_summary(run: BenchmarkRun) -> None:
+    if run.outcome_filter is None:
+        return
+    excluded = run.outcome_filter["excluded"]
+    excluded_total = sum(excluded.values())
+    details = (
+        ", ".join(f"{reason}={count}" for reason, count in excluded.items() if count) or "none"
+    )
+    print(
+        f"{run.label} outcome filter: kept {run.outcome_filter['kept']} "
+        f"benchmark(s), excluded {excluded_total} ({details})"
+    )
+
+
+def _junit_testcase_outcome(testcase: ElementTree.Element) -> str:
+    child_tags = {_local_name(child.tag) for child in testcase}
+    if "error" in child_tags:
+        return "error"
+    if "failure" in child_tags:
+        return "failed"
+    if "skipped" in child_tags:
+        return "skipped"
+    return "passed"
+
+
+def _merge_outcome(existing: str | None, new: str) -> str:
+    if existing is None:
+        return new
+    priority = {"passed": 0, "skipped": 1, "failed": 2, "error": 3}
+    return new if priority[new] > priority[existing] else existing
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
 
 
 def _plain_table(headers: list[str], rows: list[list[str]]) -> list[str]:


### PR DESCRIPTION
Add safer benchmark comparison tooling for stacked performance work.

This builds on `constructor_compilation_fixes` by improving `tools/compare_benchmarks.py` so benchmark comparisons can be filtered using JUnit XML outcomes, avoiding comparisons against failed, errored, skipped, or missing benchmark cases.
