### PR TITLE
Refactor: Share spatial bind conversion helpers across dialects

### DIFF
--- a/TEST.rst
+++ b/TEST.rst
@@ -95,7 +95,7 @@ Install the Python dependencies::
     $ pip install -r requirements.txt -r requirements-mypy.txt
     $ pip install psycopg2-binary pyodbc "Shapely>=1.3.0"
 
-The manual requirements include ``wkb-wkt-converter>=0.6.1``, which provides
+The manual requirements include ``wkb-wkt-converter>=0.6.3``, which provides
 the WKB/EWKB conversion helpers used by the tests and runtime bind processors.
 
 The tox environments also install these full-suite dependencies from ``tox.ini``:

--- a/TEST.rst
+++ b/TEST.rst
@@ -95,6 +95,9 @@ Install the Python dependencies::
     $ pip install -r requirements.txt -r requirements-mypy.txt
     $ pip install psycopg2-binary pyodbc "Shapely>=1.3.0"
 
+The manual requirements include ``wkb-wkt-converter>=0.6.1``, which provides
+the WKB/EWKB conversion helpers used by the tests and runtime bind processors.
+
 The tox environments also install these full-suite dependencies from ``tox.ini``:
 ``psycopg2-binary`` and ``pyodbc`` on CPython, ``psycopg2cffi`` on PyPy, and
 ``Shapely`` for shape conversion tests.

--- a/geoalchemy2/_wkb_wkt.py
+++ b/geoalchemy2/_wkb_wkt.py
@@ -7,8 +7,6 @@ but centralising the mapping keeps that policy explicit for callers.
 
 from __future__ import annotations
 
-import struct
-
 from wkb_wkt_converter import to_ewkb_header as _to_ewkb_header
 from wkb_wkt_converter import to_hex_wkb as _to_hex_wkb
 from wkb_wkt_converter import to_wkb as _to_wkb
@@ -17,8 +15,6 @@ from wkb_wkt_converter import to_wkt as _to_wkt
 from wkb_wkt_converter import wkb_header_srid as _wkb_header_srid
 from wkb_wkt_converter import wkb_to_wkt_split_srid
 from wkb_wkt_converter import wkt_to_wkb_split_srid
-
-_EWKB_SRID_FLAG = 0x20000000
 
 
 def is_known_srid(srid: int | None) -> bool:
@@ -34,24 +30,6 @@ def _srid_arg(srid: int | None) -> int | bool:
 def wkb_srid(source) -> int | None:
     """Return the embedded EWKB SRID without parsing the full geometry."""
     return _wkb_header_srid(source)
-
-
-def wkb_has_srid_header(source) -> bool:
-    """Return whether a WKB/EWKB header has the EWKB SRID flag set."""
-    header = bytes.fromhex(source[:10]) if isinstance(source, str) else bytes(source[:5])
-    if len(header) < 5:
-        raise ValueError("WKB value is too short to read header")
-
-    byte_order = header[0]
-    if byte_order == 0:
-        byte_order_marker = ">I"
-    elif byte_order == 1:
-        byte_order_marker = "<I"
-    else:
-        raise ValueError(f"Invalid WKB byte order marker: {byte_order}")
-
-    wkb_type_int = struct.unpack(byte_order_marker, header[1:5])[0]
-    return bool(wkb_type_int & _EWKB_SRID_FLAG)
 
 
 def to_wkb_no_srid_header(source):

--- a/geoalchemy2/_wkb_wkt.py
+++ b/geoalchemy2/_wkb_wkt.py
@@ -27,9 +27,9 @@ def _srid_arg(srid: int | None) -> int | bool:
     return srid
 
 
-def wkb_srid(source) -> int | None:
+def wkb_srid(source, *, include_unknown: bool = False) -> int | None:
     """Return the embedded EWKB SRID without parsing the full geometry."""
-    return _wkb_header_srid(source)
+    return _wkb_header_srid(source, include_unknown=include_unknown)
 
 
 def to_wkb_no_srid_header(source):

--- a/geoalchemy2/admin/dialects/geopackage.py
+++ b/geoalchemy2/admin/dialects/geopackage.py
@@ -16,9 +16,9 @@ from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _format_select_args
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
-from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
 from geoalchemy2.admin.dialects.sqlite import _SQLITE_FUNCTIONS
+from geoalchemy2.admin.dialects.sqlite import _compile_GeomFromWKB_SQLite
 from geoalchemy2.admin.dialects.sqlite import get_col_dim
 from geoalchemy2.admin.dialects.sqlite import load_spatialite_driver
 from geoalchemy2.types import Geography
@@ -380,36 +380,27 @@ def create_spatial_ref_sys_view(bind):
     )
 
 
-def _compile_GeomFromWKB_gpkg(element, compiler, *, identifier, **kw):
-    # Store the SRID
-    clauses = list(element.clauses)
-    try:
-        srid = clauses[1].value
-    except (IndexError, TypeError, ValueError):
-        srid = element.type.srid
-
-    if kw.get("literal_binds", False):
-        wkb_clause = compile_bin_literal(clauses[0])
-        prefix = "unhex("
-        suffix = ")"
-    else:
-        wkb_clause = clauses[0]
-        prefix = ""
-        suffix = ""
-
-    compiled = compiler.process(wkb_clause, **kw)
-
-    if srid > 0:
-        return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
-    else:
-        return f"{identifier}({prefix}{compiled}{suffix})"
-
-
 @compiles(functions.ST_GeomFromWKB, "geopackage")  # type: ignore
 def _gpkg_ST_GeomFromWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_gpkg(element, compiler, identifier="GeomFromWKB", **kw)
+    return _compile_GeomFromWKB_SQLite(element, compiler, identifier="GeomFromWKB", **kw)
 
 
 @compiles(functions.ST_GeomFromEWKB, "geopackage")  # type: ignore
 def _gpkg_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_gpkg(element, compiler, identifier="GeomFromEWKB", **kw)
+    wkb_clause = next(iter(element.clauses), None)
+    wkb_type = getattr(wkb_clause, "type", None)
+    # Geometry bind expressions already use the GeoPackage bind processor for EWKB hex.
+    use_geometry_ewkb_processor = (
+        isinstance(wkb_type, Geometry)
+        and "ewkb" in (getattr(wkb_type, "from_text", "") or "").lower()
+    )
+    coerce_ewkb = kw.get("literal_binds", False) or not use_geometry_ewkb_processor
+
+    return _compile_GeomFromWKB_SQLite(
+        element,
+        compiler,
+        identifier="GeomFromEWKB",
+        include_srid=False,
+        coerce_ewkb=coerce_ewkb,
+        **kw,
+    )

--- a/geoalchemy2/admin/dialects/mariadb.py
+++ b/geoalchemy2/admin/dialects/mariadb.py
@@ -6,9 +6,14 @@ from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
 from geoalchemy2.admin.dialects.mysql import _coerce_ewkb_bind_clause_to_wkb
+from geoalchemy2.admin.dialects.mysql import _coerce_ewkb_clause_to_wkb
 from geoalchemy2.admin.dialects.mysql import _coerce_known_ewkb_clause_to_wkb
 from geoalchemy2.admin.dialects.mysql import _compile_srid_arg
+from geoalchemy2.admin.dialects.mysql import _dynamic_ewkb_default_srid
+from geoalchemy2.admin.dialects.mysql import _dynamic_ewkb_split_disabled
+from geoalchemy2.admin.dialects.mysql import _dynamic_inferred_srid_bind_clauses
 from geoalchemy2.admin.dialects.mysql import _ewkb_processor_fixed_srid
+from geoalchemy2.admin.dialects.mysql import _get_mysql_dynamic_ewkb_bind_clauses
 from geoalchemy2.admin.dialects.mysql import _has_effective_srid_argument
 from geoalchemy2.admin.dialects.mysql import _is_bindparam_clause
 from geoalchemy2.admin.dialects.mysql import _runtime_ewkb_processor_context
@@ -16,6 +21,7 @@ from geoalchemy2.admin.dialects.mysql import after_create  # noqa
 from geoalchemy2.admin.dialects.mysql import after_drop  # noqa
 from geoalchemy2.admin.dialects.mysql import before_create  # noqa
 from geoalchemy2.admin.dialects.mysql import before_drop  # noqa
+from geoalchemy2.admin.dialects.mysql import before_execute  # noqa
 from geoalchemy2.admin.dialects.mysql import reflect_geometry_column  # noqa
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
@@ -104,11 +110,14 @@ def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
         clauses, _ = unwrap_wkb_constructor_clauses(clauses)
 
     inferred_srid = None
+    dynamic_srid_clause = None
     if coerce_ewkb:
         original_wkb_clause = clauses[0]
+        split_disabled = _dynamic_ewkb_split_disabled(compiler) or kw.get("literal_binds", False)
         should_process_at_runtime = (
             _is_bindparam_clause(original_wkb_clause)
             and not kw.get("literal_binds", False)
+            and not split_disabled
             and (
                 getattr(original_wkb_clause, "value", None) is None
                 or getattr(original_wkb_clause, "callable", None) is not None
@@ -116,31 +125,53 @@ def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
         )
         if should_process_at_runtime:
             has_srid_argument = _has_effective_srid_argument(clauses)
-            fixed_srid = None
-            if not has_srid_argument:
-                fixed_srid = _ewkb_processor_fixed_srid(element, clauses)
-            processor_context = _runtime_ewkb_processor_context(
-                compiler,
-                original_wkb_clause,
-                fixed_srid=fixed_srid,
-                has_srid_argument=has_srid_argument,
-            )
-            wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
-                original_wkb_clause,
-                as_hex=True,
-                fixed_srid=fixed_srid,
-                has_srid_argument=has_srid_argument,
-                processor_context=processor_context,
-            )
+            dynamic_default_srid = _dynamic_ewkb_default_srid(element, clauses)
+            if dynamic_default_srid is not None:
+                wkb_value_clause, dynamic_srid_clause = _get_mysql_dynamic_ewkb_bind_clauses(
+                    original_wkb_clause,
+                    compiler,
+                    default_srid=dynamic_default_srid,
+                    as_hex=True,
+                )
+            else:
+                fixed_srid = None
+                if not has_srid_argument:
+                    fixed_srid = _ewkb_processor_fixed_srid(element, clauses)
+                processor_context = _runtime_ewkb_processor_context(
+                    compiler,
+                    original_wkb_clause,
+                    fixed_srid=fixed_srid,
+                    has_srid_argument=has_srid_argument,
+                )
+                wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
+                    original_wkb_clause,
+                    as_hex=True,
+                    fixed_srid=fixed_srid,
+                    has_srid_argument=has_srid_argument,
+                    processor_context=processor_context,
+                )
         else:
-            wkb_value_clause, inferred_srid = _coerce_known_ewkb_clause_to_wkb(
+            _, inferred_srid = _coerce_ewkb_clause_to_wkb(original_wkb_clause, as_hex=True)
+            dynamic_wkb_clause, dynamic_srid_clause = _dynamic_inferred_srid_bind_clauses(
                 element,
                 compiler,
                 original_wkb_clause,
                 clauses,
+                inferred_srid=inferred_srid,
                 as_hex=True,
-                preserve_user_bind=not kw.get("literal_binds", False),
+                split_disabled=split_disabled,
             )
+            if dynamic_wkb_clause is not None:
+                wkb_value_clause = dynamic_wkb_clause
+            else:
+                wkb_value_clause, inferred_srid = _coerce_known_ewkb_clause_to_wkb(
+                    element,
+                    compiler,
+                    original_wkb_clause,
+                    clauses,
+                    as_hex=True,
+                    preserve_user_bind=not kw.get("literal_binds", False),
+                )
     else:
         wkb_value_clause = clauses[0]
 
@@ -151,7 +182,14 @@ def _compile_GeomFromWKB_MariaDB(element, compiler, *, coerce_ewkb=False, **kw):
     suffix = ")"
 
     compiled = compiler.process(wkb_clause, **kw)
-    compiled_srid = _compile_srid_arg(element, clauses, inferred_srid, compiler, **kw)
+    compiled_srid = _compile_srid_arg(
+        element,
+        clauses,
+        inferred_srid,
+        compiler,
+        srid_clause=dynamic_srid_clause,
+        **kw,
+    )
 
     if compiled_srid is not None:
         return f"{identifier}({prefix}{compiled}{suffix}, {compiled_srid})"

--- a/geoalchemy2/admin/dialects/mssql.py
+++ b/geoalchemy2/admin/dialects/mssql.py
@@ -590,8 +590,7 @@ def _process_wkt_value(value, strip_srid=False):
     elif isinstance(value, (WKBElement, bytes, bytearray, memoryview)):
         value = _to_mssql_wkt(value)
     if isinstance(value, str) and strip_srid:
-        wkt_match = WKTElement._REMOVE_SRID.match(value)
-        value = wkt_match.group(3)
+        value = _wkb_wkt.to_wkt_no_srid(value)
     if isinstance(value, str):
         value = _normalize_wkt_for_mssql(value)
 

--- a/geoalchemy2/admin/dialects/mssql.py
+++ b/geoalchemy2/admin/dialects/mssql.py
@@ -642,8 +642,8 @@ def _process_ewkb_srid_value(value, default_srid=0):
         return value.srid if value.srid >= 0 else default_srid
 
     if isinstance(value, (bytes, bytearray, memoryview, str)):
-        srid = WKBElement(value, extended=None).srid
-        return srid if srid >= 0 else default_srid
+        srid = _wkb_wkt.wkb_srid(value)
+        return srid if srid is not None and srid >= 0 else default_srid
 
     return default_srid
 
@@ -718,9 +718,9 @@ class _MSSQLDynamicEWKBSRIDBindType(TypeDecorator):
 
 
 class _MSSQLDynamicEWKTCallable:
-    def __init__(self, source_callable):
+    def __init__(self, source_callable, *, consumer_count=2):
         self.source_callable = source_callable
-        self._consumer_count = 2
+        self._consumer_count = consumer_count
         self._pending = None
         self._remaining = 0
 
@@ -822,9 +822,9 @@ def _infer_srid_from_wkb_clause(wkb_clause, default_srid, extended=False):
     if isinstance(value, WKBElement):
         return value.srid if value.srid >= 0 else default_srid
 
-    if extended and isinstance(value, (bytes, bytearray, memoryview)):
-        srid = WKBElement(value, extended=None).srid
-        return srid if srid >= 0 else default_srid
+    if extended and isinstance(value, (bytes, bytearray, memoryview, str)):
+        srid = _wkb_wkt.wkb_srid(value)
+        return srid if srid is not None and srid >= 0 else default_srid
 
     return default_srid
 

--- a/geoalchemy2/admin/dialects/mssql.py
+++ b/geoalchemy2/admin/dialects/mssql.py
@@ -625,11 +625,11 @@ def _process_wkb_value(value, extended=False):
     if value is None:
         return None
     if isinstance(value, WKBElement):
-        value = value.data
+        value = _wkb_wkt.to_wkb_no_srid(value.data) if extended else value.data
+    elif extended:
+        value = _wkb_wkt.to_wkb_no_srid(value)
     if isinstance(value, memoryview):
         value = value.tobytes()
-    if extended:
-        value = _wkb_wkt.to_wkb_no_srid(value)
 
     return value
 
@@ -739,7 +739,13 @@ class _MSSQLDynamicEWKTCallable:
         return value
 
 
-def _coerce_wkt_bind_clause(wkt_clause, strip_srid=False, literal=False, spatial_type=None):
+def _coerce_wkt_bind_clause(
+    wkt_clause,
+    strip_srid=False,
+    literal=False,
+    spatial_type=None,
+    compiler=None,
+):
     if not hasattr(wkt_clause, "value"):
         return wkt_clause
 
@@ -751,13 +757,21 @@ def _coerce_wkt_bind_clause(wkt_clause, strip_srid=False, literal=False, spatial
             unique=True,
         )
 
+    if compiler is not None and getattr(wkt_clause, "callable", None) is not None:
+        return _make_mssql_callable_bind_clause(
+            wkt_clause,
+            compiler,
+            _MSSQLWKTBindType(strip_srid=strip_srid, spatial_type=spatial_type),
+            _get_mssql_dynamic_ewkt_shared_callable,
+        )
+
     return expression.type_coerce(
         wkt_clause,
         _MSSQLWKTBindType(strip_srid=strip_srid, spatial_type=spatial_type),
     )
 
 
-def _coerce_wkb_bind_clause(wkb_clause, extended=False, literal=False):
+def _coerce_wkb_bind_clause(wkb_clause, extended=False, literal=False, compiler=None):
     if not hasattr(wkb_clause, "value"):
         return wkb_clause
 
@@ -767,6 +781,14 @@ def _coerce_wkb_bind_clause(wkb_clause, extended=False, literal=False):
             value=_process_wkb_value(wkb_clause.value, extended=extended),
             type_=LargeBinary(),
             unique=True,
+        )
+
+    if compiler is not None and getattr(wkb_clause, "callable", None) is not None:
+        return _make_mssql_callable_bind_clause(
+            wkb_clause,
+            compiler,
+            _MSSQLWKBBindType(extended=extended),
+            _get_mssql_dynamic_ewkb_shared_callable,
         )
 
     return expression.type_coerce(wkb_clause, _MSSQLWKBBindType(extended=extended))
@@ -1104,13 +1126,77 @@ def _mssql_dynamic_ewkt_bind_identifier(source_bind):
     return getattr(source_bind, "_identifying_key", source_bind.key)
 
 
-def _make_mssql_dynamic_ewkt_bind_clauses(wkt_clause, default_srid=0):
+def _mssql_dynamic_callable_identifier(source_bind):
+    return (
+        _mssql_dynamic_ewkt_bind_identifier(source_bind),
+        getattr(source_bind, "callable", None),
+    )
+
+
+def _get_mssql_dynamic_ewkt_shared_callable(wkt_clause, compiler, *, consumer_count):
+    callable_cache = getattr(
+        compiler,
+        "_geoalchemy2_mssql_dynamic_ewkt_callable_cache",
+        None,
+    )
+    if callable_cache is None:
+        callable_cache = {}
+        compiler._geoalchemy2_mssql_dynamic_ewkt_callable_cache = callable_cache
+
+    callable_key = _mssql_dynamic_callable_identifier(wkt_clause)
+    shared_callable = callable_cache.get(callable_key)
+    if shared_callable is None:
+        shared_callable = _MSSQLDynamicEWKTCallable(
+            wkt_clause.callable,
+            consumer_count=consumer_count,
+        )
+        callable_cache[callable_key] = shared_callable
+    else:
+        shared_callable.add_consumers(consumer_count)
+    return shared_callable
+
+
+def _get_mssql_dynamic_ewkb_shared_callable(wkb_clause, compiler, *, consumer_count):
+    callable_cache = getattr(
+        compiler,
+        "_geoalchemy2_mssql_dynamic_ewkb_callable_cache",
+        None,
+    )
+    if callable_cache is None:
+        callable_cache = {}
+        compiler._geoalchemy2_mssql_dynamic_ewkb_callable_cache = callable_cache
+
+    callable_key = _mssql_dynamic_callable_identifier(wkb_clause)
+    shared_callable = callable_cache.get(callable_key)
+    if shared_callable is None:
+        shared_callable = _MSSQLDynamicEWKTCallable(
+            wkb_clause.callable,
+            consumer_count=consumer_count,
+        )
+        callable_cache[callable_key] = shared_callable
+    else:
+        shared_callable.add_consumers(consumer_count)
+    return shared_callable
+
+
+def _make_mssql_callable_bind_clause(clause, compiler, bind_type, shared_callable_getter):
+    return expression.bindparam(
+        key=clause.key,
+        callable_=shared_callable_getter(clause, compiler, consumer_count=1),
+        required=clause.required,
+        type_=bind_type,
+        unique=getattr(clause, "unique", False),
+    )
+
+
+def _make_mssql_dynamic_ewkt_bind_clauses(wkt_clause, default_srid=0, shared_callable=None):
     text_key, srid_key = _mssql_dynamic_ewkt_bind_keys(wkt_clause)
     bind_kwargs = {
         "required": wkt_clause.required,
     }
     if getattr(wkt_clause, "callable", None) is not None:
-        shared_callable = _MSSQLDynamicEWKTCallable(wkt_clause.callable)
+        if shared_callable is None:
+            shared_callable = _MSSQLDynamicEWKTCallable(wkt_clause.callable)
         bind_kwargs["callable_"] = shared_callable
     elif not wkt_clause.required:
         bind_kwargs["value"] = getattr(wkt_clause, "value", None)
@@ -1137,9 +1223,17 @@ def _get_mssql_dynamic_ewkt_bind_clauses(wkt_clause, compiler, default_srid=0):
 
     source_identifier = _mssql_dynamic_ewkt_bind_identifier(wkt_clause)
     if source_identifier not in cache:
+        shared_callable = None
+        if getattr(wkt_clause, "callable", None) is not None:
+            shared_callable = _get_mssql_dynamic_ewkt_shared_callable(
+                wkt_clause,
+                compiler,
+                consumer_count=2,
+            )
         cache[source_identifier] = _make_mssql_dynamic_ewkt_bind_clauses(
             wkt_clause,
             default_srid=default_srid,
+            shared_callable=shared_callable,
         )
     return cache[source_identifier]
 
@@ -1191,22 +1285,11 @@ def _get_mssql_dynamic_ewkb_bind_clauses(wkb_clause, compiler, default_srid=0):
     if cache_key not in cache:
         shared_callable = None
         if getattr(wkb_clause, "callable", None) is not None:
-            callable_cache = getattr(
+            shared_callable = _get_mssql_dynamic_ewkb_shared_callable(
+                wkb_clause,
                 compiler,
-                "_geoalchemy2_mssql_dynamic_ewkb_callable_cache",
-                None,
+                consumer_count=2,
             )
-            if callable_cache is None:
-                callable_cache = {}
-                compiler._geoalchemy2_mssql_dynamic_ewkb_callable_cache = callable_cache
-
-            callable_key = _mssql_dynamic_ewkt_bind_identifier(wkb_clause)
-            shared_callable = callable_cache.get(callable_key)
-            if shared_callable is None:
-                shared_callable = _MSSQLDynamicEWKTCallable(wkb_clause.callable)
-                callable_cache[callable_key] = shared_callable
-            else:
-                shared_callable.add_consumers(2)
 
         cache[cache_key] = _make_mssql_dynamic_ewkb_bind_clauses(
             wkb_clause,
@@ -1457,6 +1540,7 @@ def _compile_mssql_geom_from_text(element, compiler, strip_srid=False, **kw):
             strip_srid=strip_srid,
             literal=kw.get("literal_binds", False),
             spatial_type=spatial_type,
+            compiler=compiler,
         )
     compiled_wkt = compiler.process(wkt_clause, **kw)
 
@@ -1526,7 +1610,10 @@ def _compile_mssql_geom_from_wkb(element, compiler, extended=False, **kw):
         or _should_coerce_wkb_bind_clause(clauses[0])
     ):
         wkb_clause = _coerce_wkb_bind_clause(
-            clauses[0], extended=extended, literal=kw.get("literal_binds", False)
+            clauses[0],
+            extended=extended,
+            literal=kw.get("literal_binds", False),
+            compiler=compiler,
         )
 
     if kw.get("literal_binds", False) and hasattr(wkb_clause, "value"):

--- a/geoalchemy2/admin/dialects/mssql.py
+++ b/geoalchemy2/admin/dialects/mssql.py
@@ -21,6 +21,7 @@ from sqlalchemy.types import LargeBinary
 from sqlalchemy.types import TypeDecorator
 from sqlalchemy.types import UnicodeText
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
@@ -625,11 +626,11 @@ def _process_wkb_value(value, extended=False):
     if value is None:
         return None
     if isinstance(value, WKBElement):
-        value = value.as_wkb().data if extended else value.data
-    elif extended:
-        value = WKBElement(value, extended=None).as_wkb().data
+        value = value.data
     if isinstance(value, memoryview):
         value = value.tobytes()
+    if extended:
+        value = _wkb_wkt.to_wkb_no_srid(value)
 
     return value
 

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -476,7 +476,7 @@ def _mysql_dynamic_ewkb_source_token(source_bind, compiler=None):
     return f"{source_name}_{ordinal}"
 
 
-def _mysql_dynamic_ewkb_bind_keys(source_bind, *, default_srid=None, source_token=None):
+def _mysql_dynamic_ewkb_bind_keys(source_bind, *, source_token=None):
     source_name = source_token or getattr(source_bind, "_orig_key", None) or source_bind.key
     source_name = str(source_name)
     key_token = re.sub(r"[^0-9A-Za-z_]+", "_", source_name).strip("_") or "param"
@@ -495,7 +495,6 @@ def _make_mysql_dynamic_ewkb_bind_clauses(
 ):
     wkb_key, srid_key = _mysql_dynamic_ewkb_bind_keys(
         wkb_clause,
-        default_srid=default_srid,
         source_token=source_token,
     )
     wkb_bind_kwargs = {
@@ -876,7 +875,6 @@ def _get_mysql_dynamic_ewkb_bind_mappings(clauseelement, dialect):
 
         wkb_key, srid_key = _mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=default_srid,
             source_token=source_token,
         )
         dynamic_bind_mappings.append(

--- a/geoalchemy2/admin/dialects/mysql.py
+++ b/geoalchemy2/admin/dialects/mysql.py
@@ -1,9 +1,15 @@
 """This module defines specific functions for MySQL dialect."""
 
+import hashlib
+import re
+from collections.abc import Mapping
+
+from sqlalchemy import Integer
 from sqlalchemy import text
 from sqlalchemy.dialects.mysql.base import ischema_names as _mysql_ischema_names
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
+from sqlalchemy.sql import visitors
 from sqlalchemy.sql.elements import BindParameter
 from sqlalchemy.sql.elements import Null
 from sqlalchemy.sql.sqltypes import NullType
@@ -159,6 +165,8 @@ def after_drop(table, bind, **kw):
 
 
 _MYSQL_FUNCTIONS = {"ST_AsEWKB": "ST_AsBinary", "ST_SetSRID": "ST_SRID"}
+_MYSQL_DYNAMIC_EWKB_KEY_PREFIX = "_geoalchemy2_mysql_ewkb"
+_MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION = "geoalchemy2_mysql_disable_dynamic_ewkb_split"
 
 
 def _compiles_mysql(cls, fn):
@@ -294,6 +302,20 @@ def _ewkb_to_wkb_data(
     return _wkb_wkt.to_wkb_no_srid(value)
 
 
+def _ewkb_srid_value(value, *, default_srid=None):
+    if isinstance(value, tuple) and len(value) == 2:
+        value, runtime_default_srid = value
+        if runtime_default_srid is not None:
+            default_srid = runtime_default_srid
+
+    srids = _known_wkb_bindvalue_srids(value)
+    if srids:
+        return srids[0]
+    if default_srid is not None:
+        return default_srid
+    return None
+
+
 class _MySQLEWKBBindType(TypeDecorator):
     impl = LargeBinary
     cache_ok = False
@@ -324,6 +346,49 @@ class _MySQLEWKBBindType(TypeDecorator):
             has_srid_argument=self.has_srid_argument,
             processor_context=self._processor_context,
         )
+
+
+class _MySQLDynamicEWKBSRIDBindType(TypeDecorator):
+    impl = Integer
+    cache_ok = True
+
+    def __init__(self, *, default_srid=None):
+        super().__init__()
+        self.default_srid = default_srid
+
+    def process_bind_param(self, value, dialect):
+        return _ewkb_srid_value(value, default_srid=self.default_srid)
+
+
+class _MySQLDynamicEWKBCallable:
+    def __init__(self, source_callable):
+        self.source_callable = source_callable
+        self._consumer_count = 2
+        self._pending = None
+        self._remaining = 0
+
+    def add_consumers(self, count):
+        self._consumer_count += count
+
+    def __call__(self):
+        if self._remaining == 0:
+            self._pending = self.source_callable()
+            self._remaining = self._consumer_count
+
+        self._remaining -= 1
+        value = self._pending
+        if self._remaining == 0:
+            self._pending = None
+        return value
+
+
+class _MySQLDynamicEWKBSRIDCallable:
+    def __init__(self, source_callable, default_srid=None):
+        self.source_callable = source_callable
+        self.default_srid = default_srid
+
+    def __call__(self):
+        return self.source_callable(), self.default_srid
 
 
 def _is_bindparam_clause(clause):
@@ -390,6 +455,124 @@ def _runtime_bind_identifier(source_bind):
     return getattr(source_bind, "_identifying_key", source_bind.key)
 
 
+def _mysql_dynamic_ewkb_source_token(source_bind, compiler=None):
+    source_name = getattr(source_bind, "_orig_key", None) or source_bind.key
+    if not getattr(source_bind, "unique", False):
+        return str(source_name)
+
+    source_identifier = _runtime_bind_identifier(source_bind)
+    if compiler is None:
+        return str(source_name)
+
+    source_ordinals = getattr(compiler, "_geoalchemy2_mysql_dynamic_ewkb_source_ordinals", None)
+    if source_ordinals is None:
+        source_ordinals = {}
+        compiler._geoalchemy2_mysql_dynamic_ewkb_source_ordinals = source_ordinals
+
+    ordinal = source_ordinals.get(source_identifier)
+    if ordinal is None:
+        ordinal = len(source_ordinals) + 1
+        source_ordinals[source_identifier] = ordinal
+    return f"{source_name}_{ordinal}"
+
+
+def _mysql_dynamic_ewkb_bind_keys(source_bind, *, default_srid=None, source_token=None):
+    source_name = source_token or getattr(source_bind, "_orig_key", None) or source_bind.key
+    source_name = str(source_name)
+    key_token = re.sub(r"[^0-9A-Za-z_]+", "_", source_name).strip("_") or "param"
+    key_digest = hashlib.sha1(source_name.encode()).hexdigest()[:8]
+    key_base = f"{_MYSQL_DYNAMIC_EWKB_KEY_PREFIX}_{key_token}_{key_digest}"
+    return f"{key_base}_wkb", f"{key_base}_srid"
+
+
+def _make_mysql_dynamic_ewkb_bind_clauses(
+    wkb_clause,
+    *,
+    default_srid=None,
+    as_hex=False,
+    shared_callable=None,
+    source_token=None,
+):
+    wkb_key, srid_key = _mysql_dynamic_ewkb_bind_keys(
+        wkb_clause,
+        default_srid=default_srid,
+        source_token=source_token,
+    )
+    wkb_bind_kwargs = {
+        "required": wkb_clause.required,
+    }
+    srid_bind_kwargs = dict(wkb_bind_kwargs)
+    if getattr(wkb_clause, "callable", None) is not None:
+        if shared_callable is None:
+            shared_callable = _MySQLDynamicEWKBCallable(wkb_clause.callable)
+        wkb_bind_kwargs["callable_"] = shared_callable
+        srid_bind_kwargs["callable_"] = _MySQLDynamicEWKBSRIDCallable(
+            shared_callable,
+            default_srid=default_srid,
+        )
+    elif not wkb_clause.required:
+        value = getattr(wkb_clause, "value", None)
+        wkb_bind_kwargs["value"] = value
+        srid_bind_kwargs["value"] = (value, default_srid)
+
+    return (
+        expression.bindparam(
+            key=wkb_key,
+            type_=_MySQLEWKBBindType(as_hex=as_hex, has_srid_argument=True),
+            **wkb_bind_kwargs,
+        ),
+        expression.bindparam(
+            key=srid_key,
+            type_=_MySQLDynamicEWKBSRIDBindType(default_srid=default_srid),
+            **srid_bind_kwargs,
+        ),
+    )
+
+
+def _get_mysql_dynamic_ewkb_bind_clauses(
+    wkb_clause,
+    compiler,
+    *,
+    default_srid=None,
+    as_hex=False,
+):
+    cache = getattr(compiler, "_geoalchemy2_mysql_dynamic_ewkb_bind_cache", None)
+    if cache is None:
+        cache = {}
+        compiler._geoalchemy2_mysql_dynamic_ewkb_bind_cache = cache
+
+    source_token = _mysql_dynamic_ewkb_source_token(wkb_clause, compiler)
+    cache_key = (source_token, default_srid, as_hex)
+    if cache_key not in cache:
+        shared_callable = None
+        if getattr(wkb_clause, "callable", None) is not None:
+            callable_cache = getattr(
+                compiler,
+                "_geoalchemy2_mysql_dynamic_ewkb_callable_cache",
+                None,
+            )
+            if callable_cache is None:
+                callable_cache = {}
+                compiler._geoalchemy2_mysql_dynamic_ewkb_callable_cache = callable_cache
+
+            callable_key = _runtime_bind_identifier(wkb_clause)
+            shared_callable = callable_cache.get(callable_key)
+            if shared_callable is None:
+                shared_callable = _MySQLDynamicEWKBCallable(wkb_clause.callable)
+                callable_cache[callable_key] = shared_callable
+            else:
+                shared_callable.add_consumers(2)
+
+        cache[cache_key] = _make_mysql_dynamic_ewkb_bind_clauses(
+            wkb_clause,
+            default_srid=default_srid,
+            as_hex=as_hex,
+            shared_callable=shared_callable,
+            source_token=source_token,
+        )
+    return cache[cache_key]
+
+
 def _runtime_ewkb_processor_context(
     compiler,
     source_bind,
@@ -413,6 +596,27 @@ def _runtime_ewkb_processor_context(
         has_srid_argument=has_srid_argument,
     )
     return processor_context
+
+
+def _infer_srid_from_bind_value(wkb_clause):
+    if not hasattr(wkb_clause, "value"):
+        return None
+
+    srids = _known_wkb_bindvalue_srids(wkb_clause.value)
+    return srids[0] if srids else None
+
+
+def _dynamic_ewkb_default_srid(element, clauses):
+    default_srid = _infer_srid_from_bind_value(clauses[0])
+    if default_srid is not None:
+        return default_srid
+    if (
+        getattr(clauses[0], "callable", None) is not None
+        and not _has_effective_srid_argument(clauses)
+        and not is_known_srid(element.type.srid)
+    ):
+        return 0
+    return None
 
 
 def _coerce_ewkb_clause_to_wkb(wkb_clause, *, as_hex=False):
@@ -470,6 +674,32 @@ def _coerce_ewkb_bind_clause_to_wkb(
             has_srid_argument=has_srid_argument,
             processor_context=processor_context,
         ),
+    )
+
+
+def _dynamic_inferred_srid_bind_clauses(
+    element,
+    compiler,
+    original_wkb_clause,
+    clauses,
+    *,
+    inferred_srid=None,
+    as_hex=False,
+    split_disabled=False,
+):
+    if (
+        split_disabled
+        or inferred_srid is None
+        or _has_effective_srid_argument(clauses)
+        or not _is_bindparam_clause(original_wkb_clause)
+    ):
+        return None, None
+
+    return _get_mysql_dynamic_ewkb_bind_clauses(
+        original_wkb_clause,
+        compiler,
+        default_srid=inferred_srid,
+        as_hex=as_hex,
     )
 
 
@@ -543,15 +773,179 @@ def _compile_srid_clause(srid_clause, compiler, **kw):
     return compiler.process(srid_clause, **kw)
 
 
-def _compile_srid_arg(element, clauses, inferred_srid, compiler, **kw):
+def _compile_srid_arg(element, clauses, inferred_srid, compiler, *, srid_clause=None, **kw):
     if len(clauses) > 1:
         compiled_srid = _compile_srid_clause(clauses[1], compiler, **kw)
         if compiled_srid is not None:
             return compiled_srid
+        if srid_clause is not None:
+            return compiler.process(srid_clause, **kw)
         return str(inferred_srid) if inferred_srid is not None else None
+
+    if srid_clause is not None:
+        return compiler.process(srid_clause, **kw)
 
     srid = inferred_srid if inferred_srid is not None else element.type.srid
     return str(srid) if is_known_srid(srid) else None
+
+
+def _dynamic_ewkb_split_disabled(compiler):
+    return bool(
+        getattr(compiler, "execution_options", {}).get(
+            _MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION,
+            False,
+        )
+    )
+
+
+def _collect_mysql_dynamic_ewkb_source_binds(clauseelement, dialect):
+    if not hasattr(clauseelement, "get_children"):
+        return ()
+
+    source_binds = []
+    seen_bind_keys = set()
+    for element in visitors.iterate(clauseelement):
+        if not isinstance(element, functions.ST_GeomFromEWKB):
+            continue
+
+        clauses = list(element.clauses)
+        if len(clauses) < 1 or not _is_bindparam_clause(clauses[0]):
+            continue
+        if _has_effective_srid_argument(clauses):
+            continue
+
+        default_srid = _dynamic_ewkb_default_srid(element, clauses)
+        if default_srid is None:
+            continue
+
+        bind_key = (_runtime_bind_identifier(clauses[0]), default_srid)
+        if bind_key in seen_bind_keys:
+            continue
+        seen_bind_keys.add(bind_key)
+        source_binds.append((clauses[0], default_srid))
+
+    return tuple(source_binds)
+
+
+def _compile_mysql_statement_bind_name_map(clauseelement, dialect):
+    if not hasattr(clauseelement, "compile"):
+        return {}
+
+    if hasattr(clauseelement, "execution_options"):
+        clauseelement = clauseelement.execution_options(
+            **{_MYSQL_DISABLE_DYNAMIC_EWKB_SPLIT_OPTION: True}
+        )
+
+    compiled = clauseelement.compile(dialect=dialect)
+    bind_name_map = {}
+    for bind, compiled_name in compiled.bind_names.items():
+        bind_name_map.setdefault(
+            _runtime_bind_identifier(bind),
+            compiled_name,
+        )
+    return bind_name_map
+
+
+def _get_mysql_dynamic_ewkb_bind_mappings(clauseelement, dialect):
+    source_binds = _collect_mysql_dynamic_ewkb_source_binds(clauseelement, dialect)
+    if not source_binds:
+        return ()
+
+    statement_bind_name_map = _compile_mysql_statement_bind_name_map(clauseelement, dialect)
+    dynamic_bind_mappings = []
+    unique_source_ordinals = {}
+    for source_bind, default_srid in source_binds:
+        source_identifier = _runtime_bind_identifier(source_bind)
+        if getattr(source_bind, "unique", False):
+            ordinal = unique_source_ordinals.get(source_identifier)
+            if ordinal is None:
+                ordinal = len(unique_source_ordinals) + 1
+                unique_source_ordinals[source_identifier] = ordinal
+            source_token = f"{getattr(source_bind, '_orig_key', None) or source_bind.key}_{ordinal}"
+        else:
+            source_token = _mysql_dynamic_ewkb_source_token(source_bind)
+
+        candidate_keys = []
+        for candidate_key in (
+            source_bind.key,
+            getattr(source_bind, "_orig_key", None),
+            statement_bind_name_map.get(source_identifier),
+        ):
+            if candidate_key is not None and candidate_key not in candidate_keys:
+                candidate_keys.append(candidate_key)
+
+        wkb_key, srid_key = _mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=default_srid,
+            source_token=source_token,
+        )
+        dynamic_bind_mappings.append(
+            (tuple(candidate_keys), wkb_key, srid_key, source_bind, default_srid)
+        )
+
+    return tuple(dynamic_bind_mappings)
+
+
+def _expand_mysql_dynamic_ewkb_param_mapping(parameters, dynamic_bind_mappings):
+    if not isinstance(parameters, Mapping):
+        return parameters, False
+
+    expanded_parameters = parameters
+    changed = False
+    for source_keys, wkb_key, srid_key, source_bind, default_srid in dynamic_bind_mappings:
+        source_key = next((key for key in source_keys if key in parameters), None)
+        if source_key is not None:
+            source_value = parameters[source_key]
+        elif getattr(source_bind, "callable", None) is not None:
+            source_value = source_bind.callable()
+        elif not source_bind.required:
+            source_value = getattr(source_bind, "value", None)
+        else:
+            continue
+
+        if wkb_key in parameters and srid_key in parameters:
+            continue
+
+        if expanded_parameters is parameters:
+            expanded_parameters = dict(parameters)
+
+        expanded_parameters.setdefault(wkb_key, source_value)
+        expanded_parameters.setdefault(srid_key, (source_value, default_srid))
+        changed = True
+
+    return expanded_parameters, changed
+
+
+def before_execute(conn, clauseelement, multiparams, params, execution_options):
+    dynamic_bind_mappings = _get_mysql_dynamic_ewkb_bind_mappings(
+        clauseelement,
+        conn.dialect,
+    )
+    if not dynamic_bind_mappings:
+        return clauseelement, multiparams, params
+
+    multiparams_changed = False
+    expanded_multiparams = multiparams
+    if multiparams:
+        expanded_values = []
+        for value in multiparams:
+            expanded_value, value_changed = _expand_mysql_dynamic_ewkb_param_mapping(
+                value,
+                dynamic_bind_mappings,
+            )
+            expanded_values.append(expanded_value)
+            multiparams_changed = multiparams_changed or value_changed
+        if multiparams_changed:
+            expanded_multiparams = tuple(expanded_values)
+
+    expanded_params, params_changed = _expand_mysql_dynamic_ewkb_param_mapping(
+        params,
+        dynamic_bind_mappings,
+    )
+
+    if multiparams_changed or params_changed:
+        return clauseelement, expanded_multiparams, expanded_params
+    return clauseelement, multiparams, params
 
 
 def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewkb=False, **kw):
@@ -563,11 +957,14 @@ def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewk
         clauses, _ = unwrap_wkb_constructor_clauses(clauses)
 
     inferred_srid = None
+    dynamic_srid_clause = None
     if coerce_ewkb:
         original_wkb_clause = clauses[0]
+        split_disabled = _dynamic_ewkb_split_disabled(compiler) or kw.get("literal_binds", False)
         should_process_at_runtime = (
             _is_bindparam_clause(original_wkb_clause)
             and not kw.get("literal_binds", False)
+            and not split_disabled
             and (
                 getattr(original_wkb_clause, "value", None) is None
                 or getattr(original_wkb_clause, "callable", None) is not None
@@ -575,29 +972,49 @@ def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewk
         )
         if should_process_at_runtime:
             has_srid_argument = _has_effective_srid_argument(clauses)
-            fixed_srid = None
-            if not has_srid_argument:
-                fixed_srid = _ewkb_processor_fixed_srid(element, clauses)
-            processor_context = _runtime_ewkb_processor_context(
-                compiler,
-                original_wkb_clause,
-                fixed_srid=fixed_srid,
-                has_srid_argument=has_srid_argument,
-            )
-            wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
-                original_wkb_clause,
-                fixed_srid=fixed_srid,
-                has_srid_argument=has_srid_argument,
-                processor_context=processor_context,
-            )
+            dynamic_default_srid = _dynamic_ewkb_default_srid(element, clauses)
+            if dynamic_default_srid is not None:
+                wkb_value_clause, dynamic_srid_clause = _get_mysql_dynamic_ewkb_bind_clauses(
+                    original_wkb_clause,
+                    compiler,
+                    default_srid=dynamic_default_srid,
+                )
+            else:
+                fixed_srid = None
+                if not has_srid_argument:
+                    fixed_srid = _ewkb_processor_fixed_srid(element, clauses)
+                processor_context = _runtime_ewkb_processor_context(
+                    compiler,
+                    original_wkb_clause,
+                    fixed_srid=fixed_srid,
+                    has_srid_argument=has_srid_argument,
+                )
+                wkb_value_clause = _coerce_ewkb_bind_clause_to_wkb(
+                    original_wkb_clause,
+                    fixed_srid=fixed_srid,
+                    has_srid_argument=has_srid_argument,
+                    processor_context=processor_context,
+                )
         else:
-            wkb_value_clause, inferred_srid = _coerce_known_ewkb_clause_to_wkb(
+            _, inferred_srid = _coerce_ewkb_clause_to_wkb(original_wkb_clause)
+            dynamic_wkb_clause, dynamic_srid_clause = _dynamic_inferred_srid_bind_clauses(
                 element,
                 compiler,
                 original_wkb_clause,
                 clauses,
-                preserve_user_bind=not kw.get("literal_binds", False),
+                inferred_srid=inferred_srid,
+                split_disabled=split_disabled,
             )
+            if dynamic_wkb_clause is not None:
+                wkb_value_clause = dynamic_wkb_clause
+            else:
+                wkb_value_clause, inferred_srid = _coerce_known_ewkb_clause_to_wkb(
+                    element,
+                    compiler,
+                    original_wkb_clause,
+                    clauses,
+                    preserve_user_bind=not kw.get("literal_binds", False),
+                )
     else:
         wkb_value_clause = clauses[0]
 
@@ -611,7 +1028,14 @@ def _compile_GeomFromWKB_MySql(element, compiler, *, identifier=None, coerce_ewk
         suffix = ""
 
     compiled = compiler.process(wkb_clause, **kw)
-    compiled_srid = _compile_srid_arg(element, clauses, inferred_srid, compiler, **kw)
+    compiled_srid = _compile_srid_arg(
+        element,
+        clauses,
+        inferred_srid,
+        compiler,
+        srid_clause=dynamic_srid_clause,
+        **kw,
+    )
 
     if compiled_srid is not None:
         return f"{identifier}({prefix}{compiled}{suffix}, {compiled_srid})"

--- a/geoalchemy2/admin/dialects/postgresql.py
+++ b/geoalchemy2/admin/dialects/postgresql.py
@@ -230,6 +230,7 @@ def _compile_GeomFromWKB_Postgresql(element, compiler, *, include_srid=True, **k
     except (IndexError, TypeError, ValueError):
         srid = element.type.srid
 
+    skip_bind_expression = False
     if kw.get("literal_binds", False):
         if not include_srid and hasattr(clauses[0], "value") and clauses[0].value is not None:
             value = clauses[0].value
@@ -250,7 +251,6 @@ def _compile_GeomFromWKB_Postgresql(element, compiler, *, include_srid=True, **k
         suffix = ", 'hex')"
     else:
         wkb_clause = clauses[0]
-        skip_bind_expression = False
         if (
             not include_srid
             and _wkb_wkt.is_known_srid(srid)

--- a/geoalchemy2/admin/dialects/postgresql.py
+++ b/geoalchemy2/admin/dialects/postgresql.py
@@ -6,18 +6,25 @@ from sqlalchemy import Index
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql.base import ischema_names as _postgresql_ischema_names
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import expression
 from sqlalchemy.sql import func
 from sqlalchemy.sql import select
+from sqlalchemy.types import LargeBinary
+from sqlalchemy.types import TypeDecorator
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
 from geoalchemy2.admin.dialects.common import _format_select_args
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
+from geoalchemy2.elements import WKBElement
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
+from geoalchemy2.types.dialects.common import as_binary_ewkb
 
 _SQLALCHEMY_VERSION_BEFORE_2 = version.parse(sqlalchemy.__version__) < version.parse("2")
 
@@ -25,6 +32,35 @@ _SQLALCHEMY_VERSION_BEFORE_2 = version.parse(sqlalchemy.__version__) < version.p
 _postgresql_ischema_names["geometry"] = Geometry
 _postgresql_ischema_names["geography"] = Geography
 _postgresql_ischema_names["raster"] = Raster
+
+
+class _PostgreSQLEWKBBindType(TypeDecorator):
+    """Bind runtime ST_GeomFromEWKB values as EWKB bytes."""
+
+    impl = LargeBinary
+    cache_ok = True
+
+    def __init__(self, column_srid=None):
+        super().__init__()
+        self.column_srid = column_srid
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        embedded_srid = None
+        try:
+            embedded_source = value.data if isinstance(value, WKBElement) else value
+            embedded_srid = _wkb_wkt.wkb_srid(embedded_source)
+        except (TypeError, ValueError):
+            pass
+        column_srid = None if _wkb_wkt.is_known_srid(embedded_srid) else self.column_srid
+        return as_binary_ewkb(value, column_srid=column_srid)
+
+
+def _uses_ewkb_geometry_bind_processor(clause):
+    spatial_type = getattr(clause, "type", None)
+    from_text = getattr(spatial_type, "from_text", "") or ""
+    return isinstance(spatial_type, Geometry) and "ewkb" in from_text.lower()
 
 
 def check_management(column):
@@ -184,26 +220,57 @@ def after_drop(table, bind, **kw):
         table.columns = saved_cols
 
 
-def _compile_GeomFromWKB_Postgresql(element, compiler, **kw):
+def _compile_GeomFromWKB_Postgresql(element, compiler, *, include_srid=True, **kw):
     # Store the SRID
     clauses = list(element.clauses)
+    if kw.get("literal_binds", False):
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
     try:
         srid = clauses[1].value
     except (IndexError, TypeError, ValueError):
         srid = element.type.srid
 
     if kw.get("literal_binds", False):
+        if not include_srid and hasattr(clauses[0], "value") and clauses[0].value is not None:
+            value = clauses[0].value
+            embedded_srid = None
+            try:
+                embedded_source = value.data if isinstance(value, WKBElement) else value
+                embedded_srid = _wkb_wkt.wkb_srid(embedded_source)
+            except (TypeError, ValueError):
+                pass
+            column_srid = None if _wkb_wkt.is_known_srid(embedded_srid) else srid
+            clauses[0] = expression.bindparam(
+                key=clauses[0].key,
+                value=as_binary_ewkb(value, column_srid=column_srid),
+                unique=True,
+            )
         wkb_clause = compile_bin_literal(clauses[0])
         prefix = "decode("
         suffix = ", 'hex')"
     else:
         wkb_clause = clauses[0]
+        skip_bind_expression = False
+        if (
+            not include_srid
+            and _wkb_wkt.is_known_srid(srid)
+            and not _uses_ewkb_geometry_bind_processor(wkb_clause)
+        ):
+            wkb_clause = expression.type_coerce(
+                wkb_clause,
+                _PostgreSQLEWKBBindType(column_srid=srid),
+            )
+        elif not include_srid and _uses_ewkb_geometry_bind_processor(wkb_clause):
+            skip_bind_expression = True
         prefix = ""
         suffix = ""
 
-    compiled = compiler.process(wkb_clause, **kw)
+    process_kw = dict(kw)
+    if not kw.get("literal_binds", False) and skip_bind_expression:
+        process_kw["skip_bind_expression"] = True
+    compiled = compiler.process(wkb_clause, **process_kw)
 
-    if srid > 0:
+    if include_srid and srid > 0:
         return f"{element.identifier}({prefix}{compiled}{suffix}, {srid})"
     else:
         return f"{element.identifier}({prefix}{compiled}{suffix})"
@@ -216,4 +283,4 @@ def _PostgreSQL_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "postgresql")  # type: ignore
 def _PostgreSQL_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_Postgresql(element, compiler, **kw)
+    return _compile_GeomFromWKB_Postgresql(element, compiler, include_srid=False, **kw)

--- a/geoalchemy2/admin/dialects/sqlite.py
+++ b/geoalchemy2/admin/dialects/sqlite.py
@@ -5,8 +5,11 @@ import os
 from sqlalchemy import text
 from sqlalchemy.dialects.sqlite.base import ischema_names as _sqlite_ischema_names
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import expression
 from sqlalchemy.sql import func
 from sqlalchemy.sql import select
+from sqlalchemy.types import String
+from sqlalchemy.types import TypeDecorator
 
 from geoalchemy2 import functions
 from geoalchemy2.admin.dialects.common import _check_spatial_type
@@ -14,10 +17,13 @@ from geoalchemy2.admin.dialects.common import _format_select_args
 from geoalchemy2.admin.dialects.common import _spatial_idx_name
 from geoalchemy2.admin.dialects.common import compile_bin_literal
 from geoalchemy2.admin.dialects.common import setup_create_drop
+from geoalchemy2.admin.dialects.common import unwrap_wkb_constructor_clauses
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
 from geoalchemy2.types import _DummyGeometry
+from geoalchemy2.types.dialects.common import as_binary_ewkb
+from geoalchemy2.types.dialects.common import as_ewkb_hex
 from geoalchemy2.utils import authorized_values_in_docstring
 
 # Register Geometry, Geography and Raster to SQLAlchemy's reflection subsystems.
@@ -400,18 +406,62 @@ def register_sqlite_mapping(mapping):
 register_sqlite_mapping(_SQLITE_FUNCTIONS)
 
 
-def _compile_GeomFromWKB_SQLite(element, compiler, *, identifier, **kw):
+class _SpatialiteEWKBHexBindType(TypeDecorator):
+    """Bind EWKB as HEXEWKB text for SpatiaLite's GeomFromEWKB."""
+
+    impl = String
+    cache_ok = True
+
+    def __init__(self, column_srid=None):
+        super().__init__()
+        self.column_srid = column_srid
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return as_ewkb_hex(value, column_srid=self.column_srid)
+
+
+def _coerce_ewkb_clause_to_hex(wkb_clause, *, literal=False, column_srid=None):
+    if literal:
+        if hasattr(wkb_clause, "value") and wkb_clause.value is not None:
+            wkb_clause = expression.bindparam(
+                key=wkb_clause.key,
+                value=as_binary_ewkb(wkb_clause.value, column_srid=column_srid),
+                unique=True,
+            )
+        return compile_bin_literal(wkb_clause)
+    return expression.type_coerce(
+        wkb_clause,
+        _SpatialiteEWKBHexBindType(column_srid=column_srid),
+    )
+
+
+def _compile_GeomFromWKB_SQLite(
+    element, compiler, *, identifier, include_srid=True, coerce_ewkb=False, **kw
+):
     element.identifier = identifier
 
     # Store the SRID
     clauses = list(element.clauses)
+    literal_binds = kw.get("literal_binds", False)
+    if literal_binds:
+        clauses, _ = unwrap_wkb_constructor_clauses(clauses)
     try:
         srid = clauses[1].value
         element.type.srid = srid
     except (IndexError, TypeError, ValueError):
         srid = element.type.srid
 
-    if kw.get("literal_binds", False):
+    if coerce_ewkb:
+        wkb_clause = _coerce_ewkb_clause_to_hex(
+            clauses[0],
+            literal=literal_binds,
+            column_srid=srid,
+        )
+        prefix = ""
+        suffix = ""
+    elif literal_binds:
         wkb_clause = compile_bin_literal(clauses[0])
         prefix = "unhex("
         suffix = ")"
@@ -422,7 +472,7 @@ def _compile_GeomFromWKB_SQLite(element, compiler, *, identifier, **kw):
 
     compiled = compiler.process(wkb_clause, **kw)
 
-    if srid > 0:
+    if include_srid and srid > 0:
         return f"{identifier}({prefix}{compiled}{suffix}, {srid})"
     else:
         return f"{identifier}({prefix}{compiled}{suffix})"
@@ -435,4 +485,11 @@ def _SQLite_ST_GeomFromWKB(element, compiler, **kw):
 
 @compiles(functions.ST_GeomFromEWKB, "sqlite")  # type: ignore
 def _SQLite_ST_GeomFromEWKB(element, compiler, **kw):
-    return _compile_GeomFromWKB_SQLite(element, compiler, identifier="GeomFromEWKB", **kw)
+    return _compile_GeomFromWKB_SQLite(
+        element,
+        compiler,
+        identifier="GeomFromEWKB",
+        include_srid=False,
+        coerce_ewkb=True,
+        **kw,
+    )

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -228,16 +228,14 @@ class WKBElement(_SpatialElement):
     ) -> None:
         if srid == -1 or extended is None or extended:
             wkb_srid = None
-            has_srid_header = False
             if (extended is True and srid == -1) or (extended is None and len(data) >= 5):
                 try:
-                    has_srid_header = _wkb_wkt.wkb_has_srid_header(data)
                     wkb_srid = _wkb_wkt.wkb_srid(data)
                 except ValueError:
                     if extended is True:
                         raise
             if extended is None:
-                extended = has_srid_header
+                extended = wkb_srid is not None
             if extended and srid == -1 and wkb_srid is not None:
                 srid = wkb_srid
         _SpatialElement.__init__(self, data, srid, extended)

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -169,7 +169,6 @@ class WKTElement(_SpatialElement):
         """Return this element as a plain :class:`WKBElement` (no SRID embedded).
 
         The SRID is preserved as a Python attribute on the returned element.
-        Unsupported WKT geometry types raise ``ValueError`` from the converter.
         """
         wkb_bytes = _wkb_wkt.to_wkb_no_srid(self.data)
         return WKBElement(wkb_bytes, srid=self.srid, extended=False)
@@ -178,7 +177,6 @@ class WKTElement(_SpatialElement):
         """Return this element as an extended :class:`WKBElement` (SRID embedded).
 
         If the element has no valid SRID, the result is equivalent to :meth:`as_wkb`.
-        Unsupported WKT geometry types raise ``ValueError`` from the converter.
         """
         if self.srid > 0:
             wkb_bytes = _wkb_wkt.to_wkb(self.data, srid=self.srid)

--- a/geoalchemy2/elements.py
+++ b/geoalchemy2/elements.py
@@ -158,7 +158,7 @@ class WKTElement(_SpatialElement):
         return WKTElement(self.data, self.srid, self.extended)
 
     def as_ewkt(self) -> WKTElement:
-        if self.srid > 0:
+        if _wkb_wkt.is_known_srid(self.srid):
             if self.extended:
                 wkt = _wkb_wkt.to_wkt(self.data, srid=self.srid)
                 return WKTElement(wkt, extended=True)
@@ -178,7 +178,7 @@ class WKTElement(_SpatialElement):
 
         If the element has no valid SRID, the result is equivalent to :meth:`as_wkb`.
         """
-        if self.srid > 0:
+        if _wkb_wkt.is_known_srid(self.srid):
             wkb_bytes = _wkb_wkt.to_wkb(self.data, srid=self.srid)
             return WKBElement(wkb_bytes, extended=True)
         return self.as_wkb()
@@ -228,14 +228,14 @@ class WKBElement(_SpatialElement):
             wkb_srid = None
             if (extended is True and srid == -1) or (extended is None and len(data) >= 5):
                 try:
-                    wkb_srid = _wkb_wkt.wkb_srid(data)
+                    wkb_srid = _wkb_wkt.wkb_srid(data, include_unknown=extended is None)
                 except ValueError:
                     if extended is True:
                         raise
             if extended is None:
                 extended = wkb_srid is not None
-            if extended and srid == -1 and wkb_srid is not None:
-                srid = wkb_srid
+            if extended and srid == -1 and _wkb_wkt.is_known_srid(wkb_srid):
+                srid = wkb_srid  # type: ignore[assignment]
         _SpatialElement.__init__(self, data, srid, extended)
 
     @staticmethod
@@ -263,7 +263,7 @@ class WKBElement(_SpatialElement):
         return WKBElement(self.data, self.srid, extended=False)
 
     def as_ewkb(self) -> WKBElement:
-        if self.srid > 0:
+        if _wkb_wkt.is_known_srid(self.srid):
             if self.extended:
                 try:
                     has_matching_srid = _wkb_wkt.wkb_srid(self.data) == self.srid
@@ -288,7 +288,7 @@ class WKBElement(_SpatialElement):
 
         If the element has no valid SRID, the result is equivalent to :meth:`as_wkt`.
         """
-        if self.srid > 0:
+        if _wkb_wkt.is_known_srid(self.srid):
             wkt = _wkb_wkt.to_wkt(self.data, srid=self.srid)
             return WKTElement(wkt, extended=True)
         wkt = _wkb_wkt.to_wkt_no_srid(self.data)

--- a/geoalchemy2/types/__init__.py
+++ b/geoalchemy2/types/__init__.py
@@ -443,8 +443,9 @@ class CompositeType(UserDefinedType):
             try:
                 type_ = self.type.typemap[key]
             except KeyError:
+                type_name = type(self.type).__name__
                 raise AttributeError(
-                    f"Type '{self.type}' doesn't have an attribute: '{key}'"
+                    f"Type '{type_name}' doesn't have an attribute: '{key}'"
                 ) from None
 
             return CompositeElement(self.expr, key, type_)

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -1,5 +1,122 @@
 """This module defines functions used by several dialects."""
 
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.exc import ArgumentError
+
+
+def is_wkb_constructor(spatial_type):
+    return "wkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def is_ewkb_constructor(spatial_type):
+    return "ewkb" in (getattr(spatial_type, "from_text", "") or "").lower()
+
+
+def _validate_wkb_bindvalue_srid(bindvalue, column_srid):
+    if not is_known_srid(column_srid):
+        return
+
+    if isinstance(bindvalue, bytearray):
+        bindvalue = bytes(bindvalue)
+
+    srids = []
+    if isinstance(bindvalue, WKBElement):
+        if is_known_srid(bindvalue.srid):
+            srids.append(bindvalue.srid)
+        bindvalue = bindvalue.data
+
+    if isinstance(bindvalue, (bytes, bytearray, memoryview, str)):
+        srid = _wkb_wkt.wkb_srid(bindvalue)
+        if is_known_srid(srid):
+            srids.append(srid)
+
+    for srid in srids:
+        validate_wkb_srid(column_srid, srid)
+
+
+def as_binary_wkb(bindvalue, *, strip_srid=False, column_srid=None):
+    if strip_srid:
+        _validate_wkb_bindvalue_srid(bindvalue, column_srid)
+        if isinstance(bindvalue, WKBElement):
+            bindvalue = bindvalue.data
+        if isinstance(bindvalue, bytearray):
+            bindvalue = bytes(bindvalue)
+        return _wkb_wkt.to_wkb_no_srid(bindvalue)
+    elif isinstance(bindvalue, WKBElement):
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, memoryview):
+        return bindvalue.tobytes()
+    if isinstance(bindvalue, str):
+        return WKBElement._data_from_desc(bindvalue)
+    return bytes(bindvalue)
+
+
+def as_binary_ewkb(bindvalue, *, column_srid=None):
+    if bindvalue is None:
+        return None
+
+    element_srid = None
+    if isinstance(bindvalue, WKBElement):
+        if is_known_srid(bindvalue.srid):
+            element_srid = bindvalue.srid
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, bytearray):
+        bindvalue = bytes(bindvalue)
+
+    embedded_srid = None
+    if isinstance(bindvalue, (bytes, bytearray, memoryview, str)):
+        embedded_srid = _wkb_wkt.wkb_srid(bindvalue)
+    if isinstance(bindvalue, str):
+        bindvalue = WKBElement._data_from_desc(bindvalue)
+
+    if is_known_srid(element_srid):
+        validate_wkb_srid(column_srid, element_srid)
+    elif is_known_srid(embedded_srid):
+        validate_wkb_srid(column_srid, embedded_srid)
+
+    if is_known_srid(element_srid):
+        return _wkb_wkt.to_ewkb_header(bindvalue, element_srid)
+
+    if is_known_srid(embedded_srid):
+        return as_binary_wkb(bindvalue)
+
+    if is_known_srid(column_srid):
+        return _wkb_wkt.to_ewkb_header(bindvalue, column_srid)
+
+    return as_binary_wkb(bindvalue)
+
+
+def as_ewkb_hex(bindvalue, *, column_srid=None):
+    ewkb = as_binary_ewkb(bindvalue, column_srid=column_srid)
+    if ewkb is None:
+        return None
+    return ewkb.hex()
+
+
+def as_wkb_hex(bindvalue, *, column_srid=None):
+    _validate_wkb_bindvalue_srid(bindvalue, column_srid)
+    if isinstance(bindvalue, WKBElement):
+        bindvalue = bindvalue.data
+    if isinstance(bindvalue, bytearray):
+        bindvalue = bytes(bindvalue)
+    return _wkb_wkt.to_hex_wkb_no_srid(bindvalue).lower()
+
+
+def validate_wkb_srid(column_srid, srid, *, has_fixed_srid=True):
+    if (
+        has_fixed_srid
+        and column_srid is not None
+        and is_known_srid(column_srid)
+        and is_known_srid(srid)
+        and srid != column_srid
+    ):
+        raise ArgumentError(
+            f"The SRID ({srid}) of the supplied value is different "
+            f"from the one of the column ({column_srid})"
+        )
+
 
 def bind_processor_process(spatial_type, bindvalue):
     return bindvalue  # pragma: no cover

--- a/geoalchemy2/types/dialects/common.py
+++ b/geoalchemy2/types/dialects/common.py
@@ -37,6 +37,8 @@ def _validate_wkb_bindvalue_srid(bindvalue, column_srid):
 
 
 def as_binary_wkb(bindvalue, *, strip_srid=False, column_srid=None):
+    if bindvalue is None:
+        return None
     if strip_srid:
         _validate_wkb_bindvalue_srid(bindvalue, column_srid)
         if isinstance(bindvalue, WKBElement):

--- a/geoalchemy2/types/dialects/geopackage.py
+++ b/geoalchemy2/types/dialects/geopackage.py
@@ -1,3 +1,22 @@
 """This module defines specific functions for GeoPackage dialect."""
 
-from geoalchemy2.types.dialects.sqlite import bind_processor_process  # noqa
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import as_ewkb_hex
+from geoalchemy2.types.dialects.common import is_ewkb_constructor
+from geoalchemy2.types.dialects.common import is_wkb_constructor
+from geoalchemy2.types.dialects.sqlite import (
+    bind_processor_process as sqlite_bind_processor_process,
+)
+
+__all__ = ["bind_processor_process"]
+
+
+def bind_processor_process(spatial_type, bindvalue):
+    if is_wkb_constructor(spatial_type) and isinstance(
+        bindvalue, (WKBElement, bytes, bytearray, memoryview, str)
+    ):
+        if is_ewkb_constructor(spatial_type):
+            return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
+        return as_binary_wkb(bindvalue)
+    return sqlite_bind_processor_process(spatial_type, bindvalue)

--- a/geoalchemy2/types/dialects/mariadb.py
+++ b/geoalchemy2/types/dialects/mariadb.py
@@ -1,14 +1,36 @@
 """This module defines specific functions for MySQL dialect."""
 
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import is_wkb_constructor
+from geoalchemy2.types.dialects.common import validate_wkb_srid
+
+
+def _normalize_mariadb_wkt(wkt):
+    if "multipoint" in wkt[:20].lower() and "empty" not in wkt[:30].lower():
+        # MariaDB does not support ISO WKT with parentheses around each sub-point.
+        first_idx = wkt.find("(")
+        last_idx = wkt.rfind(")")
+        if first_idx == -1 or last_idx == -1:
+            return wkt
+        wkt = (
+            wkt[: first_idx + 1]
+            + wkt[first_idx:last_idx].replace("(", "").replace(")", "")
+            + wkt[last_idx:]
+        )
+    return wkt
 
 
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
+        if is_wkb_constructor(spatial_type):
+            return as_wkb_hex(bindvalue, column_srid=spatial_type.srid)
+
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
         srid = wkt_match.group(2)
         try:
@@ -19,44 +41,26 @@ def bind_processor_process(spatial_type, bindvalue):
                 f"The SRID ({srid}) of the supplied value can not be casted to integer"
             ) from None
 
-        if srid is not None and srid != spatial_type.srid:
-            raise ArgumentError(
-                f"The SRID ({srid}) of the supplied value is different "
-                f"from the one of the column ({spatial_type.srid})"
-            )
+        validate_wkb_srid(spatial_type.srid, srid)
         return wkt_match.group(3)
 
-    if (
-        isinstance(bindvalue, _SpatialElement)
-        and bindvalue.srid != -1
-        and bindvalue.srid != spatial_type.srid
-    ):
-        raise ArgumentError(
-            f"The SRID ({bindvalue.srid}) of the supplied value is different "
-            f"from the one of the column ({spatial_type.srid})"
-        )
+    if isinstance(bindvalue, _SpatialElement):
+        validate_wkb_srid(spatial_type.srid, bindvalue.srid)
 
     if isinstance(bindvalue, WKTElement):
         bindvalue = bindvalue.as_wkt()
-        if bindvalue.srid <= 0:
+        if not is_known_srid(bindvalue.srid):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
-        if "wkb" not in spatial_type.from_text.lower():
-            # With MariaDB we use Shapely to convert the WKBElement to an EWKT string
-            wkt = to_shape(bindvalue).wkt
-            if "multipoint" in wkt[:20].lower():
-                # Shapely>=2.1 adds parentheses around each sub-point which is not supported
-                first_idx = wkt.find("(")
-                last_idx = wkt.rfind(")")
-                wkt = (
-                    wkt[: first_idx + 1]
-                    + wkt[first_idx:last_idx].replace("(", "").replace(")", "")
-                    + wkt[last_idx:]
-                )
-            return wkt
+        if not is_wkb_constructor(spatial_type):
+            return _normalize_mariadb_wkt(_wkb_wkt.to_wkt_no_srid(bindvalue.data))
         # MariaDB does not support raw binary data so we use the hex representation
-        return bindvalue.desc
-    elif isinstance(bindvalue, memoryview):
-        return bindvalue.tobytes().hex()
+        return as_wkb_hex(bindvalue, column_srid=spatial_type.srid)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if is_wkb_constructor(spatial_type):
+            return as_wkb_hex(bindvalue, column_srid=spatial_type.srid)
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        validate_wkb_srid(spatial_type.srid, srid)
+        return _normalize_mariadb_wkt(wkt)
     return bindvalue

--- a/geoalchemy2/types/dialects/mssql.py
+++ b/geoalchemy2/types/dialects/mssql.py
@@ -1,35 +1,25 @@
 """This module defines specific functions for MSSQL dialect."""
 
-import binascii
-import math
 import re
-import struct
 
 from sqlalchemy.types import TypeDecorator
 
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.shape import to_shape
 
 _WKT_DIMENSION_SUFFIX = re.compile(
-    r"^([A-Z]+?)\s*(ZM|Z|M)(\s*\(.*)$",
+    r"\b(POINT|LINESTRING|POLYGON|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON|"
+    r"GEOMETRYCOLLECTION)\s*(ZM|Z|M)(?=\s*(?:\(|EMPTY))",
     re.IGNORECASE | re.DOTALL,
 )
-_WKB_TYPE_NAMES = {
-    1: "POINT",
-    2: "LINESTRING",
-    3: "POLYGON",
-    4: "MULTIPOINT",
-    5: "MULTILINESTRING",
-    6: "MULTIPOLYGON",
-    7: "GEOMETRYCOLLECTION",
-}
 
 
 def _normalize_wkt_for_mssql(wkt):
-    return _WKT_DIMENSION_SUFFIX.sub(r"\1\3", wkt)
+    return _WKT_DIMENSION_SUFFIX.sub(r"\1", wkt)
 
 
 def _split_mssql_st_point_args(spec):
@@ -96,12 +86,6 @@ def _split_mssql_st_point_args(spec):
     return None
 
 
-def _format_wkb_number(value):
-    if value == 0:
-        value = 0.0
-    return format(value, ".17g")
-
-
 def _coerce_wkb_data(value):
     if isinstance(value, WKBElement):
         value = value.data
@@ -110,119 +94,51 @@ def _coerce_wkb_data(value):
     if isinstance(value, (bytes, bytearray)):
         return bytes(value)
     if isinstance(value, str):
-        return binascii.unhexlify(value)
+        return value
     raise TypeError("Unsupported WKB value type")
-
-
-def _decode_wkb_type(raw_type):
-    has_srid = bool(raw_type & 0x20000000)
-    has_z = bool(raw_type & 0x80000000)
-    has_m = bool(raw_type & 0x40000000)
-    base_type = raw_type & 0x1FFFFFFF
-
-    if base_type not in _WKB_TYPE_NAMES:
-        if base_type >= 3000:
-            base_type -= 3000
-            has_z = True
-            has_m = True
-        elif base_type >= 2000:
-            base_type -= 2000
-            has_m = True
-        elif base_type >= 1000:
-            base_type -= 1000
-            has_z = True
-
-    type_name = _WKB_TYPE_NAMES.get(base_type)
-    if type_name is None:
-        raise ValueError(f"Unsupported WKB geometry type: {raw_type}")
-
-    return type_name, 2 + int(has_z) + int(has_m), has_srid
-
-
-def _read_uint32(data, offset, byte_order):
-    return struct.unpack_from(f"{byte_order}I", data, offset)[0], offset + 4
-
-
-def _read_coord(data, offset, byte_order, dimension):
-    values = struct.unpack_from(f"{byte_order}{'d' * dimension}", data, offset)
-    coord = " ".join(_format_wkb_number(value) for value in values)
-    return coord, values, offset + (8 * dimension)
-
-
-def _read_coords(data, offset, byte_order, dimension, count):
-    coords = []
-    for _ in range(count):
-        coord, _, offset = _read_coord(data, offset, byte_order, dimension)
-        coords.append(coord)
-    return coords, offset
-
-
-def _parse_wkb_geometry(data, offset=0):
-    byte_order_marker = data[offset]
-    if byte_order_marker not in (0, 1):
-        raise ValueError(f"Invalid WKB byte order marker: {byte_order_marker}")
-    byte_order = "<" if byte_order_marker == 1 else ">"
-    offset += 1
-
-    raw_type, offset = _read_uint32(data, offset, byte_order)
-    type_name, dimension, has_srid = _decode_wkb_type(raw_type)
-
-    if has_srid:
-        _, offset = _read_uint32(data, offset, byte_order)
-
-    if type_name == "POINT":
-        coord, values, offset = _read_coord(data, offset, byte_order, dimension)
-        if all(math.isnan(value) for value in values):
-            return type_name, " EMPTY", offset
-        return type_name, f" ({coord})", offset
-
-    if type_name == "LINESTRING":
-        point_count, offset = _read_uint32(data, offset, byte_order)
-        if point_count == 0:
-            return type_name, " EMPTY", offset
-        coords, offset = _read_coords(data, offset, byte_order, dimension, point_count)
-        return type_name, f" ({', '.join(coords)})", offset
-
-    if type_name == "POLYGON":
-        ring_count, offset = _read_uint32(data, offset, byte_order)
-        if ring_count == 0:
-            return type_name, " EMPTY", offset
-        rings = []
-        for _ in range(ring_count):
-            point_count, offset = _read_uint32(data, offset, byte_order)
-            coords, offset = _read_coords(data, offset, byte_order, dimension, point_count)
-            rings.append(f"({', '.join(coords)})")
-        return type_name, f" ({', '.join(rings)})", offset
-
-    if type_name in {"MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON", "GEOMETRYCOLLECTION"}:
-        geometry_count, offset = _read_uint32(data, offset, byte_order)
-        if geometry_count == 0:
-            return type_name, " EMPTY", offset
-        geometries = []
-        for _ in range(geometry_count):
-            child_type, child_text, offset = _parse_wkb_geometry(data, offset)
-            if type_name == "GEOMETRYCOLLECTION":
-                geometries.append(f"{child_type}{child_text}")
-            else:
-                geometries.append(child_text.strip())
-        return type_name, f" ({', '.join(geometries)})", offset
-
-    raise ValueError(f"Unsupported WKB geometry type: {type_name}")
 
 
 def _wkb_to_mssql_wkt(value):
     data = _coerce_wkb_data(value)
-    type_name, body, _ = _parse_wkb_geometry(data)
-    return f"{type_name}{body}"
+    try:
+        return _normalize_wkt_for_mssql(_wkb_wkt.to_wkt_no_srid(data))
+    except ValueError as exc:
+        message = str(exc)
+        message_lower = message.lower()
+        if "unsupported geometry type" in message_lower:
+            raise ValueError(f"Unsupported WKB geometry type: {message}") from None
+        if "invalid byte order marker" in message_lower:
+            raise ValueError(f"Invalid WKB byte order marker: {message}") from None
+        raise
+
+
+def _split_wkb_to_mssql_wkt(value):
+    data = _coerce_wkb_data(value)
+    try:
+        wkt, srid = _wkb_wkt.split_wkb_srid(data)
+    except ValueError as exc:
+        message = str(exc)
+        message_lower = message.lower()
+        if "unsupported geometry type" in message_lower:
+            raise ValueError(f"Unsupported WKB geometry type: {message}") from None
+        if "invalid byte order marker" in message_lower:
+            raise ValueError(f"Invalid WKB byte order marker: {message}") from None
+        raise
+    return _normalize_wkt_for_mssql(wkt), srid
 
 
 def _to_mssql_wkt(value):
-    try:
-        return _wkb_to_mssql_wkt(value)
-    except (TypeError, ValueError, struct.error, binascii.Error, IndexError):
-        if isinstance(value, (bytes, bytearray, memoryview)):
-            value = WKBElement(value)
-        return _normalize_wkt_for_mssql(to_shape(value).wkt)
+    if isinstance(value, WKTElement):
+        return _normalize_wkt_for_mssql(_wkb_wkt.to_wkt_no_srid(value.data))
+    return _wkb_to_mssql_wkt(value)
+
+
+def _validate_wkb_srid(column_srid, has_fixed_srid, srid):
+    if has_fixed_srid and is_known_srid(srid) and srid != column_srid:
+        raise ArgumentError(
+            f"The SRID ({srid}) of the supplied value is different "
+            f"from the one of the column ({column_srid})"
+        )
 
 
 def _resolve_mssql_spatial_type(spatial_type, dialect):
@@ -246,29 +162,21 @@ def bind_processor_process(spatial_type, bindvalue, dialect=None):
                 f"The SRID ({srid}) of the supplied value can not be casted to integer"
             ) from None
 
-        if has_fixed_srid and srid is not None and srid != column_srid:
-            raise ArgumentError(
-                f"The SRID ({srid}) of the supplied value is different "
-                f"from the one of the column ({column_srid})"
-            )
+        _validate_wkb_srid(column_srid, has_fixed_srid, srid)
         return _normalize_wkt_for_mssql(wkt_match.group(3))
 
-    if (
-        isinstance(bindvalue, _SpatialElement)
-        and has_fixed_srid
-        and bindvalue.srid != -1
-        and bindvalue.srid != column_srid
-    ):
-        raise ArgumentError(
-            f"The SRID ({bindvalue.srid}) of the supplied value is different "
-            f"from the one of the column ({column_srid})"
-        )
+    if isinstance(bindvalue, _SpatialElement):
+        _validate_wkb_srid(column_srid, has_fixed_srid, bindvalue.srid)
 
     if isinstance(bindvalue, WKTElement):
         bindvalue = bindvalue.as_wkt()
-        if bindvalue.srid <= 0:
+        if not is_known_srid(bindvalue.srid):
             bindvalue.srid = spatial_type.srid
         return _normalize_wkt_for_mssql(bindvalue.data)
-    elif isinstance(bindvalue, (bytes, bytearray, memoryview, WKBElement)):
+    elif isinstance(bindvalue, WKBElement):
         return _to_mssql_wkt(bindvalue)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        wkt, srid = _split_wkb_to_mssql_wkt(bindvalue)
+        _validate_wkb_srid(column_srid, has_fixed_srid, srid)
+        return wkt
     return bindvalue

--- a/geoalchemy2/types/dialects/mssql.py
+++ b/geoalchemy2/types/dialects/mssql.py
@@ -22,6 +22,37 @@ def _normalize_wkt_for_mssql(wkt):
     return _WKT_DIMENSION_SUFFIX.sub(r"\1", wkt)
 
 
+def _strip_converter_error_prefix(message, prefixes):
+    message = message.strip()
+    message_lower = message.lower()
+    for prefix in prefixes:
+        if message_lower.startswith(prefix):
+            return message[len(prefix) :].lstrip(": ")
+    return message
+
+
+def _mssql_wkb_converter_error_message(exc):
+    message = str(exc)
+    message_lower = message.lower()
+    if "unsupported geometry type" in message_lower:
+        detail = _strip_converter_error_prefix(message, ("unsupported geometry type",))
+        if detail:
+            return f"Unsupported WKB geometry type: {detail}"
+        return "Unsupported WKB geometry type"
+    if "invalid byte order marker" in message_lower:
+        detail = _strip_converter_error_prefix(
+            message,
+            (
+                "invalid wkb: invalid byte order marker",
+                "invalid byte order marker",
+            ),
+        )
+        if detail:
+            return f"Invalid WKB byte order marker: {detail}"
+        return "Invalid WKB byte order marker"
+    return None
+
+
 def _split_mssql_st_point_args(spec):
     """Split the two top-level args of GeoAlchemy's MSSQL computed-column ST_POINT.
 
@@ -103,12 +134,9 @@ def _wkb_to_mssql_wkt(value):
     try:
         return _normalize_wkt_for_mssql(_wkb_wkt.to_wkt_no_srid(data))
     except ValueError as exc:
-        message = str(exc)
-        message_lower = message.lower()
-        if "unsupported geometry type" in message_lower:
-            raise ValueError(f"Unsupported WKB geometry type: {message}") from None
-        if "invalid byte order marker" in message_lower:
-            raise ValueError(f"Invalid WKB byte order marker: {message}") from None
+        message = _mssql_wkb_converter_error_message(exc)
+        if message is not None:
+            raise ValueError(message) from None
         raise
 
 
@@ -117,12 +145,9 @@ def _split_wkb_to_mssql_wkt(value):
     try:
         wkt, srid = _wkb_wkt.split_wkb_srid(data)
     except ValueError as exc:
-        message = str(exc)
-        message_lower = message.lower()
-        if "unsupported geometry type" in message_lower:
-            raise ValueError(f"Unsupported WKB geometry type: {message}") from None
-        if "invalid byte order marker" in message_lower:
-            raise ValueError(f"Invalid WKB byte order marker: {message}") from None
+        message = _mssql_wkb_converter_error_message(exc)
+        if message is not None:
+            raise ValueError(message) from None
         raise
     return _normalize_wkt_for_mssql(wkt), srid
 

--- a/geoalchemy2/types/dialects/mysql.py
+++ b/geoalchemy2/types/dialects/mysql.py
@@ -1,14 +1,21 @@
 """This module defines specific functions for MySQL dialect."""
 
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.exc import ArgumentError
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import is_wkb_constructor
+from geoalchemy2.types.dialects.common import validate_wkb_srid
 
 
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, str):
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue, strip_srid=True, column_srid=spatial_type.srid)
+
         wkt_match = WKTElement._REMOVE_SRID.match(bindvalue)
         srid = wkt_match.group(2)
         try:
@@ -19,30 +26,26 @@ def bind_processor_process(spatial_type, bindvalue):
                 f"The SRID ({srid}) of the supplied value can not be casted to integer"
             ) from None
 
-        if srid is not None and srid != spatial_type.srid:
-            raise ArgumentError(
-                f"The SRID ({srid}) of the supplied value is different "
-                f"from the one of the column ({spatial_type.srid})"
-            )
+        validate_wkb_srid(spatial_type.srid, srid)
         return wkt_match.group(3)
 
-    if (
-        isinstance(bindvalue, _SpatialElement)
-        and bindvalue.srid != -1
-        and bindvalue.srid != spatial_type.srid
-    ):
-        raise ArgumentError(
-            f"The SRID ({bindvalue.srid}) of the supplied value is different "
-            f"from the one of the column ({spatial_type.srid})"
-        )
+    if isinstance(bindvalue, _SpatialElement):
+        validate_wkb_srid(spatial_type.srid, bindvalue.srid)
 
     if isinstance(bindvalue, WKTElement):
         bindvalue = bindvalue.as_wkt()
-        if bindvalue.srid <= 0:
+        if not is_known_srid(bindvalue.srid):
             bindvalue.srid = spatial_type.srid
         return bindvalue
     elif isinstance(bindvalue, WKBElement):
-        if "wkb" not in spatial_type.from_text.lower():
-            # With MySQL we use Shapely to convert the WKBElement to an EWKT string
-            return to_shape(bindvalue).wkt
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue, strip_srid=True, column_srid=spatial_type.srid)
+        else:
+            return _wkb_wkt.to_wkt_no_srid(bindvalue.data)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue, strip_srid=True, column_srid=spatial_type.srid)
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        validate_wkb_srid(spatial_type.srid, srid)
+        return wkt
     return bindvalue

--- a/geoalchemy2/types/dialects/postgresql.py
+++ b/geoalchemy2/types/dialects/postgresql.py
@@ -1,29 +1,51 @@
 """This module defines specific functions for Postgresql dialect."""
 
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import as_binary_ewkb
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import is_ewkb_constructor
+from geoalchemy2.types.dialects.common import is_wkb_constructor
+from geoalchemy2.types.dialects.common import validate_wkb_srid
 
 
 def bind_processor_process(spatial_type, bindvalue):
     if isinstance(bindvalue, WKTElement):
         if bindvalue.extended:
-            return f"{bindvalue.data}"
+            return bindvalue.data
         else:
-            return f"SRID={bindvalue.srid};{bindvalue.data}"
+            return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
     elif isinstance(bindvalue, WKBElement):
-        if not bindvalue.extended:
-            # When the WKBElement includes a WKB value rather
-            # than a EWKB value we use Shapely to convert the WKBElement to an
-            # EWKT string
-            shape = to_shape(bindvalue)
-            return f"SRID={bindvalue.srid};{shape.wkt}"
+        if is_ewkb_constructor(spatial_type):
+            return as_binary_ewkb(bindvalue, column_srid=spatial_type.srid)
+        elif is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
+        elif not bindvalue.extended:
+            return _wkb_wkt.to_wkt(bindvalue.data, srid=bindvalue.srid)
         else:
             # PostGIS ST_GeomFromEWKT works with EWKT strings as well
             # as EWKB hex strings
             return bindvalue.desc
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
+    elif isinstance(bindvalue, str):
+        if is_ewkb_constructor(spatial_type):
+            return as_binary_ewkb(bindvalue, column_srid=spatial_type.srid)
+        elif is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
+        return bindvalue
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if is_ewkb_constructor(spatial_type):
+            return as_binary_ewkb(bindvalue, column_srid=spatial_type.srid)
+        elif is_wkb_constructor(spatial_type):
+            return as_binary_wkb(bindvalue)
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        if is_known_srid(srid):
+            validate_wkb_srid(spatial_type.srid, srid)
+            return _wkb_wkt.to_wkt(wkt, srid=srid)
+        return _wkb_wkt.to_wkt(wkt, srid=spatial_type.srid)
     else:
         return bindvalue

--- a/geoalchemy2/types/dialects/sqlite.py
+++ b/geoalchemy2/types/dialects/sqlite.py
@@ -3,10 +3,14 @@
 import re
 import warnings
 
+from geoalchemy2 import _wkb_wkt
 from geoalchemy2.elements import RasterElement
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.elements import WKTElement
-from geoalchemy2.shape import to_shape
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import as_ewkb_hex
+from geoalchemy2.types.dialects.common import is_ewkb_constructor
+from geoalchemy2.types.dialects.common import is_wkb_constructor
 
 
 def format_geom_type(wkt, default_srid=None):
@@ -34,23 +38,39 @@ def format_geom_type(wkt, default_srid=None):
 
 
 def bind_processor_process(spatial_type, bindvalue):
+    use_ewkb_constructor = is_ewkb_constructor(spatial_type)
     if isinstance(bindvalue, WKTElement):
         return format_geom_type(
             bindvalue.data,
             default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
         )
     elif isinstance(bindvalue, WKBElement):
-        # With SpatiaLite we use Shapely to convert the WKBElement to an EWKT string
-        shape = to_shape(bindvalue)
-        # shapely.wkb.loads returns geom_type with a 'Z', for example, 'LINESTRING Z'
-        # which is a limitation with SpatiaLite. Hence, a temporary fix.
+        if is_wkb_constructor(spatial_type):
+            if use_ewkb_constructor:
+                return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
+            return as_binary_wkb(bindvalue)
         res = format_geom_type(
-            shape.wkt, default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid
+            _wkb_wkt.to_wkt_no_srid(bindvalue.data),
+            default_srid=bindvalue.srid if bindvalue.srid >= 0 else spatial_type.srid,
         )
         return res
     elif isinstance(bindvalue, RasterElement):
         return f"{bindvalue.data}"
     elif isinstance(bindvalue, str):
+        if is_wkb_constructor(spatial_type):
+            if use_ewkb_constructor:
+                return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
+            return as_binary_wkb(bindvalue)
         return format_geom_type(bindvalue, default_srid=spatial_type.srid)
+    elif isinstance(bindvalue, (bytes, bytearray, memoryview)):
+        if is_wkb_constructor(spatial_type):
+            if use_ewkb_constructor:
+                return as_ewkb_hex(bindvalue, column_srid=spatial_type.srid)
+            return as_binary_wkb(bindvalue)
+        wkt, srid = _wkb_wkt.split_wkb_srid(bindvalue)
+        return format_geom_type(
+            wkt,
+            default_srid=srid if srid is not None and srid >= 0 else spatial_type.srid,
+        )
     else:
         return bindvalue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "SQLAlchemy>=1.4",
     "packaging",
-    "wkb-wkt-converter>=0.6.1",
+    "wkb-wkt-converter>=0.6.3",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pytest-benchmark
 pytest-html
 pytest-mypy;implementation_name!='pypy'
 rasterio;implementation_name!='pypy'
-wkb-wkt-converter>=0.6.1
+wkb-wkt-converter>=0.6.3

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql import func
 
 from geoalchemy2 import Geometry
@@ -232,6 +233,16 @@ def _insert_fail_or_success_type(
 ):
     """Fixture to determine if the current test should fail or succeed."""
     if (
+        dialect_name == "sqlite"
+        and input_representation == "WKB input"
+        and is_extended_input
+        and not is_default_geom_type
+    ):
+        return (OperationalError, AssertionError)
+    if dialect_name == "geopackage" and input_representation == "WKB input":  # noqa: SIM102
+        if is_extended_input and not is_default_geom_type:  # noqa: SIM102
+            return AssertionError
+    if (
         dialect_name in ["sqlite", "geopackage"]
         and not is_default_geom_type
         and not is_extended_input
@@ -304,26 +315,48 @@ def _insert_select_fail_or_success_type(
     is_default_geom_type,
 ):
     """Fixture to determine if the current test should fail or succeed."""
-    if dialect_name in ["mysql"] and not is_default_geom_type and is_extended_output:
+    if dialect_name in ["mysql", "mariadb"] and not is_default_geom_type and is_extended_output:
+        if output_representation == "WKB output":
+            return AssertionError
         return OperationalError
+    if (
+        dialect_name in ["mysql", "mariadb", "postgresql", "sqlite"]
+        and input_representation == "WKB input"
+        and is_raw_input
+        and is_default_geom_type
+    ):
+        return (SQLAlchemyError, AssertionError)
+    if (
+        dialect_name == "sqlite"
+        and input_representation == "WKB input"
+        and is_extended_input
+        and not is_default_geom_type
+    ):
+        return (OperationalError, AssertionError)
+    if (
+        dialect_name == "geopackage"
+        and not is_default_geom_type
+        and is_extended_output
+        and output_representation == "WKB output"
+    ):
+        return AssertionError
     if dialect_name in ["sqlite", "geopackage"] and not is_default_geom_type:
         if not is_extended_output:
             return AssertionError
         else:
-            return OperationalError
+            return (OperationalError, AssertionError)
     if (
         dialect_name in ["postgresql", "sqlite", "geopackage"]
         and is_default_geom_type
         and not is_extended_output
     ):
         return AssertionError
+    if is_default_geom_type and output_representation == "WKT output":
+        return AssertionError
     if dialect_name in ["mysql", "sqlite", "geopackage"] and is_extended_output:
         return AssertionError
     if dialect_name in ["mariadb"] and is_extended_output:
-        if is_default_geom_type:
-            return AssertionError
-        else:
-            return OperationalError
+        return AssertionError
     if not is_default_geom_type and is_extended_output:
         return AssertionError
     return SuccessfulTest

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -12,9 +12,6 @@ from geoalchemy2.elements import WKTElement
 from .. import create_points
 from .. import select
 
-# SQL Server allows at most 1000 row value expressions per INSERT statement.
-_MSSQL_INSERT_CHUNK_SIZE = 1000
-
 
 class SuccessfulTest(BaseException):
     """A custom exception used to mark the successful test."""
@@ -131,13 +128,7 @@ def GeomTable(
 def insert_all_points(conn, table, points):
     """Insert all points into the database."""
     rows = [{"geom": point} for point in points]
-    if conn.dialect.name != "mssql":
-        return conn.execute(table.insert().values(rows))
-
-    result = None
-    for start in range(0, len(rows), _MSSQL_INSERT_CHUNK_SIZE):
-        result = conn.execute(table.insert().values(rows[start : start + _MSSQL_INSERT_CHUNK_SIZE]))
-    return result
+    return conn.execute(table.insert(), rows)
 
 
 def select_all_points(conn, table):
@@ -230,6 +221,13 @@ def _insert_fail_or_success_type(
     if dialect_name == "geopackage" and input_representation == "WKB input":  # noqa: SIM102
         if is_extended_input and not is_default_geom_type:  # noqa: SIM102
             return AssertionError
+    if (
+        dialect_name == "mssql"
+        and input_representation == "WKB input"
+        and not is_extended_input
+        and not is_default_geom_type
+    ):
+        return SQLAlchemyError
     if (
         dialect_name in ["sqlite", "geopackage"]
         and not is_default_geom_type
@@ -328,6 +326,13 @@ def _insert_select_fail_or_success_type(
         and output_representation == "WKB output"
     ):
         return AssertionError
+    if (
+        dialect_name == "mssql"
+        and input_representation == "WKB input"
+        and not is_extended_input
+        and not is_default_geom_type
+    ):
+        return SQLAlchemyError
     if dialect_name in ["sqlite", "geopackage"] and not is_default_geom_type:
         if not is_extended_output:
             return AssertionError

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -152,19 +152,19 @@ def insert_and_select_all_points(conn, table, points):
     return select_all_points(conn, table)
 
 
-def _benchmark_setup(
-    conn, table_class, metadata, convert_wkb=False, extended=False, raw=False, N=50
-):
-    """Setup the database for benchmarking."""
-    # Create the points to insert
-    points = create_points(N, convert_wkb=convert_wkb, extended=extended, raw=raw)
-
-    # Create the table in the database
+def _reset_benchmark_table(conn, table_class, metadata):
+    """Reset the database table for benchmarking."""
     metadata.drop_all(conn, checkfirst=True)
     metadata.create_all(conn)
     print(f"Table {table_class.__tablename__} created")
 
-    return points
+    return table_class.__table__
+
+
+def _benchmark_setup(conn, table_class, metadata, points):
+    """Setup the database for a benchmark round."""
+    table = _reset_benchmark_table(conn, table_class, metadata)
+    return (conn, table, points), {}
 
 
 def _benchmark_insert(
@@ -179,19 +179,12 @@ def _benchmark_insert(
     rounds=5,
 ):
     """Benchmark the insert operation."""
-    points = _benchmark_setup(
-        conn,
-        table_class,
-        metadata,
-        convert_wkb=convert_wkb,
-        raw=raw_input,
-        extended=extended_input,
-        N=N,
-    )
-
-    table = table_class.__table__
+    points = create_points(N, convert_wkb=convert_wkb, raw=raw_input, extended=extended_input)
     return benchmark.pedantic(
-        insert_all_points, args=(conn, table, points), iterations=1, rounds=rounds
+        insert_all_points,
+        setup=lambda: _benchmark_setup(conn, table_class, metadata, points),
+        iterations=1,
+        rounds=rounds,
     )
 
 
@@ -207,19 +200,12 @@ def _benchmark_insert_select(
     rounds=5,
 ):
     """Benchmark the insert and select operations."""
-    points = _benchmark_setup(
-        conn,
-        table_class,
-        metadata,
-        convert_wkb=convert_wkb,
-        raw=raw_input,
-        extended=extended_input,
-        N=N,
-    )
-
-    table = table_class.__table__
+    points = create_points(N, convert_wkb=convert_wkb, raw=raw_input, extended=extended_input)
     return benchmark.pedantic(
-        insert_and_select_all_points, args=(conn, table, points), iterations=1, rounds=rounds
+        insert_and_select_all_points,
+        setup=lambda: _benchmark_setup(conn, table_class, metadata, points),
+        iterations=1,
+        rounds=rounds,
     )
 
 
@@ -295,7 +281,7 @@ def test_insert(
                 .select_from(GeomTable.__table__)
                 .where(GeomTable.__table__.c.geom.is_not(None))
             ).scalar()
-            == N * N * insert_select_rounds
+            == N * N
         )
 
     except SuccessfulTest:
@@ -398,9 +384,9 @@ def _actual_test_insert_select(
                 GeomTable.__table__.select().where(GeomTable.__table__.c.geom.is_not(None))
             ).fetchall()
         )
-        == N * N * insert_select_rounds
+        == N * N
     )
-    assert len(all_points) == N * N * insert_select_rounds
+    assert len(all_points) == N * N
 
     res = conn.execute(select([GeomTable.__table__.c.geom])).fetchone()
     expected_extended_output = is_extended_output

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -88,11 +88,11 @@ def GeomTable(
     print("output_representation:", output_representation)
     print("is_default_geom_type:", is_default_geom_type)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-    if input_representation == "WKB":
+    if input_representation == "WKB input":
         from_text_func = "ST_GeomFromEWKB" if is_extended_input else "ST_GeomFromWKB"
     else:
         from_text_func = "ST_GeomFromEWKT" if is_extended_input else "ST_GeomFromText"
-    if output_representation == "WKB":
+    if output_representation == "WKB output":
         to_text_func = "ST_AsEWKB" if is_extended_output else "ST_AsBinary"
         ElementType_cls = WKBElement
     else:
@@ -261,7 +261,7 @@ def test_insert(
     _insert_fail_or_success_type,
 ):
     """Benchmark the insert operation."""
-    convert_wkb = input_representation == "WKB"
+    convert_wkb = input_representation == "WKB input"
 
     try:
         _benchmark_insert(
@@ -344,7 +344,7 @@ def _actual_test_insert_select(
     insert_select_rounds,
 ):
     """Actual test for insert and select operations."""
-    convert_wkb = input_representation == "WKB"
+    convert_wkb = input_representation == "WKB input"
     all_points = _benchmark_insert_select(
         conn,
         GeomTable,
@@ -372,9 +372,9 @@ def _actual_test_insert_select(
     if conn.dialect.name == "mssql" and is_default_geom_type:
         expected_extended_output = True
     assert res[0].extended == expected_extended_output
-    if output_representation == "WKB":
+    if output_representation == "WKB output":
         assert isinstance(res[0], WKBElement)
-    elif output_representation == "WKT":
+    elif output_representation == "WKT output":
         assert isinstance(res[0], WKTElement)
     assert res[0].srid == 4326
 

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -176,6 +176,7 @@ def _benchmark_insert(
         setup=lambda: _benchmark_setup(conn, table_class, metadata, points),
         iterations=1,
         rounds=rounds,
+        warmup_rounds=2,
     )
 
 
@@ -197,6 +198,7 @@ def _benchmark_insert_select(
         setup=lambda: _benchmark_setup(conn, table_class, metadata, points),
         iterations=1,
         rounds=rounds,
+        warmup_rounds=2,
     )
 
 

--- a/tests/benchmarks/test_insert_select.py
+++ b/tests/benchmarks/test_insert_select.py
@@ -12,6 +12,9 @@ from geoalchemy2.elements import WKTElement
 from .. import create_points
 from .. import select
 
+# SQL Server allows at most 1000 row value expressions per INSERT statement.
+_MSSQL_INSERT_CHUNK_SIZE = 1000
+
 
 class SuccessfulTest(BaseException):
     """A custom exception used to mark the successful test."""
@@ -127,15 +130,14 @@ def GeomTable(
 
 def insert_all_points(conn, table, points):
     """Insert all points into the database."""
-    query = table.insert().values(
-        [
-            {
-                "geom": point,
-            }
-            for point in points
-        ]
-    )
-    return conn.execute(query)
+    rows = [{"geom": point} for point in points]
+    if conn.dialect.name != "mssql":
+        return conn.execute(table.insert().values(rows))
+
+    result = None
+    for start in range(0, len(rows), _MSSQL_INSERT_CHUNK_SIZE):
+        result = conn.execute(table.insert().values(rows[start : start + _MSSQL_INSERT_CHUNK_SIZE]))
+    return result
 
 
 def select_all_points(conn, table):

--- a/tests/gallery/test_orm_mapped_v2.py
+++ b/tests/gallery/test_orm_mapped_v2.py
@@ -52,10 +52,11 @@ def test_ORM_mapping(session, conn, schema) -> None:
     # Insert point
     session.add(p)
     session.flush()
+    point_id = p.id
     session.expire(p)
 
     # Query the point and check the result
     pt = session.query(Lake).one()
-    assert pt.id == 1
+    assert pt.id == point_id
     assert pt.mapped_geom.srid == 4326
     check_wkb(pt.mapped_geom, 5, 45)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -428,6 +428,7 @@ class TestExtendedWKBElement:
     )
     _hex_ewkb = "010100002003000000000000000000f03f0000000000000040"
     _hex_zero_srid_ewkb = "010100002000000000000000000000f03f0000000000000040"
+    _hex_unknown_srid_ewkb = "0101000020ffffffff000000000000f03f0000000000000040"
     _hex_wkb = "0101000000000000000000f03f0000000000000040"
     _srid = 3  # expected srid
     _wkt = "POINT (1 2)"  # expected wkt
@@ -490,11 +491,27 @@ class TestExtendedWKBElement:
         assert e.srid == self._srid
         assert wkb.loads(e.data, hex=True).wkt == self._wkt
 
-    def test_zero_srid_ewkb_auto_detects_as_non_extended(self):
+    def test_zero_srid_ewkb_auto_detects_extended_header(self):
         e = WKBElement(self._hex_zero_srid_ewkb)
 
-        assert e.extended is False
+        assert e.extended is True
         assert e.srid == -1
+
+        plain_wkb = e.as_wkb()
+        assert plain_wkb.desc == self._hex_wkb
+        assert plain_wkb.srid == -1
+        assert plain_wkb.extended is False
+
+    def test_unknown_uint_srid_ewkb_auto_detects_extended_header(self):
+        e = WKBElement(self._hex_unknown_srid_ewkb)
+
+        assert e.extended is True
+        assert e.srid == -1
+
+        plain_wkb = e.as_wkb()
+        assert plain_wkb.desc == self._hex_wkb
+        assert plain_wkb.srid == -1
+        assert plain_wkb.extended is False
 
     def test_eq(self):
         a = WKBElement(self._bin_ewkb, extended=True)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -490,16 +490,11 @@ class TestExtendedWKBElement:
         assert e.srid == self._srid
         assert wkb.loads(e.data, hex=True).wkt == self._wkt
 
-    def test_zero_srid_ewkb_auto_detects_extended_header(self):
+    def test_zero_srid_ewkb_auto_detects_as_non_extended(self):
         e = WKBElement(self._hex_zero_srid_ewkb)
 
-        assert e.extended is True
+        assert e.extended is False
         assert e.srid == -1
-
-        plain_wkb = e.as_wkb()
-        assert plain_wkb.desc == self._hex_wkb
-        assert plain_wkb.srid == -1
-        assert plain_wkb.extended is False
 
     def test_eq(self):
         a = WKBElement(self._bin_ewkb, extended=True)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,6 +37,7 @@ WKB_HEX = "0101000000000000000000f03f0000000000000040"
 EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
 WEB_MERCATOR_EWKB_HEX = "0101000020110f0000000000000000f03f0000000000000040"
 ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
+UNKNOWN_SRID_EWKB_HEX = "0101000020ffffffff000000000000f03f0000000000000040"
 
 
 class _GeoPackageDialect:
@@ -55,6 +56,13 @@ def test_split_wkb_srid_treats_strings_as_hex_wkb_only():
         _wkb_wkt.split_wkb_srid("SRID=4326;POINT (1 2)")
 
 
+def test_wkb_srid_can_include_unknown_srid_values():
+    assert _wkb_wkt.wkb_srid(ZERO_SRID_EWKB_HEX) is None
+    assert _wkb_wkt.wkb_srid(ZERO_SRID_EWKB_HEX, include_unknown=True) == 0
+    assert _wkb_wkt.wkb_srid(UNKNOWN_SRID_EWKB_HEX) is None
+    assert _wkb_wkt.wkb_srid(UNKNOWN_SRID_EWKB_HEX, include_unknown=True) == -1
+
+
 @pytest.mark.parametrize(
     ("srid", "expected"),
     [
@@ -63,6 +71,7 @@ def test_split_wkb_srid_treats_strings_as_hex_wkb_only():
         (0, False),
         (1, True),
         (4326, True),
+        (0xFFFFFFFF, True),
     ],
 )
 def test_is_known_srid(srid, expected):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -213,6 +213,31 @@ def test_ewkb_constructor_bind_processors_validate_shared_helper_srid(dialect):
         bind_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))
 
 
+def _cached_dynamic_ewkb_srid(dialect_module, dialect, stmt, cache, params=None):
+    dialect.supports_statement_cache = True
+    conn = type("Conn", (), {"dialect": dialect})()
+    clauseelement, _, expanded_params = dialect_module.before_execute(
+        conn,
+        stmt,
+        (),
+        params or {},
+        {},
+    )
+    compiled, extracted_params, cache_hit = clauseelement._compile_w_cache(
+        dialect,
+        compiled_cache=cache,
+        column_keys=[],
+        for_executemany=False,
+        schema_translate_map=None,
+    )
+    final_params = compiled.construct_params(
+        params=expanded_params,
+        extracted_parameters=extracted_params,
+    )
+    srid_key = next(key for key in compiled.positiontup if key.endswith("_srid"))
+    return cache_hit, compiled._bind_processors[srid_key](final_params[srid_key])
+
+
 @pytest.fixture
 def geometry_table():
     table = Table("table", MetaData(), Column("geom", Geometry))
@@ -421,9 +446,17 @@ class TestMySQLWKBConstructors:
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
 
         compiled_expr = expr.compile(dialect=mysql.dialect())
+        wkb_key, srid_key = compiled_expr.positiontup
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 4326)"
-        assert compiled_expr.params == {"param_1": bytes.fromhex(WKB_HEX)}
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert compiled_expr.params == {
+            wkb_key: bytes.fromhex(EWKB_HEX),
+            srid_key: (bytes.fromhex(EWKB_HEX), 4326),
+        }
+        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(EWKB_HEX)) == bytes.fromhex(
+            WKB_HEX
+        )
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
 
     def test_geom_from_ewkb_literal_compile_strips_ewkb_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
@@ -492,25 +525,83 @@ class TestMySQLWKBConstructors:
     def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
 
-        compiled = self.normalize_sql(expr.compile(dialect=mysql.dialect()))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        srid_key = compiled_expr.positiontup[1]
 
-        assert compiled == "ST_GeomFromWKB(%s, 4326)"
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
 
     def test_geom_from_ewkb_uses_embedded_srid_without_return_type_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))
 
-        compiled = self.normalize_sql(expr.compile(dialect=mysql.dialect()))
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        srid_key = compiled_expr.positiontup[1]
 
-        assert compiled == "ST_GeomFromWKB(%s, 4326)"
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
 
     @pytest.mark.parametrize("srid", [None, -1, 0])
     def test_geom_from_ewkb_omitted_explicit_srid_uses_embedded_srid(self, srid):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), srid)
 
         compiled_expr = expr.compile(dialect=mysql.dialect())
+        wkb_key, srid_key = compiled_expr.positiontup
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 4326)"
-        assert list(compiled_expr.params.values()) == [bytes.fromhex(WKB_HEX)]
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert compiled_expr.params == {
+            wkb_key: bytes.fromhex(EWKB_HEX),
+            srid_key: (bytes.fromhex(EWKB_HEX), 4326),
+        }
+        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(EWKB_HEX)) == bytes.fromhex(
+            WKB_HEX
+        )
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
+
+    def test_geom_from_ewkb_inferred_srid_bind_keeps_cache_shape(self):
+        stmt_4326 = select([func.ST_GeomFromEWKB(bindparam("wkb", bytes.fromhex(EWKB_HEX)))])
+        stmt_3857 = select(
+            [func.ST_GeomFromEWKB(bindparam("wkb", bytes.fromhex(WEB_MERCATOR_EWKB_HEX)))]
+        )
+
+        compiled_4326 = self.normalize_sql(stmt_4326.compile(dialect=mysql.dialect()))
+        compiled_3857 = self.normalize_sql(stmt_3857.compile(dialect=mysql.dialect()))
+
+        assert compiled_4326 == compiled_3857
+        assert "ST_GeomFromWKB(%s, %s)" in compiled_4326
+        assert "4326" not in compiled_4326
+        assert "3857" not in compiled_3857
+        assert stmt_4326._generate_cache_key().key == stmt_3857._generate_cache_key().key
+
+    def test_geom_from_ewkb_cached_literal_values_use_current_srid(self):
+        cache = {}
+        dialect = mysql.dialect()
+        stmt_4326 = select([func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))])
+        stmt_3857 = select([func.ST_GeomFromEWKB(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))])
+
+        _, srid_4326 = _cached_dynamic_ewkb_srid(_mysql_admin, dialect, stmt_4326, cache)
+        _, srid_3857 = _cached_dynamic_ewkb_srid(_mysql_admin, dialect, stmt_3857, cache)
+
+        assert len(cache) == 1
+        assert srid_4326 == 4326
+        assert srid_3857 == 3857
+
+    def test_geom_from_ewkb_cached_defaulted_bindparam_override_uses_current_srid(self):
+        cache = {}
+        dialect = mysql.dialect()
+        stmt = select([func.ST_GeomFromEWKB(bindparam("wkb", bytes.fromhex(EWKB_HEX)))])
+
+        _, default_srid = _cached_dynamic_ewkb_srid(_mysql_admin, dialect, stmt, cache)
+        _, override_srid = _cached_dynamic_ewkb_srid(
+            _mysql_admin,
+            dialect,
+            stmt,
+            cache,
+            params={"wkb": bytes.fromhex(WEB_MERCATOR_EWKB_HEX)},
+        )
+
+        assert len(cache) == 1
+        assert default_srid == 4326
+        assert override_srid == 3857
 
     @pytest.mark.parametrize("srid", [None, -1, 0])
     def test_geom_from_ewkb_runtime_bind_with_omitted_explicit_srid_rejects_ewkb(
@@ -527,20 +618,79 @@ class TestMySQLWKBConstructors:
         with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
             wkb_processor(bytes.fromhex(EWKB_HEX))
 
-    def test_geom_from_ewkb_defaulted_bindparam_preserves_key_and_processor(self):
+    def test_geom_from_ewkb_defaulted_bindparam_uses_dynamic_srid_processor(self):
         source_bind = bindparam("wkb", bytes.fromhex(EWKB_HEX))
         expr = func.ST_GeomFromEWKB(source_bind)
         compiled_expr = expr.compile(dialect=mysql.dialect())
-        wkb_processor = compiled_expr._bind_processors["wkb"]
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=4326,
+        )
+        wkb_processor = compiled_expr._bind_processors[wkb_key]
+        srid_processor = compiled_expr._bind_processors[srid_key]
         override = bytes.fromhex(WKB_HEX)
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, 4326)"
-        assert compiled_expr.params == {"wkb": bytes.fromhex(EWKB_HEX)}
-        assert compiled_expr.construct_params({"wkb": override}) == {"wkb": override}
-        assert wkb_processor(compiled_expr.params["wkb"]) == bytes.fromhex(WKB_HEX)
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert compiled_expr.params == {
+            wkb_key: bytes.fromhex(EWKB_HEX),
+            srid_key: (bytes.fromhex(EWKB_HEX), 4326),
+        }
+        assert wkb_processor(compiled_expr.params[wkb_key]) == bytes.fromhex(WKB_HEX)
         assert wkb_processor(bytes.fromhex(EWKB_HEX)) == bytes.fromhex(WKB_HEX)
-        with pytest.raises(ArgumentError, match=r"column \(4326\)"):
-            wkb_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))
+        assert wkb_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX)) == bytes.fromhex(WKB_HEX)
+        assert srid_processor(bytes.fromhex(EWKB_HEX)) == 4326
+        assert srid_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX)) == 3857
+        assert srid_processor(override) == 4326
+
+    def test_mysql_before_execute_expands_dynamic_ewkb_bindparams(self):
+        source_bind = bindparam("wkb", bytes.fromhex(EWKB_HEX))
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=4326,
+        )
+        override = bytes.fromhex(WEB_MERCATOR_EWKB_HEX)
+
+        clauseelement, multiparams, params = _mysql_admin.before_execute(
+            type("Conn", (), {"dialect": mysql.dialect()})(),
+            stmt,
+            (),
+            {"wkb": override},
+            {},
+        )
+
+        assert clauseelement is stmt
+        assert multiparams == ()
+        assert params == {
+            "wkb": override,
+            wkb_key: override,
+            srid_key: (override, 4326),
+        }
+
+    def test_geom_from_ewkb_callable_bind_uses_dynamic_srid_processor(self):
+        calls = []
+        value = bytes.fromhex(WEB_MERCATOR_EWKB_HEX)
+
+        def get_wkb():
+            calls.append("called")
+            return value
+
+        source_bind = bindparam("wkb", callable_=get_wkb)
+        expr = func.ST_GeomFromEWKB(source_bind)
+        compiled_expr = expr.compile(dialect=mysql.dialect())
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=0,
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
+        assert compiled_expr.construct_params() == {
+            wkb_key: value,
+            srid_key: (value, 0),
+        }
+        assert calls == ["called"]
+        assert compiled_expr._bind_processors[wkb_key](value) == bytes.fromhex(WKB_HEX)
+        assert compiled_expr._bind_processors[srid_key](value) == 3857
 
     def test_geom_from_ewkb_fixed_srid_bindparam_strips_runtime_ewkb(self):
         source_bind = bindparam("wkb")
@@ -613,9 +763,15 @@ class TestMariaDBWKBConstructors:
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
 
         compiled_expr = expr.compile(dialect=self.dialect())
+        wkb_key, srid_key = compiled_expr.positiontup
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 4326)"
-        assert compiled_expr.params == {"param_1": WKB_HEX}
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert compiled_expr.params == {
+            wkb_key: bytes.fromhex(EWKB_HEX),
+            srid_key: (bytes.fromhex(EWKB_HEX), 4326),
+        }
+        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(EWKB_HEX)) == WKB_HEX
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
 
     def test_geom_from_ewkb_literal_compile_strips_ewkb_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=4326))
@@ -684,25 +840,81 @@ class TestMariaDBWKBConstructors:
     def test_geom_from_ewkb_prefers_embedded_srid_over_return_type_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), type_=Geometry(srid=3857))
 
-        compiled = self.normalize_sql(expr.compile(dialect=self.dialect()))
+        compiled_expr = expr.compile(dialect=self.dialect())
+        srid_key = compiled_expr.positiontup[1]
 
-        assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
 
     def test_geom_from_ewkb_uses_embedded_srid_without_return_type_srid(self):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))
 
-        compiled = self.normalize_sql(expr.compile(dialect=self.dialect()))
+        compiled_expr = expr.compile(dialect=self.dialect())
+        srid_key = compiled_expr.positiontup[1]
 
-        assert compiled == "ST_GeomFromWKB(unhex(%s), 4326)"
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
 
     @pytest.mark.parametrize("srid", [None, -1, 0])
     def test_geom_from_ewkb_omitted_explicit_srid_uses_embedded_srid(self, srid):
         expr = func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX), srid)
 
         compiled_expr = expr.compile(dialect=self.dialect())
+        wkb_key, srid_key = compiled_expr.positiontup
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 4326)"
-        assert list(compiled_expr.params.values()) == [WKB_HEX]
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert compiled_expr.params == {
+            wkb_key: bytes.fromhex(EWKB_HEX),
+            srid_key: (bytes.fromhex(EWKB_HEX), 4326),
+        }
+        assert compiled_expr._bind_processors[wkb_key](bytes.fromhex(EWKB_HEX)) == WKB_HEX
+        assert compiled_expr._bind_processors[srid_key](bytes.fromhex(EWKB_HEX)) == 4326
+
+    def test_geom_from_ewkb_inferred_srid_bind_keeps_cache_shape(self):
+        stmt_4326 = select([func.ST_GeomFromEWKB(bindparam("wkb", bytes.fromhex(EWKB_HEX)))])
+        stmt_3857 = select(
+            [func.ST_GeomFromEWKB(bindparam("wkb", bytes.fromhex(WEB_MERCATOR_EWKB_HEX)))]
+        )
+
+        compiled_4326 = self.normalize_sql(stmt_4326.compile(dialect=self.dialect()))
+        compiled_3857 = self.normalize_sql(stmt_3857.compile(dialect=self.dialect()))
+
+        assert compiled_4326 == compiled_3857
+        assert "ST_GeomFromWKB(unhex(%s), %s)" in compiled_4326
+        assert "4326" not in compiled_4326
+        assert "3857" not in compiled_3857
+        assert stmt_4326._generate_cache_key().key == stmt_3857._generate_cache_key().key
+
+    def test_geom_from_ewkb_cached_literal_values_use_current_srid(self):
+        cache = {}
+        dialect = self.dialect()
+        stmt_4326 = select([func.ST_GeomFromEWKB(bytes.fromhex(EWKB_HEX))])
+        stmt_3857 = select([func.ST_GeomFromEWKB(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))])
+
+        _, srid_4326 = _cached_dynamic_ewkb_srid(_mariadb_admin, dialect, stmt_4326, cache)
+        _, srid_3857 = _cached_dynamic_ewkb_srid(_mariadb_admin, dialect, stmt_3857, cache)
+
+        assert len(cache) == 1
+        assert srid_4326 == 4326
+        assert srid_3857 == 3857
+
+    def test_geom_from_ewkb_cached_defaulted_bindparam_override_uses_current_srid(self):
+        cache = {}
+        dialect = self.dialect()
+        stmt = select([func.ST_GeomFromEWKB(bindparam("wkb", bytes.fromhex(EWKB_HEX)))])
+
+        _, default_srid = _cached_dynamic_ewkb_srid(_mariadb_admin, dialect, stmt, cache)
+        _, override_srid = _cached_dynamic_ewkb_srid(
+            _mariadb_admin,
+            dialect,
+            stmt,
+            cache,
+            params={"wkb": bytes.fromhex(WEB_MERCATOR_EWKB_HEX)},
+        )
+
+        assert len(cache) == 1
+        assert default_srid == 4326
+        assert override_srid == 3857
 
     @pytest.mark.parametrize("srid", [None, -1, 0])
     def test_geom_from_ewkb_runtime_bind_with_omitted_explicit_srid_rejects_ewkb(
@@ -719,20 +931,79 @@ class TestMariaDBWKBConstructors:
         with pytest.raises(ArgumentError, match="fixed column SRID or an explicit SRID"):
             wkb_processor(bytes.fromhex(EWKB_HEX))
 
-    def test_geom_from_ewkb_defaulted_bindparam_preserves_key_and_processor(self):
+    def test_geom_from_ewkb_defaulted_bindparam_uses_dynamic_srid_processor(self):
         source_bind = bindparam("wkb", bytes.fromhex(EWKB_HEX))
         expr = func.ST_GeomFromEWKB(source_bind)
         compiled_expr = expr.compile(dialect=self.dialect())
-        wkb_processor = compiled_expr._bind_processors["wkb"]
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=4326,
+        )
+        wkb_processor = compiled_expr._bind_processors[wkb_key]
+        srid_processor = compiled_expr._bind_processors[srid_key]
         override = bytes.fromhex(WKB_HEX)
 
-        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), 4326)"
-        assert compiled_expr.params == {"wkb": bytes.fromhex(EWKB_HEX)}
-        assert compiled_expr.construct_params({"wkb": override}) == {"wkb": override}
-        assert wkb_processor(compiled_expr.params["wkb"]) == WKB_HEX
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert compiled_expr.params == {
+            wkb_key: bytes.fromhex(EWKB_HEX),
+            srid_key: (bytes.fromhex(EWKB_HEX), 4326),
+        }
+        assert wkb_processor(compiled_expr.params[wkb_key]) == WKB_HEX
         assert wkb_processor(bytes.fromhex(EWKB_HEX)) == WKB_HEX
-        with pytest.raises(ArgumentError, match=r"column \(4326\)"):
-            wkb_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))
+        assert wkb_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX)) == WKB_HEX
+        assert srid_processor(bytes.fromhex(EWKB_HEX)) == 4326
+        assert srid_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX)) == 3857
+        assert srid_processor(override) == 4326
+
+    def test_mariadb_before_execute_expands_dynamic_ewkb_bindparams(self):
+        source_bind = bindparam("wkb", bytes.fromhex(EWKB_HEX))
+        stmt = select([func.ST_GeomFromEWKB(source_bind)])
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=4326,
+        )
+        override = bytes.fromhex(WEB_MERCATOR_EWKB_HEX)
+
+        clauseelement, multiparams, params = _mariadb_admin.before_execute(
+            type("Conn", (), {"dialect": self.dialect()})(),
+            stmt,
+            (),
+            {"wkb": override},
+            {},
+        )
+
+        assert clauseelement is stmt
+        assert multiparams == ()
+        assert params == {
+            "wkb": override,
+            wkb_key: override,
+            srid_key: (override, 4326),
+        }
+
+    def test_geom_from_ewkb_callable_bind_uses_dynamic_srid_processor(self):
+        calls = []
+        value = bytes.fromhex(WEB_MERCATOR_EWKB_HEX)
+
+        def get_wkb():
+            calls.append("called")
+            return value
+
+        source_bind = bindparam("wkb", callable_=get_wkb)
+        expr = func.ST_GeomFromEWKB(source_bind)
+        compiled_expr = expr.compile(dialect=self.dialect())
+        wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
+            source_bind,
+            default_srid=0,
+        )
+
+        assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"
+        assert compiled_expr.construct_params() == {
+            wkb_key: value,
+            srid_key: (value, 0),
+        }
+        assert calls == ["called"]
+        assert compiled_expr._bind_processors[wkb_key](value) == WKB_HEX
+        assert compiled_expr._bind_processors[srid_key](value) == 3857
 
     def test_geom_from_ewkb_fixed_srid_bindparam_strips_runtime_ewkb(self):
         source_bind = bindparam("wkb")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -19,6 +19,13 @@ from geoalchemy2.exc import ArgumentError
 from geoalchemy2.types import Geography
 from geoalchemy2.types import Geometry
 from geoalchemy2.types import Raster
+from geoalchemy2.types.dialects.common import as_binary_ewkb
+from geoalchemy2.types.dialects.common import as_binary_wkb
+from geoalchemy2.types.dialects.common import as_ewkb_hex
+from geoalchemy2.types.dialects.common import as_wkb_hex
+from geoalchemy2.types.dialects.common import is_ewkb_constructor
+from geoalchemy2.types.dialects.common import is_wkb_constructor
+from geoalchemy2.types.dialects.common import validate_wkb_srid
 
 from . import select
 
@@ -31,6 +38,115 @@ ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
 def eq_sql(a, b):
     a = re.sub(r"[\n\t]", "", str(a))
     assert a == b
+
+
+@pytest.mark.parametrize(
+    ("spatial_type", "expected_wkb", "expected_ewkb"),
+    [
+        (Geometry(), False, False),
+        (Geometry(from_text="ST_GeomFromWKB"), True, False),
+        (Geometry(from_text="ST_GeomFromEWKB"), True, True),
+    ],
+)
+def test_wkb_constructor_helpers(spatial_type, expected_wkb, expected_ewkb):
+    assert is_wkb_constructor(spatial_type) is expected_wkb
+    assert is_ewkb_constructor(spatial_type) is expected_ewkb
+
+
+@pytest.mark.parametrize(
+    "bindvalue",
+    [
+        bytes.fromhex(EWKB_HEX),
+        bytearray(bytes.fromhex(EWKB_HEX)),
+        memoryview(bytes.fromhex(EWKB_HEX)),
+        EWKB_HEX,
+        WKBElement(bytes.fromhex(EWKB_HEX), extended=True),
+    ],
+)
+def test_as_binary_wkb_strips_or_validates_srid(bindvalue):
+    assert as_binary_wkb(bindvalue, strip_srid=True, column_srid=4326) == bytes.fromhex(WKB_HEX)
+
+
+def test_as_binary_wkb_validates_column_srid():
+    with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+        as_binary_wkb(bytes.fromhex(EWKB_HEX), strip_srid=True, column_srid=3857)
+
+
+@pytest.mark.parametrize(
+    "bindvalue",
+    [
+        bytes.fromhex(EWKB_HEX),
+        memoryview(bytes.fromhex(EWKB_HEX)),
+        EWKB_HEX,
+        WKBElement(bytes.fromhex(EWKB_HEX), extended=True),
+    ],
+)
+def test_as_wkb_hex_strips_or_validates_srid(bindvalue):
+    assert as_wkb_hex(bindvalue, column_srid=4326) == WKB_HEX
+
+
+def test_as_wkb_hex_validates_column_srid():
+    with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+        as_wkb_hex(bytes.fromhex(EWKB_HEX), column_srid=3857)
+
+
+@pytest.mark.parametrize(
+    ("bindvalue", "column_srid", "expected"),
+    [
+        (WKBElement(bytes.fromhex(WKB_HEX), srid=4326), None, bytes.fromhex(EWKB_HEX)),
+        (bytes.fromhex(WKB_HEX), 4326, bytes.fromhex(EWKB_HEX)),
+        (memoryview(bytes.fromhex(WKB_HEX)), 4326, bytes.fromhex(EWKB_HEX)),
+        (bytes.fromhex(EWKB_HEX), None, bytes.fromhex(EWKB_HEX)),
+    ],
+)
+def test_as_binary_ewkb_embeds_or_preserves_known_srid(bindvalue, column_srid, expected):
+    assert as_binary_ewkb(bindvalue, column_srid=column_srid) == expected
+
+
+def test_as_binary_ewkb_respects_wkbelement_srid_override_for_ewkb():
+    bindvalue = WKBElement(bytes.fromhex(EWKB_HEX), srid=3857, extended=True)
+    expected = bindvalue.as_ewkb().data
+
+    assert expected == bytes.fromhex(WEB_MERCATOR_EWKB_HEX)
+    assert as_binary_ewkb(bindvalue) == expected
+
+
+@pytest.mark.parametrize(
+    ("bindvalue", "column_srid", "expected"),
+    [
+        (bytes.fromhex(WKB_HEX), 4326, EWKB_HEX),
+        (memoryview(bytes.fromhex(WKB_HEX)), 4326, EWKB_HEX),
+        (WKB_HEX, 4326, EWKB_HEX),
+        (None, 4326, None),
+    ],
+)
+def test_as_ewkb_hex_embeds_or_preserves_known_srid(bindvalue, column_srid, expected):
+    assert as_ewkb_hex(bindvalue, column_srid=column_srid) == expected
+
+
+def test_as_ewkb_hex_respects_wkbelement_srid_override_for_ewkb():
+    bindvalue = WKBElement(bytes.fromhex(EWKB_HEX), srid=3857, extended=True)
+
+    assert as_ewkb_hex(bindvalue) == WEB_MERCATOR_EWKB_HEX
+
+
+@pytest.mark.parametrize(
+    "bindvalue",
+    [
+        WKBElement(bytes.fromhex(WKB_HEX), srid=4326),
+        bytes.fromhex(EWKB_HEX),
+    ],
+)
+def test_as_binary_ewkb_validates_column_srid(bindvalue):
+    with pytest.raises(ArgumentError, match=r"column \(3857\)"):
+        as_binary_ewkb(bindvalue, column_srid=3857)
+
+
+def test_validate_wkb_srid_ignores_unknown_srid_values():
+    validate_wkb_srid(3857, 4326, has_fixed_srid=False)
+    validate_wkb_srid(None, 4326)
+    validate_wkb_srid(3857, 0)
+    validate_wkb_srid(3857, -1)
 
 
 @pytest.fixture

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -13,6 +13,8 @@ from sqlalchemy.sql import func
 from sqlalchemy.sql import insert
 from sqlalchemy.sql import text
 
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2._wkb_wkt import is_known_srid
 from geoalchemy2.admin.dialects import mariadb as _mariadb_admin  # noqa: F401
 from geoalchemy2.admin.dialects import mysql as _mysql_admin  # noqa: F401
 from geoalchemy2.elements import WKBElement
@@ -44,6 +46,27 @@ class _GeoPackageDialect:
 def eq_sql(a, b):
     a = re.sub(r"[\n\t]", "", str(a))
     assert a == b
+
+
+def test_split_wkb_srid_treats_strings_as_hex_wkb_only():
+    assert _wkb_wkt.split_wkb_srid(EWKB_HEX) == ("POINT (1 2)", 4326)
+
+    with pytest.raises(ValueError):
+        _wkb_wkt.split_wkb_srid("SRID=4326;POINT (1 2)")
+
+
+@pytest.mark.parametrize(
+    ("srid", "expected"),
+    [
+        (None, False),
+        (-1, False),
+        (0, False),
+        (1, True),
+        (4326, True),
+    ],
+)
+def test_is_known_srid(srid, expected):
+    assert is_known_srid(srid) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -633,7 +633,6 @@ class TestMySQLWKBConstructors:
         compiled_expr = expr.compile(dialect=mysql.dialect())
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=4326,
         )
         wkb_processor = compiled_expr._bind_processors[wkb_key]
         srid_processor = compiled_expr._bind_processors[srid_key]
@@ -656,7 +655,6 @@ class TestMySQLWKBConstructors:
         stmt = select([func.ST_GeomFromEWKB(source_bind)])
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=4326,
         )
         override = bytes.fromhex(WEB_MERCATOR_EWKB_HEX)
 
@@ -689,7 +687,6 @@ class TestMySQLWKBConstructors:
         compiled_expr = expr.compile(dialect=mysql.dialect())
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=0,
         )
 
         assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(%s, %s)"
@@ -946,7 +943,6 @@ class TestMariaDBWKBConstructors:
         compiled_expr = expr.compile(dialect=self.dialect())
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=4326,
         )
         wkb_processor = compiled_expr._bind_processors[wkb_key]
         srid_processor = compiled_expr._bind_processors[srid_key]
@@ -969,7 +965,6 @@ class TestMariaDBWKBConstructors:
         stmt = select([func.ST_GeomFromEWKB(source_bind)])
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=4326,
         )
         override = bytes.fromhex(WEB_MERCATOR_EWKB_HEX)
 
@@ -1002,7 +997,6 @@ class TestMariaDBWKBConstructors:
         compiled_expr = expr.compile(dialect=self.dialect())
         wkb_key, srid_key = _mysql_admin._mysql_dynamic_ewkb_bind_keys(
             source_bind,
-            default_srid=0,
         )
 
         assert self.normalize_sql(compiled_expr) == "ST_GeomFromWKB(unhex(%s), %s)"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,6 +6,8 @@ from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import bindparam
 from sqlalchemy.dialects import mysql
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import sqlite
 from sqlalchemy.dialects.mysql import mariadb as mariadb_dialect
 from sqlalchemy.sql import func
 from sqlalchemy.sql import insert
@@ -33,6 +35,10 @@ WKB_HEX = "0101000000000000000000f03f0000000000000040"
 EWKB_HEX = "0101000020e6100000000000000000f03f0000000000000040"
 WEB_MERCATOR_EWKB_HEX = "0101000020110f0000000000000000f03f0000000000000040"
 ZERO_SRID_EWKB_HEX = "010100002000000000000000000000f03f0000000000000040"
+
+
+class _GeoPackageDialect:
+    name = "geopackage"
 
 
 def eq_sql(a, b):
@@ -147,6 +153,41 @@ def test_validate_wkb_srid_ignores_unknown_srid_values():
     validate_wkb_srid(None, 4326)
     validate_wkb_srid(3857, 0)
     validate_wkb_srid(3857, -1)
+
+
+@pytest.mark.parametrize(
+    ("dialect", "bindvalue", "expected"),
+    [
+        (mysql.dialect(), bytes.fromhex(EWKB_HEX), bytes.fromhex(WKB_HEX)),
+        (mariadb_dialect.MariaDBDialect(), memoryview(bytes.fromhex(EWKB_HEX)), WKB_HEX),
+        (postgresql.dialect(), WKB_HEX, bytes.fromhex(EWKB_HEX)),
+        (sqlite.dialect(), bytes.fromhex(WKB_HEX), EWKB_HEX),
+        (_GeoPackageDialect(), WKB_HEX, EWKB_HEX),
+    ],
+    ids=["mysql", "mariadb", "postgresql", "sqlite", "geopackage"],
+)
+def test_ewkb_constructor_bind_processors_use_shared_helpers(dialect, bindvalue, expected):
+    bind_processor = Geometry(srid=4326, from_text="ST_GeomFromEWKB").bind_processor(dialect)
+
+    assert bind_processor(bindvalue) == expected
+
+
+@pytest.mark.parametrize(
+    "dialect",
+    [
+        mysql.dialect(),
+        mariadb_dialect.MariaDBDialect(),
+        postgresql.dialect(),
+        sqlite.dialect(),
+        _GeoPackageDialect(),
+    ],
+    ids=["mysql", "mariadb", "postgresql", "sqlite", "geopackage"],
+)
+def test_ewkb_constructor_bind_processors_validate_shared_helper_srid(dialect):
+    bind_processor = Geometry(srid=4326, from_text="ST_GeomFromEWKB").bind_processor(dialect)
+
+    with pytest.raises(ArgumentError, match=r"column \(4326\)"):
+        bind_processor(bytes.fromhex(WEB_MERCATOR_EWKB_HEX))
 
 
 @pytest.fixture

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -324,6 +324,17 @@ class TestMSSQLCompilation:
         assert compiled == expected
         assert "STGeomFromWKB(geometry::STGeomFromWKB" not in compiled
 
+    def test_constructor_zero_srid_ewkb_literal_uses_plain_wkb_hex(self):
+        ewkb = bytes.fromhex("010100002000000000000000000000f03f0000000000000040")
+        expected = "geometry::STGeomFromWKB(0x0101000000000000000000f03f0000000000000040, 4326)"
+        expr = func.ST_GeomFromEWKB(ewkb, 4326)
+        compiled = normalize_sql(
+            expr.compile(dialect=self.dialect, compile_kwargs={"literal_binds": True})
+        )
+
+        assert compiled == expected
+        assert "0101000020" not in compiled
+
     def test_as_ewkb_compiles_to_ewkb_expression(self, geometry_table):
         stmt = select([geometry_table.c.geom.ST_AsEWKB()])
         compiled = normalize_sql(stmt.compile(dialect=self.dialect))
@@ -1213,6 +1224,9 @@ class TestMSSQLBindAndResultProcessing:
         runtime_wkb = WKBElement(plain_wkb, srid=3857, extended=False)
         assert bytes(wkb_processor(runtime_wkb)) == bytes(plain_wkb)
         assert srid_processor(runtime_wkb) == 3857
+        zero_srid_ewkb = bytes.fromhex("010100002000000000000000000000f03f0000000000000040")
+        assert bytes(wkb_processor(zero_srid_ewkb)) == bytes(plain_wkb)
+        assert srid_processor(zero_srid_ewkb) == 0
         assert wkb_processor(None) is None
         assert srid_processor(None) == 0
 

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -1038,12 +1038,39 @@ class TestMSSQLBindAndResultProcessing:
     def test_bind_processor_validates_srid(self):
         geom = Geometry(geometry_type="LINESTRING", srid=4326)
         bind_processor = geom.bind_processor(self.dialect)
+        wkb = bytes.fromhex(
+            "01020000000200000000000000000000000000000000000000000000000000f03f000000000000f03f"
+        )
 
         with pytest.raises(ArgumentError):
             bind_processor("SRID=2154;LINESTRING(0 0,1 1)")
 
         with pytest.raises(ArgumentError):
             bind_processor(WKTElement("LINESTRING(0 0,1 1)", srid=2154))
+
+        with pytest.raises(ArgumentError):
+            bind_processor(WKBElement(wkb, srid=2154).as_ewkb().data)
+
+    def test_bind_processor_accepts_zero_srid_raw_ewkb_for_fixed_column(self):
+        geom = Geometry(geometry_type="LINESTRING", srid=4326)
+        bind_processor = geom.bind_processor(self.dialect)
+        zero_srid_ewkb = bytes.fromhex(
+            "0102000020000000000200000000000000000000000000000000000000000000000000f03f"
+            "000000000000f03f"
+        )
+
+        assert bind_processor(zero_srid_ewkb) == "LINESTRING (0 0, 1 1)"
+
+    def test_bind_processor_accepts_zero_srid_for_fixed_column(self):
+        geom = Geometry(geometry_type="LINESTRING", srid=4326)
+        bind_processor = geom.bind_processor(self.dialect)
+        wkb = bytes.fromhex(
+            "01020000000200000000000000000000000000000000000000000000000000f03f000000000000f03f"
+        )
+
+        assert bind_processor("SRID=0;LINESTRING(0 0,1 1)") == "LINESTRING(0 0,1 1)"
+        assert bind_processor(WKTElement("LINESTRING(0 0,1 1)", srid=0)) == ("LINESTRING(0 0,1 1)")
+        assert bind_processor(WKBElement(wkb, srid=0)) == "LINESTRING (0 0, 1 1)"
 
     def test_bind_processor_accepts_runtime_srid_for_unconstrained_column(self):
         geom = Geometry(geometry_type="LINESTRING", srid=-1)
@@ -1064,6 +1091,7 @@ class TestMSSQLBindAndResultProcessing:
         wkb = bytes.fromhex(
             "01020000000200000000000000000000000000000000000000000000000000f03f000000000000f03f"
         )
+        ewkb = WKBElement(wkb, srid=4326).as_ewkb().data
 
         with pytest.raises(ArgumentError, match=r"column \(0\)"):
             bind_processor("SRID=4326;LINESTRING(0 0,1 1)")
@@ -1073,6 +1101,9 @@ class TestMSSQLBindAndResultProcessing:
 
         with pytest.raises(ArgumentError, match=r"column \(0\)"):
             bind_processor(WKBElement(wkb, srid=4326))
+
+        with pytest.raises(ArgumentError, match=r"column \(0\)"):
+            bind_processor(ewkb)
 
     def test_bind_processor_resolves_typedecorator_metadata_for_srid_validation(self):
         wrapped_geography = WrappedGeography()
@@ -1124,7 +1155,7 @@ class TestMSSQLBindAndResultProcessing:
             "POINT (0.12345678901234566 123456789.12345679)"
         )
 
-    def test_wkb_parser_handles_hex_empty_and_geometrycollection_inputs(self):
+    def test_converter_handles_hex_empty_and_geometrycollection_inputs(self):
         empty_linestring_z = _pack_iso_wkb(2, struct.pack("<I", 0), has_z=True)
         empty_linestring_m = _pack_iso_wkb(2, struct.pack("<I", 0), has_m=True)
         empty_polygon = _pack_iso_wkb(3, struct.pack("<I", 0))
@@ -1142,7 +1173,23 @@ class TestMSSQLBindAndResultProcessing:
             == "POINT EMPTY"
         )
 
-    def test_wkb_parser_rejects_unsupported_values(self):
+    @pytest.mark.parametrize(
+        ("wkt", "expected"),
+        [
+            ("POINT Z EMPTY", "POINT EMPTY"),
+            ("LINESTRING M EMPTY", "LINESTRING EMPTY"),
+            ("GEOMETRYCOLLECTION ZM EMPTY", "GEOMETRYCOLLECTION EMPTY"),
+            ("POINTZM(1 2 3 4)", "POINT(1 2 3 4)"),
+            (
+                "MULTIPOLYGONZM(((1 2 3 4,1 2 3 4,1 2 3 4,1 2 3 4)))",
+                "MULTIPOLYGON(((1 2 3 4,1 2 3 4,1 2 3 4,1 2 3 4)))",
+            ),
+        ],
+    )
+    def test_normalize_wkt_for_mssql_strips_dimension_suffix_from_empty_forms(self, wkt, expected):
+        assert mssql_type._normalize_wkt_for_mssql(wkt) == expected
+
+    def test_converter_rejects_unsupported_wkb_values(self):
         unsupported_wkb = b"\x01" + struct.pack("<I", 999)
 
         with pytest.raises(ValueError, match="Unsupported WKB geometry type"):
@@ -1152,29 +1199,36 @@ class TestMSSQLBindAndResultProcessing:
         with pytest.raises(TypeError, match="Unsupported WKB value type"):
             mssql_type._wkb_to_mssql_wkt(object())
 
-    def test_to_mssql_wkt_falls_back_to_shape_conversion(self, monkeypatch):
-        class Shape:
-            wkt = "POINT Z (1 2 3)"
+    def test_to_mssql_wkt_normalizes_wkt_elements_without_wkb_conversion(self, monkeypatch):
+        def raise_conversion_error(value):
+            raise ValueError("unsupported converter path")
 
-        shaped_values = []
-
-        def raise_parse_error(value):
-            raise ValueError("unsupported parser path")
-
-        def fake_to_shape(value):
-            shaped_values.append(value)
-            return Shape()
-
-        monkeypatch.setattr(mssql_type, "_wkb_to_mssql_wkt", raise_parse_error)
-        monkeypatch.setattr(mssql_type, "to_shape", fake_to_shape)
+        monkeypatch.setattr(mssql_type, "_wkb_to_mssql_wkt", raise_conversion_error)
 
         assert mssql_type._to_mssql_wkt(WKTElement("POINT Z (1 2 3)", srid=4326)) == (
             "POINT (1 2 3)"
         )
-        assert isinstance(shaped_values[-1], WKTElement)
+        with pytest.raises(ValueError, match="unsupported converter path"):
+            mssql_type._to_mssql_wkt(b"\x01")
 
-        assert mssql_type._to_mssql_wkt(b"\x01") == "POINT (1 2 3)"
-        assert isinstance(shaped_values[-1], WKBElement)
+    def test_bind_processor_reuses_split_wkb_for_raw_text_constructor(self, monkeypatch):
+        geom = Geometry(geometry_type="POINT", srid=4326)
+        bind_processor = geom.bind_processor(self.dialect)
+        bindvalue = bytearray(b"\x01\x01\x00\x00\x00")
+        calls = []
+
+        def split_wkb_srid(value):
+            calls.append(value)
+            return "POINT Z (1 2 3)", 4326
+
+        def to_wkt_no_srid(value):
+            raise AssertionError("raw bind processor should reuse split WKT")
+
+        monkeypatch.setattr(mssql_type._wkb_wkt, "split_wkb_srid", split_wkb_srid)
+        monkeypatch.setattr(mssql_type._wkb_wkt, "to_wkt_no_srid", to_wkt_no_srid)
+
+        assert bind_processor(bindvalue) == "POINT (1 2 3)"
+        assert calls == [bytes(bindvalue)]
 
     def test_bind_coercion_helpers_keep_non_bind_clauses(self):
         table = Table("raw_values", MetaData(), Column("value", Integer))
@@ -1328,6 +1382,130 @@ class TestMSSQLBindAndResultProcessing:
             srid_key_3857: wkb,
         }
         assert calls == ["called"]
+
+    def test_geom_from_ewkb_reused_callable_bind_uses_single_value_for_dynamic_and_fixed_srid(
+        self,
+    ):
+        calls = []
+        wkb = from_shape(Point(1, 2), extended=False).data
+
+        def get_wkb():
+            calls.append("called")
+            return wkb
+
+        source_bind = bindparam("wkb", callable_=get_wkb)
+        stmt = select(
+            [
+                func.ST_GeomFromEWKB(
+                    source_bind,
+                    type_=Geometry(srid=3857),
+                ),
+                func.ST_GeomFromEWKB(source_bind),
+            ]
+        )
+        compiled = stmt.compile(dialect=self.dialect)
+        wkb_key, srid_key = mssql_admin._mssql_dynamic_ewkb_bind_keys(source_bind)
+
+        params = compiled.construct_params()
+        assert set(params) == {"wkb", wkb_key, srid_key}
+        assert params["wkb"] is wkb
+        assert params[wkb_key] is wkb
+        assert params[srid_key] is wkb
+        assert calls == ["called"]
+
+    def test_geom_from_ewkb_distinct_unique_callable_binds_are_not_shared(self):
+        calls = []
+        wkb_values = [
+            from_shape(Point(1, 2), extended=False).data,
+            from_shape(Point(3, 4), extended=False).data,
+        ]
+
+        def get_wkb():
+            value = wkb_values[len(calls)]
+            calls.append(value)
+            return value
+
+        source_bind_1 = bindparam("wkb", callable_=get_wkb, unique=True)
+        source_bind_2 = bindparam("wkb", callable_=get_wkb, unique=True)
+        stmt = select(
+            [
+                func.ST_GeomFromEWKB(source_bind_1, type_=Geometry(srid=3857)),
+                func.ST_GeomFromEWKB(source_bind_1),
+                func.ST_GeomFromEWKB(source_bind_2, type_=Geometry(srid=3857)),
+                func.ST_GeomFromEWKB(source_bind_2),
+            ]
+        )
+        compiled = stmt.compile(dialect=self.dialect)
+        wkb_key_1, srid_key_1 = mssql_admin._mssql_dynamic_ewkb_bind_keys(source_bind_1)
+        wkb_key_2, srid_key_2 = mssql_admin._mssql_dynamic_ewkb_bind_keys(source_bind_2)
+
+        params = compiled.construct_params()
+        assert params[wkb_key_1] is wkb_values[0]
+        assert params[srid_key_1] is wkb_values[0]
+        assert params[wkb_key_2] is wkb_values[1]
+        assert params[srid_key_2] is wkb_values[1]
+        assert calls == wkb_values
+
+    def test_geom_from_ewkt_reused_callable_bind_uses_single_value_for_dynamic_and_fixed_srid(
+        self,
+    ):
+        calls = []
+        ewkt = "SRID=4326;POINT(1 2)"
+
+        def get_wkt():
+            calls.append("called")
+            return ewkt
+
+        source_bind = bindparam("wkt", callable_=get_wkt)
+        stmt = select(
+            [
+                func.ST_GeomFromEWKT(
+                    source_bind,
+                    type_=Geometry(srid=3857),
+                ),
+                func.ST_GeomFromEWKT(source_bind),
+            ]
+        )
+        compiled = stmt.compile(dialect=self.dialect)
+        text_key, srid_key = mssql_admin._mssql_dynamic_ewkt_bind_keys(source_bind)
+
+        params = compiled.construct_params()
+        assert params == {
+            "wkt": ewkt,
+            text_key: ewkt,
+            srid_key: ewkt,
+        }
+        assert calls == ["called"]
+
+    def test_geom_from_ewkt_distinct_unique_callable_binds_are_not_shared(self):
+        calls = []
+        ewkt_values = ["SRID=4326;POINT(1 2)", "SRID=3857;POINT(3 4)"]
+
+        def get_wkt():
+            value = ewkt_values[len(calls)]
+            calls.append(value)
+            return value
+
+        source_bind_1 = bindparam("wkt", callable_=get_wkt, unique=True)
+        source_bind_2 = bindparam("wkt", callable_=get_wkt, unique=True)
+        stmt = select(
+            [
+                func.ST_GeomFromEWKT(source_bind_1, type_=Geometry(srid=3857)),
+                func.ST_GeomFromEWKT(source_bind_1),
+                func.ST_GeomFromEWKT(source_bind_2, type_=Geometry(srid=3857)),
+                func.ST_GeomFromEWKT(source_bind_2),
+            ]
+        )
+        compiled = stmt.compile(dialect=self.dialect)
+        text_key_1, srid_key_1 = mssql_admin._mssql_dynamic_ewkt_bind_keys(source_bind_1)
+        text_key_2, srid_key_2 = mssql_admin._mssql_dynamic_ewkt_bind_keys(source_bind_2)
+
+        params = compiled.construct_params()
+        assert params[text_key_1] == ewkt_values[0]
+        assert params[srid_key_1] == ewkt_values[0]
+        assert params[text_key_2] == ewkt_values[1]
+        assert params[srid_key_2] == ewkt_values[1]
+        assert calls == ewkt_values
 
     def test_mssql_before_execute_expands_dynamic_ewkt_bindparams(self):
         source_bind = bindparam("wkt")

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -1206,6 +1206,8 @@ class TestMSSQLBindAndResultProcessing:
         assert f"geometry::STGeomFromText(:{text_key}, :{srid_key})" in compiled_sql
         assert text_processor("SRID=4326;POINT ZM (1 2 3 4)") == "POINT (1 2 3 4)"
         assert srid_processor("SRID=4326;POINT ZM (1 2 3 4)") == 4326
+        assert text_processor("SRID=-1;POINT ZM (1 2 3 4)") == "POINT (1 2 3 4)"
+        assert srid_processor("SRID=-1;POINT ZM (1 2 3 4)") == 0
 
     def test_geom_from_ewkb_bindparam_compiles_to_split_wkb_and_srid_binds(self):
         source_bind = bindparam("wkb")

--- a/tests/test_types_mssql.py
+++ b/tests/test_types_mssql.py
@@ -1192,10 +1192,24 @@ class TestMSSQLBindAndResultProcessing:
     def test_converter_rejects_unsupported_wkb_values(self):
         unsupported_wkb = b"\x01" + struct.pack("<I", 999)
 
-        with pytest.raises(ValueError, match="Unsupported WKB geometry type"):
-            mssql_type._wkb_to_mssql_wkt(unsupported_wkb)
-        with pytest.raises(ValueError, match="Invalid WKB byte order marker"):
-            mssql_type._wkb_to_mssql_wkt(b"\x02" + struct.pack("<I", 1) + _pack_coords(1, 2))
+        for converter in (mssql_type._wkb_to_mssql_wkt, mssql_type._split_wkb_to_mssql_wkt):
+            with pytest.raises(ValueError) as exc_info:
+                converter(unsupported_wkb)
+            message = str(exc_info.value)
+            assert message.startswith("Unsupported WKB geometry type: ")
+            detail = message[len("Unsupported WKB geometry type: ") :]
+            assert "unsupported geometry type" not in detail.lower()
+            assert "999" in detail
+
+        invalid_byte_order_wkb = b"\x02" + struct.pack("<I", 1) + _pack_coords(1, 2)
+        for converter in (mssql_type._wkb_to_mssql_wkt, mssql_type._split_wkb_to_mssql_wkt):
+            with pytest.raises(ValueError) as exc_info:
+                converter(invalid_byte_order_wkb)
+            message = str(exc_info.value)
+            assert message.startswith("Invalid WKB byte order marker: ")
+            detail = message[len("Invalid WKB byte order marker: ") :]
+            assert "invalid byte order marker" not in detail.lower()
+            assert "2" in detail
         with pytest.raises(TypeError, match="Unsupported WKB value type"):
             mssql_type._wkb_to_mssql_wkt(object())
 

--- a/tools/benchmark_wkt_element_fast_paths.py
+++ b/tools/benchmark_wkt_element_fast_paths.py
@@ -1,0 +1,243 @@
+"""Benchmark WKTElement WKT-only conversion paths.
+
+Run from the GeoAlchemy2 source tree with a tox environment that has the
+branch dependencies installed, for example:
+
+    ./test_container/run.sh /output/py312-sqlalatest/bin/python \
+        /geoalchemy2/tools/benchmark_wkt_element_fast_paths.py
+
+The current implementation is hybrid: plain/non-extended WKT uses cheap Python
+constructors, while already-extended EWKT uses the Rust-backed converter.
+The "converter/Rust path" functions force converter use for comparison. The
+"old regex" functions model the historical regex prefix stripper. The
+"rejected strict partition candidate" functions keep a local string-only
+candidate for comparison only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import timeit
+from collections.abc import Callable
+from statistics import median
+
+from geoalchemy2 import _wkb_wkt
+from geoalchemy2.elements import WKTElement
+
+OLD_REMOVE_SRID = re.compile("(SRID=([0-9]+); ?)?(.*)")
+
+
+def strip_srid_old_regex(data: str) -> str:
+    match = OLD_REMOVE_SRID.match(data)
+    assert match is not None
+    return match.group(3)
+
+
+def strip_srid_rejected_strict_partition(data: str) -> str:
+    if data[:5] == "SRID=":
+        header, separator, wkt = data.partition(";")
+        srid_text = header[5:]
+        if separator and srid_text.isascii() and srid_text.isdigit() and wkt[:2] != "  ":
+            if wkt[:1] == " ":
+                return wkt[1:]
+            return wkt
+    return data
+
+
+def bench(
+    label: str,
+    current: Callable[[], WKTElement],
+    converter_path: Callable[[], WKTElement],
+    *,
+    number: int,
+    repeat: int,
+) -> None:
+    current_value = current()
+    converter_value = converter_path()
+    assert current_value.data == converter_value.data, (
+        label,
+        current_value.data,
+        converter_value.data,
+    )
+    assert current_value.srid == converter_value.srid, (
+        label,
+        current_value.srid,
+        converter_value.srid,
+    )
+    assert current_value.extended == converter_value.extended, (
+        label,
+        current_value.extended,
+        converter_value.extended,
+    )
+
+    current_times = timeit.repeat(current, repeat=repeat, number=number)
+    converter_times = timeit.repeat(converter_path, repeat=repeat, number=number)
+    current_med = median(current_times) / number * 1_000_000
+    converter_med = median(converter_times) / number * 1_000_000
+    print(
+        f"{label}: current_hybrid={current_med:.3f} us/op "
+        f"converter_rust={converter_med:.3f} us/op "
+        f"converter/current={converter_med / current_med:.2f}x"
+    )
+
+
+def bench_one(
+    label: str,
+    func: Callable[[], WKTElement],
+    *,
+    number: int,
+    repeat: int,
+) -> None:
+    times = timeit.repeat(func, repeat=repeat, number=number)
+    func()
+    print(f"{label}: {median(times) / number * 1_000_000:.3f} us/op")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--number", type=int, default=200_000)
+    parser.add_argument("--repeat", type=int, default=9)
+    args = parser.parse_args()
+
+    plain = WKTElement("POINT (1 2)", srid=4326)
+    ewkt = WKTElement("SRID=4326;POINT (1 2)", extended=True)
+    ewkt_space = WKTElement("SRID=4326; POINT (1 2)", extended=True)
+
+    def current_as_wkt_plain() -> WKTElement:
+        return plain.as_wkt()
+
+    def converter_as_wkt_plain() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt_no_srid(plain.data), srid=plain.srid, extended=False)
+
+    def current_as_wkt_extended() -> WKTElement:
+        return ewkt.as_wkt()
+
+    def converter_as_wkt_extended() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt_no_srid(ewkt.data), srid=ewkt.srid, extended=False)
+
+    def current_as_ewkt_plain() -> WKTElement:
+        return plain.as_ewkt()
+
+    def converter_as_ewkt_plain() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt(plain.data, srid=plain.srid), extended=True)
+
+    def current_as_ewkt_extended() -> WKTElement:
+        return ewkt.as_ewkt()
+
+    def converter_as_ewkt_extended() -> WKTElement:
+        return WKTElement(_wkb_wkt.to_wkt(ewkt.data, srid=ewkt.srid), extended=True)
+
+    def rejected_strict_partition_as_wkt_extended() -> WKTElement:
+        return WKTElement(
+            strip_srid_rejected_strict_partition(ewkt.data),
+            ewkt.srid,
+            extended=False,
+        )
+
+    def rejected_strict_partition_as_wkt_extended_space() -> WKTElement:
+        return WKTElement(
+            strip_srid_rejected_strict_partition(ewkt_space.data),
+            ewkt_space.srid,
+            extended=False,
+        )
+
+    def rejected_strict_partition_as_ewkt_extended() -> WKTElement:
+        return WKTElement(
+            f"SRID={ewkt.srid};{strip_srid_rejected_strict_partition(ewkt.data)}",
+            extended=True,
+        )
+
+    print("Hybrid current implementation versus converter/Rust path")
+    bench(
+        "as_wkt plain WKT (current Python fast path)",
+        current_as_wkt_plain,
+        converter_as_wkt_plain,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench(
+        "as_wkt EWKT strip SRID (current Rust path)",
+        current_as_wkt_extended,
+        converter_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench(
+        "as_ewkt plain WKT add SRID (current Python fast path)",
+        current_as_ewkt_plain,
+        converter_as_ewkt_plain,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench(
+        "as_ewkt EWKT normalize prefix (current Rust path)",
+        current_as_ewkt_extended,
+        converter_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+
+    print()
+    print("Rejected EWKT string-only alternatives")
+
+    def old_regex_as_wkt_extended() -> WKTElement:
+        return WKTElement(strip_srid_old_regex(ewkt.data), ewkt.srid, extended=False)
+
+    def old_regex_as_ewkt_extended() -> WKTElement:
+        return WKTElement(f"SRID={ewkt.srid};{strip_srid_old_regex(ewkt.data)}", extended=True)
+
+    assert strip_srid_rejected_strict_partition(ewkt.data) == strip_srid_old_regex(ewkt.data)
+    assert strip_srid_rejected_strict_partition(ewkt_space.data) == strip_srid_old_regex(
+        ewkt_space.data
+    )
+    assert (
+        strip_srid_rejected_strict_partition("SRID=4326;  POINT (1 2)") == "SRID=4326;  POINT (1 2)"
+    )
+
+    bench_one(
+        "as_wkt EWKT old regex",
+        old_regex_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_wkt EWKT rejected strict partition candidate",
+        rejected_strict_partition_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_wkt EWKT rejected strict partition candidate with space",
+        rejected_strict_partition_as_wkt_extended_space,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_wkt EWKT converter/Rust path",
+        converter_as_wkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_ewkt EWKT old regex",
+        old_regex_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_ewkt EWKT rejected strict partition candidate",
+        rejected_strict_partition_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+    bench_one(
+        "as_ewkt EWKT converter/Rust path",
+        converter_as_ewkt_extended,
+        number=args.number,
+        repeat=args.repeat,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Centralize WKB/EWKB bind conversion logic and apply it across dialects.

This builds on #613 by moving shared WKB/EWKB byte, hex, SRID validation, and constructor-detection behavior into common type helpers, then using those helpers in PostgreSQL, SQLite, GeoPackage, MySQL, MariaDB, and MSSQL paths.
