### PR TITLE
Chore: Add CI, container, and Alembic maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,11 @@ dmypy.json
 # Miscellaneous
 *.csv
 *.sh
+*.svg
 *.txt
+!test_container/run.sh
+!test_container/start.sh
+!test_container/stop.sh
 !test_container/helpers/configure_postgres.sh
 !test_container/helpers/configure_mysql.sh
 !test_container/helpers/configure_mariadb.sh
@@ -78,3 +82,4 @@ dmypy.json
 issues
 mylocal_db/
 uv.lock
+worktrees

--- a/TEST.rst
+++ b/TEST.rst
@@ -19,11 +19,16 @@ When you are finished the containers and associated data can be removed.
 Install and run the container::
 
     $ ./test_container/build.sh
+    $ ./test_container/start.sh
     $ ./test_container/run.sh
 
 Or run a command directly in the runner container::
 
     $ ./test_container/run.sh tox --workdir /output -v run
+
+The ``run.sh`` script automatically starts the database services first when they
+are not already running. If the services are already running, it only starts a
+temporary ``runner`` container for the requested command.
 
 Run the tests inside the container::
 
@@ -41,6 +46,10 @@ or inside an interactive shell::
 You can combine `py310`, `py311`, `py312`, `py313`, or `pypy3` with `sqla14` or
 `sqlalatest` to run the tests for Python 3.10, 3.11, 3.12, 3.13, or PyPy with
 SQLAlchemy 1.4 or 2.*.
+
+Stop the database services while keeping the containers and cached test output::
+
+    $ ./test_container/stop.sh
 
 Remove the container and associated data::
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,6 +98,7 @@ pygments_style = "sphinx"
 
 # -- Options for Autodoc ---------------------------------------------------
 autodoc_default_options = {"exclude-members": "inherit_cache"}
+autodoc_inherit_docstrings = False
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/geoalchemy2/alembic_helpers.py
+++ b/geoalchemy2/alembic_helpers.py
@@ -1,5 +1,9 @@
 """Some helpers to use with Alembic migration tool."""
 
+import inspect
+import platform
+
+import sqlalchemy
 from alembic.autogenerate import renderers
 from alembic.autogenerate import rewriter
 from alembic.autogenerate.render import _add_column
@@ -26,6 +30,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import DropTable
 from sqlalchemy.sql import func
 from sqlalchemy.types import TypeDecorator
+from sqlalchemy.util import compat as sqlalchemy_compat
 
 from geoalchemy2 import Geography
 from geoalchemy2 import Geometry
@@ -38,6 +43,27 @@ writer = rewriter.Rewriter()
 """Rewriter object for Alembic."""
 
 _SPATIAL_TABLES: set[str] = set()
+
+
+def _monkey_patch_sqlalchemy_pypy_builtin_method_repr():
+    """Avoid SQLAlchemy 1.4 repr recursion on PyPy bound built-in methods."""
+    if platform.python_implementation() != "PyPy" or not sqlalchemy.__version__.startswith("1.4."):
+        return
+
+    normal_behavior = sqlalchemy_compat.inspect_getfullargspec
+    if getattr(normal_behavior, "_geoalchemy2_pypy_builtin_method_patch", False):
+        return
+
+    def inspect_getfullargspec(func):
+        if not inspect.ismethod(func) and inspect.isbuiltin(func) and hasattr(func, "__func__"):
+            raise TypeError("not a Python function")
+        return normal_behavior(func)
+
+    inspect_getfullargspec._geoalchemy2_pypy_builtin_method_patch = True
+    sqlalchemy_compat.inspect_getfullargspec = inspect_getfullargspec
+
+
+_monkey_patch_sqlalchemy_pypy_builtin_method_repr()
 
 
 class GeoPackageImpl(SQLiteImpl):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pytest
 pytest-cov
 pytest-benchmark
 pytest-html
-pytest-mypy
+pytest-mypy;implementation_name!='pypy'
 rasterio;implementation_name!='pypy'
 wkb-wkt-converter>=0.6.1

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -3,6 +3,30 @@ FROM ubuntu:24.04
 COPY ./helpers/install_requirements.sh /
 RUN /install_requirements.sh
 
+ARG PYPY_VERSION=7.3.22
+ARG PYPY_DIST=pypy3.11-v7.3.22-linux64
+ARG PYPY_SHA256=c0c239a6b0d381338bcccf852d0690b9daca632e0216389a3796f8817fd66e0e
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y bzip2; \
+    curl -fsSLo "/tmp/${PYPY_DIST}.tar.bz2" \
+        "https://downloads.python.org/pypy/${PYPY_DIST}.tar.bz2"; \
+    echo "${PYPY_SHA256}  /tmp/${PYPY_DIST}.tar.bz2" | sha256sum -c -; \
+    tar -xjf "/tmp/${PYPY_DIST}.tar.bz2" -C /opt; \
+    for binary in pypy pypy3 pypy3.11 pypy3-config pypy3.11-config; do \
+        if [ -x "/opt/${PYPY_DIST}/bin/${binary}" ]; then \
+            ln -sf "/opt/${PYPY_DIST}/bin/${binary}" "/usr/local/bin/${binary}"; \
+        fi; \
+    done; \
+    if [ ! -x /usr/local/bin/pypy3 ]; then \
+        ln -sf "/opt/${PYPY_DIST}/bin/pypy3.11" /usr/local/bin/pypy3; \
+    fi; \
+    test "$(command -v pypy3)" = "/usr/local/bin/pypy3"; \
+    pypy3 -c "import sys; assert sys.pypy_version_info[:3] == tuple(map(int, '${PYPY_VERSION}'.split('.')))"; \
+    rm "/tmp/${PYPY_DIST}.tar.bz2"; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
 ENV SPATIALITE_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/mod_spatialite.so"
 
 # Install MSSQL tools and drivers

--- a/test_container/helpers/entrypoint.sh
+++ b/test_container/helpers/entrypoint.sh
@@ -55,6 +55,7 @@ echo "GeoAlchemy2 Test Container"
 echo ""
 echo 'run tests with `tox --workdir /output -v run`'
 echo 'run only a specific job, e.g. `py310-sqlalatest`, with `tox --workdir /output -v run -e py310-sqlalatest`'
+echo 'run the PyPy job with `tox --workdir /output -v run -e pypy3-sqlalatest`'
 echo "MSSQL defaults: server=${MSSQL_HOST} db=${MSSQL_TEST_DB} user=${MSSQL_TEST_LOGIN} password=${MSSQL_TEST_PASSWORD}"
 echo "CockroachDB defaults: server=${COCKROACH_HOST}:${COCKROACH_PORT} db=${COCKROACH_DATABASE} user=${COCKROACH_USER}"
 echo "###############################"

--- a/test_container/run.sh
+++ b/test_container/run.sh
@@ -5,12 +5,34 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 mkdir -p "${SCRIPT_DIR}/output"
 
-cleanup() {
-    docker compose down >/dev/null 2>&1 || true
+SERVICES=(postgres mysql mariadb mssql cockroachdb)
+
+is_healthy() {
+    local service="$1"
+    local container_id
+    local health_status
+
+    container_id=$(docker compose ps -q "${service}" 2>/dev/null || true)
+    if [ -z "${container_id}" ]; then
+        return 1
+    fi
+
+    health_status=$(docker inspect --format '{{ if .State.Health }}{{ .State.Health.Status }}{{ end }}' "${container_id}" 2>/dev/null || true)
+    [ "${health_status}" = "healthy" ]
 }
 
-trap cleanup EXIT
-
 cd "${SCRIPT_DIR}"
-docker compose up -d postgres mysql mariadb mssql cockroachdb
-docker compose run --rm runner "$@"
+
+missing_services=()
+for service in "${SERVICES[@]}"; do
+    if ! is_healthy "${service}"; then
+        missing_services+=("${service}")
+    fi
+done
+
+if [ "${#missing_services[@]}" -gt 0 ]; then
+    echo "Starting test services: ${missing_services[*]}"
+    "${SCRIPT_DIR}/start.sh"
+fi
+
+docker compose run --rm --no-deps runner "$@"

--- a/test_container/start.sh
+++ b/test_container/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd "${SCRIPT_DIR}"
+docker compose up --wait --wait-timeout 300 postgres mysql mariadb mssql cockroachdb

--- a/test_container/stop.sh
+++ b/test_container/stop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd "${SCRIPT_DIR}"
+docker compose stop postgres mysql mariadb mssql cockroachdb

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -29,6 +29,10 @@ def filter_tables(name, type_, parent_names):
     return type_ != "table" or name in ["lake", "alembic_table"]
 
 
+def test_sqlalchemy_integer_repr_is_safe_after_alembic_helper_import():
+    assert repr(Integer()) == "Integer()"
+
+
 class TestAutogenerate:
     def test_no_diff(self, conn, Lake, setup_tables, use_alembic_monkeypatch, dialect_name):
         """Check that the autogeneration detects spatial types properly."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist = py{310,311,312,313}-sqla{14,latest}, pypy3-sqla{14,latest}, lint, coverage, docs
 requires=
-    setuptools>42
+    setuptools>77
 
 [gh-actions]
 python =
     3.10: py310-sqla{14, latest}, lint
-    3.11: py311-sqla{14, latest}, docs
+    3.11: py311-sqla{14, latest}
     3.12: py312-sqla{14, latest}
-    3.13: py313-sqla{14, latest}
+    3.13: py313-sqla{14, latest}, docs
     pypy-3.11: pypy3-sqla{14, latest}
 
 [testenv]
@@ -44,7 +44,7 @@ deps=
     -rrequirements-mypy.txt
 commands=
     pip freeze --all
-    pytest -v \
+    pytest \
         --basetemp={envtmpdir} \
         --cov=geoalchemy2 \
         --cov-branch \
@@ -87,7 +87,7 @@ commands =
     prek run --all-files
 
 [testenv:docs]
-basepython = python3.11
+basepython = python3.13
 changedir = doc
 allowlist_externals = make
 deps =


### PR DESCRIPTION
Add CI/container maintenance needed for the stacked benchmark and constructor work, with improved PyPy support and a small Alembic compatibility fix.

This builds on `benchmark_tooling` by making the test container easier to reuse, adding PyPy to the container image, and avoiding a SQLAlchemy 1.4/PyPy repr issue triggered through Alembic helpers.
